### PR TITLE
feat: stream S3 MF4 decode/send to VictoriaMetrics

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,6 +17,7 @@
   - `decoder/B3SR/send_b3sr.py`
   - `decoder/SnowLeopardTMS/send_snow_leopard_tms.py`
   - These scripts resolve source files (local or S3), decode MF4 with DBCs via `asammdf`, and post to VictoriaMetrics.
+  - D65 also supports direct S3 streaming mode (`--s3-streaming`) with preflight strategy selection (`auto|memory|tempfile`).
 - Live paths:
   - `decoder/livelogger/` handles live CAN decode (`CANReader`, `DBCDecoder`, `livestream`).
   - `decoder/GUI/` provides PySide6 UIs for live/file workflows and buffered metric sending (`metrics_manager.py`).

--- a/decoder/B3SR/dbc/b3sr_base.dbc
+++ b/decoder/B3SR/dbc/b3sr_base.dbc
@@ -1,0 +1,973 @@
+VERSION "created by Mattheas Jamieson"
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: TTC PUMP COMPRESSOR DCDC HEATER EPISPHERE MEB DESKTOPSIMULATION DESKTOP_SIMULATION
+VAL_TABLE_ OperatingStatus 3 "Not Available" 2 "Not Operable" 1 "Derated Operation" 0 "Normal Operation" ;
+VAL_TABLE_ ServiceIndicator 3 "Not Available" 2 "Reserved" 1 "Service Required" 0 "Service Not Required" ;
+VAL_TABLE_ CommandStatus 3 "Not Available" 2 "Default Command" 1 "External Command" 0 "Internal Command" ;
+VAL_TABLE_ StatusReasonLegacy 12 "Operating at Max Control Effort" 11 "Operating at Amp Limit" 10 "Unused" 9 "Over-Temp Protection Shutdown" 8 "Unused" 7 "Under-Voltage Protection Shutdn" 6 "Over Voltage Protection Shutdown" 5 "Unused" 4 "Unable to Start" 3 "Unused" 2 "Unused" 1 "Unused" 0 "OK/ Normal Operation" ;
+VAL_TABLE_ StatusReason 6 "Speed Limit due to max cap" 5 "Speed Limit due to Amp Limit" 4 "Over-Temp Protection Shutdown" 3 "Under-Voltage Protection Shutdwn" 2 "Over-Voltage Protection Shutdown" 1 "Unable to Start" 0 "Normal Operation" ;
+VAL_TABLE_ PowerHold 3 "Not Used" 2 "Reserved" 1 "Power On" 0 "Power Off" ;
+VAL_TABLE_ OnOffDir 3 "Not Used" 2 "Motor On: Reverse" 1 "Motor On: Normal/Default Dir" 0 "Motor Off" ;
+
+
+BO_ 2558198015 SPAL_PUMP_Motor_Command: 8 TTC
+ SG_ OnOffDirection : 0|2@1+ (1,0) [0|3] ""  PUMP
+ SG_ MotorSpeed : 24|8@1+ (0.5,0) [0|100] "%"  PUMP
+
+BO_ 2566651648 SPAL_PUMP_STATUS: 8 PUMP
+ SG_ Status : 0|2@1+ (1,0) [0|3] ""  TTC
+ SG_ StatusReason : 2|4@1+ (1,0) [0|15] ""  TTC
+ SG_ CommandStatus : 6|2@1+ (1,0) [0|3] ""  TTC
+ SG_ Speed : 8|16@1+ (0.5,0) [0|32127.5] "RPM"  TTC
+ SG_ Temperature : 24|16@1+ (0.03125,-273) [-273|1734.96875] "°C"  TTC
+ SG_ Power : 40|16@1+ (0.5,0) [0|32127.5] "W"  TTC
+ SG_ ServiceIndicator : 56|2@1+ (1,0) [0|3] ""  TTC
+ SG_ OperatingStatus : 58|2@1+ (1,0) [0|3] ""  TTC
+
+BO_ 2683239947 TTC_DEVICE: 8 TTC
+
+BO_ 2683177982 EPISPHERE_DEVICE: 8 EPISPHERE
+ SG_ HEADER_paramater_id : 0|16@1+ (1,0) [0|65535] ""  TTC
+ SG_ HEADER_command_type : 16|8@1+ (1,0) [0|255] ""  TTC
+
+BO_ 2683240203 TTC_BROADCAST: 8 TTC
+ SG_ ttc_episphere_device_type : 0|8@1- (1,0) [0|255] ""  EPISPHERE
+
+BO_ 2683240446 EPISPHERE_BROADCAST: 8 EPISPHERE
+
+BO_ 2365528155 HVES1PROP5: 8 MEB
+ SG_ ThermalSystemEnable : 0|2@1+ (1,0) [0|3] "State"  TTC
+ SG_ CoolingAllowed : 2|2@1+ (1,0) [0|3] "State"  TTC
+ SG_ HeatingAllowed : 4|2@1+ (1,0) [0|3] "State"  TTC
+ SG_ ServiceModeEnable : 6|2@1+ (1,0) [0|3] "State"  TTC
+ SG_ SetpointCoolingControlTemp : 8|8@1+ (0.2,0) [0|51] "°C"  TTC
+ SG_ SetpointHeaterControlTemp : 16|8@1+ (0.26,-15) [-15|51.3] "°C"  TTC
+ SG_ MaxAllowedTemperatureGradient : 24|8@1+ (0.08,0) [0|20.4] "°C"  TTC
+ SG_ MeasuredControlTemperature : 32|12@1+ (0.067,-40) [-40|234.365] "°C"  TTC
+ SG_ MeasuredTemperatureGradient : 44|12@1+ (0.005,0) [0|20.475] "°C"  TTC
+ SG_ IdlePumpSpeedPercent : 56|8@1+ (0.4,0) [0|100] "%"  TTC
+
+BO_ 2365545936 TMSHVES1D6: 8 TTC
+ SG_ HVES1_Bus_Voltage : 0|16@1+ (0.05,0) [0|3276.75] "V"  MEB
+ SG_ HVES1_Ignition_Voltage : 16|16@1+ (0.01,0) [0|655.35] "V"  MEB
+ SG_ HVES1_Intake_Coolant_Temperature : 32|8@1+ (1,-40) [-40|215] "°C"  MEB
+ SG_ HVES1_Outlet_Coolant_Temperature : 40|8@1+ (1,-40) [-40|215] "°C"  MEB
+ SG_ HVES1_Electronics_Temperature : 48|8@1+ (1,-40) [-40|215] "°C"  MEB
+
+BO_ 2365528528 TMSPROP1: 8 TTC
+ SG_ Cooling_system_readiness : 0|4@1+ (1,0) [0|15] "State"  MEB
+ SG_ Cooling_system_state : 4|4@1+ (1,0) [0|15] "State"  MEB
+ SG_ PumpActualSpeedPct : 8|8@1+ (0.4,0) [0|102] "%"  MEB
+ SG_ FanActualSpeedPct : 16|8@1+ (0.4,0) [0|102] "%"  MEB
+ SG_ HeaterTemperature : 24|8@1+ (1,-40) [-40|215] "°C"  MEB
+ SG_ AmbientTemperature : 32|8@1+ (0.5,-40) [-40|87.5] "°C"  MEB
+ SG_ ValveState : 40|2@1+ (1,0) [0|3] "State"  MEB
+
+BO_ 2365545680 HVES1TS1: 8 TTC
+ SG_ SLI_Input_Power : 0|16@1+ (0.5,0) [0|32767.5] "W"  MEB
+ SG_ High_Voltage_Input_Power : 16|16@1+ (0.5,0) [0|32767.5] "W"  MEB
+ SG_ Compressor_Speed : 32|8@1+ (32,0) [0|10000] "rpm"  MEB
+ SG_ Heater_Status : 48|3@1+ (1,0) [0|7] "bit"  MEB
+
+BO_ 2365528411 VersionMessage: 8 TTC
+ SG_ TTC_Application_Major_Version : 0|8@1+ (1,0) [0|255] ""  MEB
+ SG_ TTC_Application_Minor_Version : 8|8@1+ (1,0) [0|255] ""  MEB
+ SG_ TTC_Application_Revision_Version : 16|16@1+ (1,0) [0|255] ""  MEB
+ SG_ SPAL_Pump_Version : 32|8@1+ (1,0) [0|255] ""  MEB
+ SG_ TCCI_Compressor_Version : 40|8@1+ (1,0) [0|255] ""  MEB
+ SG_ Webasto_Heater_Version : 48|8@1+ (1,0) [0|255] ""  MEB
+ SG_ Foripower_DCDC_Version : 56|8@1+ (1,0) [0|255] ""  MEB
+
+BO_ 2583681129 TCCI_COMPRESSOR_command: 8 TTC
+ SG_ ECEnable : 24|2@1+ (1,0) [0|3] ""  COMPRESSOR
+ SG_ ECPowerPermit : 40|8@1+ (0.2,0) [0|50.8] ""  COMPRESSOR
+ SG_ ECSpeedReq : 0|16@1+ (1,0) [0|65535] "rpm"  COMPRESSOR
+ SG_ ECHVShutdown : 32|2@1+ (1,0) [0|3] ""  COMPRESSOR
+
+BO_ 2583680152 TCCI_COMPRESSOR_status: 8 COMPRESSOR
+ SG_ ECTrnstrTemp : 40|8@1+ (1,-60) [-60|194] "°C"  TTC
+ SG_ ECFaultBitmap : 28|12@1+ (1,0) [0|2047] ""  TTC
+ SG_ ECSpeedFdbk : 0|16@1+ (1,0) [0|65534] "rpm"  TTC
+ SG_ ECPhaseCurrent : 16|8@1+ (0.5,0) [0|127] "A"  TTC
+ SG_ ECOpStatus : 24|4@1+ (1,0) [0|13] ""  TTC
+ SG_ ECDCVoltage : 56|8@1+ (5,0) [0|1270] "V"  TTC
+ SG_ ECDCCurrent : 48|8@1+ (0.2,0) [0|50.8] "A"  TTC
+
+BO_ 2565817377 WEBASTO_HEATER_command: 8 TTC
+ SG_ HVH_ActiveDischarge : 28|1@1+ (1,0) [0|1] ""  HEATER
+ SG_ HVH_HeaterEnable : 27|1@1+ (1,0) [0|1] ""  HEATER
+ SG_ HVH_TargetCoolantTemp : 8|8@1+ (1,-50) [-50|205] "°C"  HEATER
+ SG_ HVH_MaxPower : 0|8@1+ (100,0) [0|25500] "W"  HEATER
+
+BO_ 2566889540 WEBASTO_HEATER_status1: 8 HEATER
+ SG_ HVH_ActualPower : 48|16@1+ (1,0) [0|65535] "W"  TTC
+ SG_ HVH_HVIL_Status : 3|2@1+ (1,0) [0|3] ""  TTC
+ SG_ HVH_ActiveDis_Status : 5|2@1+ (1,0) [0|3] ""  TTC
+ SG_ HVH_HV_Current : 24|8@1+ (0.25,0) [0|63.25] "A"  TTC
+ SG_ HVH_Status : 0|3@1+ (1,0) [0|7] ""  TTC
+ SG_ HVH_HV_Voltage : 32|10@1+ (1,0) [0|1021] "V"  TTC
+ SG_ HVH_Coolant_Out_Temp : 16|8@1+ (1,-50) [-50|203] "°C"  TTC
+ SG_ HVH_Coolant_In_Temp : 8|8@1+ (1,-50) [-50|203] "°C"  TTC
+
+BO_ 2566889796 WEBASTO_HEATER_status2: 8 HEATER
+ SG_ HVH_FailDCDCConverter : 30|2@1+ (1,0) [0|3] ""  TTC
+ SG_ HVH_FailMemory_InterCom : 28|2@1+ (1,0) [0|3] ""  TTC
+ SG_ HVH_FailHighCurrent : 26|2@1+ (1,0) [0|3] ""  TTC
+ SG_ HVH_FailDriver : 24|2@1+ (1,0) [0|3] ""  TTC
+ SG_ HVH_FailTempSensor : 22|2@1+ (1,0) [0|3] ""  TTC
+ SG_ HVH_FailHotspot : 16|2@1+ (1,0) [0|3] ""  TTC
+ SG_ HVH_WarnOverheat : 14|2@1+ (1,0) [0|3] ""  TTC
+ SG_ HVH_WarnULoOutOfRang : 5|2@1+ (1,0) [0|3] ""  TTC
+ SG_ HVH_WarnHVOutOfRng : 3|2@1+ (1,0) [0|3] ""  TTC
+ SG_ HVH_ProtocolError : 0|1@1+ (1,0) [0|1] ""  TTC
+ SG_ HVH_ComponentProtection : 1|2@1+ (1,0) [0|3] ""  TTC
+
+BO_ 2550190223 FORIPOWER_DCDC_status1: 8 DCDC
+ SG_ DCDC_Output_Voltage : 0|16@1+ (0.1,0) [0|1000] "V"  TTC
+ SG_ DCDC_Output_Current : 16|16@1+ (0.1,0) [0|1000] "A"  TTC
+ SG_ DCDC_Input_Voltage : 32|16@1+ (0.1,0) [0|1000] "V"  TTC
+ SG_ DCDC_Temperature : 48|8@1+ (1,-40) [-40|215] "°C"  TTC
+
+BO_ 2550255759 FORIPOWER_DCDC_status2: 8 DCDC
+ SG_ DCDC_State : 0|4@1+ (1,0) [0|6] ""  TTC
+ SG_ DCDC_Fault_Level : 4|2@1+ (1,0) [0|3] ""  TTC
+ SG_ DCDC_Input_OverVolt : 8|1@1+ (1,0) [0|1] ""  TTC
+ SG_ DCDC_Input_UnderVolt : 9|1@1+ (1,0) [0|1] ""  TTC
+ SG_ DCDC_Output_OverVolt : 10|1@1+ (1,0) [0|1] ""  TTC
+ SG_ DCDC_Output_Short : 11|1@1+ (1,0) [0|1] ""  TTC
+ SG_ DCDC_Output_UnderVolt : 12|1@1+ (1,0) [0|1] ""  TTC
+ SG_ DCDC_OverTemp : 13|1@1+ (1,0) [0|1] ""  TTC
+ SG_ DCDC_Output_OverCurr : 14|1@1+ (1,0) [0|1] ""  TTC
+ SG_ DCDC_SciCommFault : 15|1@1+ (1,0) [0|1] ""  TTC
+ SG_ DCDC_HwFault : 16|1@1+ (1,0) [0|1] ""  TTC
+ SG_ DCDC_CanCommFault : 17|1@1+ (1,0) [0|1] ""  TTC
+ SG_ DCDC_BoostFault : 18|1@1+ (1,0) [0|1] ""  TTC
+ SG_ DCDC_Hw_Version : 48|8@1+ (1,0) [0|255] ""  TTC
+ SG_ DCDC_Sw_Version : 56|8@1+ (1,0) [0|255] ""  TTC
+
+BO_ 2684354464 Z_INPUTS: 8 DESKTOPSIMULATION
+ SG_ Z_DI_72 m36 : 16|8@1+ (1,0) [0|255] ""  TTC
+ SG_ Z_DI_74 m38 : 16|8@1+ (1,0) [0|255] ""  TTC
+ SG_ Z_DI_78 m42 : 16|8@1+ (1,0) [0|255] ""  TTC
+ SG_ Z_DI_73 m37 : 16|8@1+ (1,0) [0|255] ""  TTC
+ SG_ Z_DI_75 m39 : 16|8@1+ (1,0) [0|255] ""  TTC
+ SG_ Z_DI_77 m41 : 16|8@1+ (1,0) [0|255] ""  TTC
+ SG_ Z_DI_79 m43 : 16|8@1+ (1,0) [0|255] ""  TTC
+ SG_ Z_AI_00 m0 : 32|32@1+ (1,0) [0|4294967295] ""  TTC
+ SG_ Z_AI_10 m10 : 32|32@1+ (1,0) [0|4294967295] ""  TTC
+ SG_ Z_AI_12 m12 : 32|32@1+ (1,0) [0|4294967295] ""  TTC
+ SG_ Z_AI_14 m14 : 32|32@1+ (1,0) [0|4294967295] ""  TTC
+ SG_ Z_AI_11 m11 : 32|32@1+ (1,0) [0|4294967295] ""  TTC
+ SG_ Z_AI_01 m1 : 32|32@1+ (1,0) [0|4294967295] ""  TTC
+ SG_ Z_AI_02 m2 : 32|32@1+ (1,0) [0|4294967295] ""  TTC
+ SG_ Z_AI_04 m4 : 32|32@1+ (1,0) [0|4294967295] ""  TTC
+ SG_ Z_AI_05 m5 : 32|32@1+ (1,0) [0|4294967295] ""  TTC
+ SG_ Z_AI_06 m6 : 32|32@1+ (1,0) [0|4294967295] ""  TTC
+ SG_ Z_DI_56 m8 : 16|8@1+ (1,0) [0|255] ""  TTC
+ SG_ Z_DI_57 m9 : 16|8@1+ (1,0) [0|255] ""  TTC
+ SG_ Z_DI_61 m13 : 16|8@1+ (1,0) [0|255] ""  TTC
+ SG_ Z_pin_id M : 0|8@1+ (1,0) [0|255] ""  TTC
+
+BO_ 2684354480 Z_OUTPUTS: 8 TTC
+ SG_ Z_DO_16 m52 : 16|8@1+ (1,0) [0|255] ""  DESKTOPSIMULATION
+ SG_ Z_DO_30 m66 : 16|8@1+ (1,0) [0|255] ""  DESKTOPSIMULATION
+ SG_ Z_DO_04 m40 : 16|8@1+ (1,0) [0|255] ""  DESKTOPSIMULATION
+ SG_ Z_DO_23 m59 : 16|8@1+ (1,0) [0|255] ""  DESKTOPSIMULATION
+ SG_ Z_PWM_04 m56 : 16|16@1+ (1,0) [0|65535] ""  DESKTOPSIMULATION
+ SG_ Z_DO_34 m70 : 16|8@1+ (1,0) [0|255] ""  DESKTOPSIMULATION
+ SG_ Z_PWM_09 m61 : 16|16@1+ (1,0) [0|65535] ""  DESKTOPSIMULATION
+ SG_ Z_pin_outputs M : 0|8@1+ (1,0) [0|255] ""  DESKTOPSIMULATION
+
+BO_ 2181033632 COMMON_WARNINGS_DIAG: 8 TTC
+ SG_ Coolant_LevelSwitch : 0|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ EEPROM_ReadFailed : 1|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ EEPROM_ValidationFailed : 2|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterStatus : 3|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterComponentProtection : 4|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterOverheat : 5|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ AmbientTemperatureSensor : 6|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ CoolingDisabled : 7|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeatingDisabled : 8|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ CoolantTempInSensor : 9|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ CoolantTempOutSensor : 10|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ CoolantPressureInSensor : 11|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ CoolantPressureOutSensor : 12|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ TankTemperatureSensor : 13|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDC_FaultLevel2 : 14|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDC_FaultLevel3 : 15|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDC_InputOvervoltage : 16|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDC_InputUndervoltage : 17|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDC_OutputOvervoltage : 18|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDC_OutputUndervoltage : 19|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDC_OutputShortCircuit : 20|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDC_OverTemperature : 21|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDC_OutputOvercurrent : 22|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDC_SciCommTimeout : 23|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDC_HardwareFault : 24|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDC_CanCommTimeout : 25|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDC_BoostFault : 26|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+
+BO_ 2181033633 LOOP_WARNINGS_DIAG: 8 TTC
+ SG_ PumpGenericStatus : 0|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ PumpDryRun : 1|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ PumpCurrentProtection : 2|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ PumpPhysicalProtection : 3|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ PumpTorqueLimit : 4|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ PumpOvertempProtection : 5|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ CoolingLoopLimpMode : 6|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Fan_1_DriveStatus : 7|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Fan_2_DriveStatus : 8|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Fan_3_DriveStatus : 9|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Fan_4_DriveStatus : 10|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+
+BO_ 2181033634 COMMON_ERRORS_DIAG: 8 TTC
+ SG_ Controller_Supply_Overvoltage : 0|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Controller_Supply_Undervoltage : 1|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ CAN_CH_1 : 2|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ CAN_CH_2 : 3|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterContactorOpen : 4|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterContactorWelded : 5|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_PcgTimeoutErr : 6|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_Status : 7|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_CANTimeout : 8|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_InternalHVIL : 9|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_PermanentLock : 10|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_Protocol : 11|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_HV_Overvoltage : 12|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_HV_Undervoltage : 13|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_LV_Overvoltage : 14|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_LV_Undervoltage : 15|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterFailHotspot : 16|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterFailTemp_sensor : 17|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterFailDriver : 18|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterFailHigh_current : 19|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterFailMem_comm : 20|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterFailDcdc_convert : 21|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ MEB_CANTimeout : 22|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ SetpointOverlap : 23|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDC_FaultLevel1 : 24|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDC_CANTimeout : 25|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Coolant_LevelSwitch : 26|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ PermanentLockout : 27|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+
+BO_ 2181033635 COMMON_ERRORS_LATCHED_DIAG: 8 TTC
+ SG_ Controller_Supply_Overvoltage : 0|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Controller_Supply_Undervoltage : 1|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ CAN_CH_1 : 2|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ CAN_CH_2 : 3|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterContactorOpen : 4|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterContactorWelded : 5|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_PcgTimeoutErr : 6|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_Status : 7|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_CANTimeout : 8|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_InternalHVIL : 9|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_PermanentLock : 10|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_Protocol : 11|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_HV_Overvoltage : 12|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_HV_Undervoltage : 13|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_LV_Overvoltage : 14|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Heater_LV_Undervoltage : 15|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterFailHotspot : 16|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterFailTemp_sensor : 17|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterFailDriver : 18|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterFailHigh_current : 19|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterFailMem_comm : 20|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterFailDcdc_convert : 21|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ MEB_CANTimeout : 22|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ SetpointOverlap : 23|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDC_FaultLevel1 : 24|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDC_CANTimeout : 25|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Coolant_LevelSwitch : 26|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ PermanentLockout : 27|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+
+BO_ 2181033636 LOOP_ERRORS_DIAG: 8 TTC
+ SG_ Pump_Status : 0|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Pump_CanTimeout : 1|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Pump_Overvoltage : 2|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Pump_Undervoltage : 3|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Pump_Overtemp : 4|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_Status : 5|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_CanTimeout : 6|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_Overvoltage : 7|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_Undervoltage : 8|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_CurrImbalanceErr : 9|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_Overcurrent : 10|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_Overtemp : 11|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_Electronic : 12|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_LostPhase : 13|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_Lockout : 14|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ FanCoverSwitchOpen : 15|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ AllFansDriveStatus : 16|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HighSidePressureSwitch : 17|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HighSidePressureSensor : 18|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ LowSidePressureSensor : 19|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ LowSideLowPressure : 20|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+
+BO_ 2181033637 LOOP_ERRORS_LATCHED_DIAG: 8 TTC
+ SG_ Pump_Status : 0|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Pump_CanTimeout : 1|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Pump_Overvoltage : 2|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Pump_Undervoltage : 3|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Pump_Overtemp : 4|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_Status : 5|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_CanTimeout : 6|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_Overvoltage : 7|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_Undervoltage : 8|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_CurrImbalanceErr : 9|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_Overcurrent : 10|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_Overtemp : 11|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_Electronic : 12|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_LostPhase : 13|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Cmprsr_Lockout : 14|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ FanCoverSwitchOpen : 15|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ AllFansDriveStatus : 16|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HighSidePressureSwitch : 17|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HighSidePressureSensor : 18|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ LowSidePressureSensor : 19|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ LowSideLowPressure : 20|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+
+BO_ 2181033638 COMMON_INPUTS_1_DIAG: 8 TTC
+ SG_ ReservoirWarningLevelSensor : 0|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ ReservoirCriticalLevelSensor : 1|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterContactorFb : 2|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ CoolantPressureIn : 8|16@1+ (0.01,0) [0|655.35] "bar"  DESKTOPSIMULATION
+ SG_ CoolantPressureOut : 24|16@1+ (0.01,0) [0|655.35] "bar"  DESKTOPSIMULATION
+ SG_ TTCInputVoltage : 40|16@1+ (0.001,0) [0|32] "V"  DESKTOPSIMULATION
+
+BO_ 2181033639 COMMON_INPUTS_2_DIAG: 8 TTC
+ SG_ AmbientTemperature : 0|16@1+ (0.1,-40) [-40|6513.5] "°C"  DESKTOPSIMULATION
+ SG_ CoolantTemperatureIn : 16|16@1+ (0.1,-40) [-40|6513.5] "°C"  DESKTOPSIMULATION
+ SG_ CoolantTemperatureOut : 32|16@1+ (0.1,-40) [-40|6513.5] "°C"  DESKTOPSIMULATION
+ SG_ TankCoolantTemperature : 48|16@1+ (0.1,-40) [-40|6513.5] "°C"  DESKTOPSIMULATION
+
+BO_ 2181033640 LOOP_SPECIFIC_INPUTS_DIAG: 8 TTC
+ SG_ Fan1_DriveStatusFb : 0|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Fan2_DriveStatusFb : 1|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Fan3_DriveStatusFb : 2|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ Fan4_DriveStatusFb : 3|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ FanCoverSwitchFb : 4|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ SuperheatControllerAlarmRelay : 5|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HighSidePressureSwitch : 6|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HighSidePressureSens : 8|16@1- (0.1,0) [-3276|3276] "PSIG"  DESKTOPSIMULATION
+ SG_ HighSideTemperature : 24|16@1+ (0.1,-40) [-40|65495] "°C"  DESKTOPSIMULATION
+ SG_ LowSidePressureSens : 40|16@1- (0.1,0) [-3276|3276] "PSIG"  DESKTOPSIMULATION
+
+BO_ 2181033641 COMMON_OUTPUTS_DIAG: 8 TTC
+ SG_ HeaterCANEnable : 0|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDCAuxSupply : 1|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterContactorControl : 2|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterMaxPower : 8|8@1+ (100,0) [0|25500] "kW"  DESKTOPSIMULATION
+ SG_ HeaterTargetTemp : 16|8@1+ (1,-50) [-50|205] "°C"  DESKTOPSIMULATION
+ SG_ CirculationPumpSpeed : 24|8@1+ (1,0) [0|255] "%"  DESKTOPSIMULATION
+ SG_ CalculatedFlowRate : 32|16@1+ (0.1,0) [0|6553.5] "litres/min"  DESKTOPSIMULATION
+
+BO_ 2181033642 LOOP_SPECIFIC_OUTPUTS: 8 TTC
+ SG_ SuperheatControllerEnable : 0|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ CompressorEnable : 1|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ CompressorShutdown : 2|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ PumpDirectionRequest : 4|2@1+ (1,0) [0|3] ""  DESKTOPSIMULATION
+ SG_ CompressorPowerLimit : 8|8@1+ (0.2,0) [0|51] "kW"  DESKTOPSIMULATION
+ SG_ PumpSpeedRequest : 16|16@1+ (1,0) [0|65535] "rpm"  DESKTOPSIMULATION
+ SG_ CompressorSpeedRequest : 32|16@1+ (1,0) [0|65535] "rpm"  DESKTOPSIMULATION
+ SG_ FanPwmSpeedRequest : 48|16@1+ (1,0) [0|65535] "%"  DESKTOPSIMULATION
+
+BO_ 2181033643 INTERNAL_VARIABLES_DIAG: 8 TTC
+ SG_ SystemLoad : 0|32@1+ (0.1,0) [0|429496729.6] "kW"  DESKTOPSIMULATION
+ SG_ MainHSMState : 32|8@1+ (1,0) [0|255] ""  DESKTOPSIMULATION
+ SG_ AmberLampIndicator : 40|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ CoolingDisabled : 41|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeatingDisabled : 42|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ CoolingLoopLimpMode : 43|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ PumpRxOk : 44|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ CompressorRxOk : 45|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ HeaterRxOk : 46|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ DCDCRxOk : 47|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+ SG_ MebRxOk : 48|1@1+ (1,0) [0|1] ""  DESKTOPSIMULATION
+
+BO_ 2181033644 PID_COEFFS_FB_DIAG: 8 TTC
+ SG_ k_p : 0|16@1- (0.1,0) [0|3276] ""  DESKTOPSIMULATION
+ SG_ k_i : 16|16@1- (0.01,0) [0|327] ""  DESKTOPSIMULATION
+ SG_ k_d : 32|16@1- (0.01,0) [0|327] ""  DESKTOPSIMULATION
+
+BO_ 2181033645 PID_COEFFS_EPISPHERE_PARAM_DIAG: 8 TTC
+ SG_ k_p : 0|16@1- (0.1,0) [0|3276] ""  DESKTOPSIMULATION
+ SG_ k_i : 16|16@1- (0.01,0) [0|327] ""  DESKTOPSIMULATION
+ SG_ k_d : 32|16@1- (0.01,0) [0|327] ""  DESKTOPSIMULATION
+
+BO_ 2181033646 DEBUG_PID_DIAG: 8 TTC
+ SG_ PID_Error : 0|16@1- (0.1,0) [-32768|32767] ""  DESKTOPSIMULATION
+ SG_ PID_Pterm : 16|16@1- (1,0) [-32768|32767] ""  DESKTOPSIMULATION
+ SG_ PID_Iterm : 32|16@1- (1,0) [-32768|32767] ""  DESKTOPSIMULATION
+ SG_ PID_Iterm_c : 48|16@1- (0.01,0) [-327.68|327.67] ""  DESKTOPSIMULATION
+
+BO_ 2181033648 FAN_CONTROL_SERVICE: 8 DESKTOPSIMULATION
+ SG_ FanEnable : 0|1@1+ (1,0) [0|1] ""  TTC
+ SG_ FanSpeedRequest : 8|16@1+ (1,0) [0|100] "%"  TTC
+
+BO_ 2181033649 COMPRESSOR_CONTROL_SERVICE: 8 DESKTOPSIMULATION
+ SG_ CompressorEnable : 0|1@1+ (1,0) [0|1] ""  TTC
+ SG_ CompressorSpeedRequest : 8|16@1+ (1,0) [1000|8500] "rpm"  TTC
+
+BO_ 2181033650 PUMPS_CONTROL_SERVICE: 8 DESKTOPSIMULATION
+ SG_ PumpEnable : 0|1@1+ (1,0) [0|1] ""  TTC
+ SG_ PumpSpeedRequest : 8|16@1+ (1,0) [1500|5350] "rpm"  TTC
+
+BO_ 2181033651 HEATER_CONTROL_SERVICE: 8 DESKTOPSIMULATION
+ SG_ HeaterEnable : 0|1@1+ (1,0) [0|1] ""  TTC
+ SG_ HeaterContactorControl : 1|1@1+ (1,0) [0|1] ""  TTC
+ SG_ HeaterTargetTemp : 8|8@1+ (1,-50) [0|100] "°C"  TTC
+ SG_ HeaterTargetTempOverride : 16|1@1+ (1,0) [0|1] ""  TTC
+ SG_ HeaterMaxPower : 24|16@1+ (1,0) [0|12000] "W"  TTC
+ SG_ HeaterMaxPowerOverride : 40|1@1+ (1,0) [0|1] ""  TTC
+
+BO_ 2181033652 COMMON_OTHER_CONTROL_SERVICE: 8 DESKTOPSIMULATION
+ SG_ DCDCAuxSupply : 0|1@1+ (1,0) [0|1] ""  TTC
+ SG_ CirculationPumpEnable : 1|1@1+ (1,0) [0|1] ""  TTC
+
+BO_ 2181033653 LOOP_OTHER_CONTROL_SERVICE: 8 DESKTOPSIMULATION
+ SG_ SuperheatControllerEnable : 0|1@1+ (1,0) [0|1] ""  TTC
+
+BO_ 2181033654 PID_TUNING_SERVICE: 8 DESKTOP_SIMULATION
+ SG_ k_p : 0|16@1- (0.05,0) [0|1638.35] ""  TTC
+ SG_ k_i : 16|16@1- (0.005,0) [0|163.835] ""  TTC
+ SG_ k_d : 32|16@1- (0.5,0) [0|32767.5] ""  TTC
+ SG_ use_custom_gains : 48|1@1+ (1,0) [0|1] ""  TTC
+ SG_ overwrite_episphere_gains : 49|1@1+ (1,0) [0|1] ""  TTC
+
+BO_ 2181033655 FAULT_RESET_MESSAGE_SERVICE: 8 DESKTOP_SIMULATION
+ SG_ Reset_Lockout : 0|1@1+ (1,0) [0|1] ""  TTC
+ SG_ Reset_Cooling_Disabled : 1|1@1+ (1,0) [0|1] ""  TTC
+ SG_ Reset_Heating_Disabled : 2|1@1+ (1,0) [0|1] ""  TTC
+
+
+
+CM_ SG_ 2683240203 ttc_episphere_device_type "Device type of TTC that is set via EpiSphereConfig in application to identify it in Episphere";
+CM_ SG_ 2583681129 ECPowerPermit "Requested upper limit for the power consumption of the compressor. If no limit is set (value of zero), then there is no limit requested from the vehicle.";
+CM_ SG_ 2583681129 ECSpeedReq "Speed command from vehicle or system to compressor. Compresor will not run if EC_Enable is 'compressor off' or EC_HV_Shutdown is 'True'. Compressor actual speed may not match commanded speed for many reasons.";
+CM_ SG_ 2583681129 ECHVShutdown "If true, initiate an immediate fast stop of the compressor motor.";
+CM_ SG_ 2583680152 ECTrnstrTemp "Transistor temperature sensor measured value";
+CM_ SG_ 2583680152 ECPhaseCurrent "Motor phase current sensor measured value (highest value among three phases)";
+CM_ SG_ 2684354464 Z_DI_72 "0 indicates normal operation, 1 indicates switch is tripped";
+CM_ SG_ 2684354464 Z_DI_74 "0 indicates normal operation, 1 indicates switch is tripped";
+CM_ SG_ 2684354464 Z_DI_78 "0 indicates normal operation, 1 indicates switch is tripped";
+CM_ SG_ 2684354464 Z_DI_73 "Fan1 DIN value";
+CM_ SG_ 2684354464 Z_DI_75 "Fan2 DIN value";
+CM_ SG_ 2684354464 Z_DI_77 "Fan3 DIN value";
+CM_ SG_ 2684354464 Z_DI_79 "Fan4 DIN value";
+CM_ SG_ 2684354464 Z_AI_00 "milli-voltage value corresponds to psig (pressure per square inch guage pressre). 1000mV is 62.5psig and 1500mV is 125psig";
+CM_ SG_ 2684354464 Z_AI_10 "milli-voltage value corresponds to psig (pressure per square inch guage pressre). 1000mV is 62.5psig and 1500mV is 125psig";
+CM_ SG_ 2684354464 Z_AI_12 "Current value corresponds to pressure, 4ma is 0 bar, and 20ma is 10 bar";
+CM_ SG_ 2684354464 Z_AI_14 "Current value corresponds to pressure, 4ma is 0 bar, and 20ma is 10 bar";
+CM_ SG_ 2684354464 Z_AI_11 "Voltage value corresponding to temperature";
+CM_ SG_ 2684354464 Z_AI_01 "Resistance value corresponds to temperature, 10000 is 25°C and 1000 is 87°C";
+CM_ SG_ 2684354464 Z_AI_02 "Resistance value corresponds to temperature, 10000 is 25°C and 1000 is 87°C";
+CM_ SG_ 2684354464 Z_AI_04 "Resistance value corresponds to temperature, 10000 is 25°C and 1000 is 87°C";
+CM_ SG_ 2684354464 Z_AI_05 "Voltage value corresponding to temperature";
+CM_ SG_ 2684354464 Z_AI_06 "Resistance value corresponds to temperature, 10000 is 25°C and 1000 is 87°C";
+BA_DEF_ SG_  "CanDootHidden" ENUM  "No","Yes";
+BA_DEF_ SG_  "CanDootGroup" ENUM  "None","g1","g2","g3","g4","g5","g6","g7","g8","g9","gA","gB","gC","gD","gE","gF";
+BA_DEF_ SG_  "GenSigStartValue" FLOAT 0 100000000000;
+BA_DEF_ SG_  "CanDootBroadcast" ENUM  "No","Yes";
+BA_DEF_ SG_  "GenSigSendType" ENUM  "Cyclic","OnWrite","OnWriteWithRepetition","OnChange","OnChangeWithRepetition","IfActive","IfActiveWithRepetition","NoSigSendType";
+BA_DEF_ SG_  "GenSigInactiveValue" INT 0 100000;
+BA_DEF_ SG_  "SPN" INT 0 524287;
+BA_DEF_ SG_  "SignalName" STRING ;
+BA_DEF_ SG_  "SigType" STRING ;
+BA_DEF_ SG_  "SigBroadcasted" ENUM  "No","Yes";
+BA_DEF_ BO_  "GenMsgStartDelayTime" INT 0 65535;
+BA_DEF_ BO_  "GenMsgNrOfRepetition" INT 0 999999;
+BA_DEF_ BO_  "GenMsgILSupport" ENUM  "No","Yes";
+BA_DEF_ BO_  "GenMsgCycleTimeFast" INT 0 50000;
+BA_DEF_ BO_  "MessageName" STRING ;
+BA_DEF_ BO_  "GenMsgSendType" ENUM  "Cyclic","Reserved","Reserved","Reserved","Reserved","Reserved","Reserved","IfActive","NoMsgSendType";
+BA_DEF_ BO_  "GenMsgRequestable" INT 0 1;
+BA_DEF_ BO_  "GenMsgDelayTime" INT 0 1000;
+BA_DEF_ BO_  "PGN" HEX 0 65535;
+BA_DEF_ BO_  "GenMsgCycleTime" INT 0 65535;
+BA_DEF_ BO_  "VFrameFormat" ENUM  "StandardCAN","ExtendedCAN","reserved","J1939PG";
+BA_DEF_ BO_  "CanDootDecode" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulateBus" INT 0 6;
+BA_DEF_ BO_  "CanDootDecodeBus" INT 0 6;
+BA_DEF_ BO_  "CanDootPaused" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulate" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulateCycleTime" INT 0 50000;
+BA_DEF_  "ProtocolType" STRING ;
+BA_DEF_DEF_  "CanDootHidden" "No";
+BA_DEF_DEF_  "CanDootGroup" "None";
+BA_DEF_DEF_  "GenSigStartValue" 0;
+BA_DEF_DEF_  "CanDootBroadcast" "";
+BA_DEF_DEF_  "GenSigSendType" "";
+BA_DEF_DEF_  "GenSigInactiveValue" 0;
+BA_DEF_DEF_  "SPN" 0;
+BA_DEF_DEF_  "SignalName" "";
+BA_DEF_DEF_  "SigType" "";
+BA_DEF_DEF_  "SigBroadcasted" "";
+BA_DEF_DEF_  "GenMsgStartDelayTime" 0;
+BA_DEF_DEF_  "GenMsgNrOfRepetition" 0;
+BA_DEF_DEF_  "GenMsgILSupport" "";
+BA_DEF_DEF_  "GenMsgCycleTimeFast" 0;
+BA_DEF_DEF_  "MessageName" "";
+BA_DEF_DEF_  "GenMsgSendType" "";
+BA_DEF_DEF_  "GenMsgRequestable" 0;
+BA_DEF_DEF_  "GenMsgDelayTime" 0;
+BA_DEF_DEF_  "PGN" 0;
+BA_DEF_DEF_  "GenMsgCycleTime" 0;
+BA_DEF_DEF_  "VFrameFormat" "";
+BA_DEF_DEF_  "CanDootDecode" "Yes";
+BA_DEF_DEF_  "CanDootSimulateBus" 0;
+BA_DEF_DEF_  "CanDootDecodeBus" 0;
+BA_DEF_DEF_  "CanDootPaused" "No";
+BA_DEF_DEF_  "CanDootSimulate" "No";
+BA_DEF_DEF_  "CanDootSimulateCycleTime" 1500;
+BA_DEF_DEF_  "ProtocolType" "";
+BA_ "GenMsgSendType" BO_ 2558198015 0;
+BA_ "GenMsgCycleTime" BO_ 2558198015 1000;
+BA_ "CanDootDecode" BO_ 2558198015 1;
+BA_ "CanDootSimulateBus" BO_ 2558198015 3;
+BA_ "CanDootSimulateCycleTime" BO_ 2558198015 100;
+BA_ "CanDootDecodeBus" BO_ 2558198015 3;
+BA_ "CanDootSimulate" BO_ 2558198015 0;
+BA_ "VFrameFormat" BO_ 2558198015 3;
+BA_ "GenMsgSendType" BO_ 2566651648 0;
+BA_ "GenMsgCycleTime" BO_ 2566651648 1000;
+BA_ "CanDootDecode" BO_ 2566651648 1;
+BA_ "CanDootDecodeBus" BO_ 2566651648 2;
+BA_ "CanDootSimulate" BO_ 2566651648 0;
+BA_ "CanDootSimulateBus" BO_ 2566651648 2;
+BA_ "CanDootSimulateCycleTime" BO_ 2566651648 500;
+BA_ "VFrameFormat" BO_ 2566651648 3;
+BA_ "CanDootDecodeBus" BO_ 2683239947 1;
+BA_ "CanDootSimulateBus" BO_ 2683239947 0;
+BA_ "GenMsgCycleTimeFast" BO_ 2683239947 100;
+BA_ "MessageName" BO_ 2683239947 "EVCA command";
+BA_ "GenMsgSendType" BO_ 2683239947 0;
+BA_ "GenMsgDelayTime" BO_ 2683239947 0;
+BA_ "GenMsgCycleTime" BO_ 2683239947 100;
+BA_ "CanDootSimulate" BO_ 2683239947 0;
+BA_ "CanDootDecode" BO_ 2683239947 1;
+BA_ "VFrameFormat" BO_ 2683239947 3;
+BA_ "CanDootDecodeBus" BO_ 2683177982 1;
+BA_ "CanDootSimulateBus" BO_ 2683177982 0;
+BA_ "GenMsgCycleTimeFast" BO_ 2683177982 100;
+BA_ "MessageName" BO_ 2683177982 "EVCA command";
+BA_ "GenMsgSendType" BO_ 2683177982 0;
+BA_ "GenMsgDelayTime" BO_ 2683177982 0;
+BA_ "GenMsgCycleTime" BO_ 2683177982 100;
+BA_ "CanDootSimulate" BO_ 2683177982 0;
+BA_ "CanDootDecode" BO_ 2683177982 1;
+BA_ "VFrameFormat" BO_ 2683177982 3;
+BA_ "CanDootDecodeBus" BO_ 2683240203 1;
+BA_ "CanDootSimulateBus" BO_ 2683240203 0;
+BA_ "GenMsgCycleTime" BO_ 2683240203 100;
+BA_ "GenMsgDelayTime" BO_ 2683240203 0;
+BA_ "GenMsgSendType" BO_ 2683240203 0;
+BA_ "MessageName" BO_ 2683240203 "EVCA command";
+BA_ "GenMsgCycleTimeFast" BO_ 2683240203 100;
+BA_ "CanDootSimulate" BO_ 2683240203 0;
+BA_ "CanDootDecode" BO_ 2683240203 1;
+BA_ "VFrameFormat" BO_ 2683240203 3;
+BA_ "CanDootDecodeBus" BO_ 2683240446 1;
+BA_ "CanDootSimulateBus" BO_ 2683240446 0;
+BA_ "GenMsgCycleTimeFast" BO_ 2683240446 100;
+BA_ "MessageName" BO_ 2683240446 "EVCA command";
+BA_ "GenMsgSendType" BO_ 2683240446 0;
+BA_ "GenMsgDelayTime" BO_ 2683240446 0;
+BA_ "GenMsgCycleTime" BO_ 2683240446 100;
+BA_ "CanDootSimulate" BO_ 2683240446 0;
+BA_ "CanDootDecode" BO_ 2683240446 1;
+BA_ "VFrameFormat" BO_ 2683240446 3;
+BA_ "GenMsgCycleTime" BO_ 2365528155 100;
+BA_ "CanDootSimulateBus" BO_ 2365528155 1;
+BA_ "CanDootDecodeBus" BO_ 2365528155 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2365528155 100;
+BA_ "CanDootSimulate" BO_ 2365528155 0;
+BA_ "CanDootDecode" BO_ 2365528155 1;
+BA_ "VFrameFormat" BO_ 2365528155 3;
+BA_ "CanDootDecodeBus" BO_ 2365545936 1;
+BA_ "CanDootSimulateBus" BO_ 2365545936 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2365545936 200;
+BA_ "CanDootSimulate" BO_ 2365545936 0;
+BA_ "GenMsgCycleTime" BO_ 2365545936 100;
+BA_ "CanDootDecode" BO_ 2365545936 1;
+BA_ "VFrameFormat" BO_ 2365545936 3;
+BA_ "CanDootSimulate" BO_ 2365528528 0;
+BA_ "GenMsgCycleTime" BO_ 2365528528 100;
+BA_ "CanDootSimulateBus" BO_ 2365528528 1;
+BA_ "CanDootDecodeBus" BO_ 2365528528 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2365528528 100;
+BA_ "CanDootDecode" BO_ 2365528528 1;
+BA_ "VFrameFormat" BO_ 2365528528 3;
+BA_ "CanDootSimulate" BO_ 2365545680 0;
+BA_ "GenMsgCycleTime" BO_ 2365545680 100;
+BA_ "CanDootSimulateBus" BO_ 2365545680 1;
+BA_ "CanDootDecodeBus" BO_ 2365545680 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2365545680 100;
+BA_ "CanDootDecode" BO_ 2365545680 1;
+BA_ "VFrameFormat" BO_ 2365545680 3;
+BA_ "CanDootSimulate" BO_ 2365528411 0;
+BA_ "GenMsgCycleTime" BO_ 2365528411 100;
+BA_ "CanDootSimulateBus" BO_ 2365528411 0;
+BA_ "CanDootDecodeBus" BO_ 2365528411 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2365528411 100;
+BA_ "CanDootDecode" BO_ 2365528411 1;
+BA_ "VFrameFormat" BO_ 2365528411 3;
+BA_ "CanDootSimulate" BO_ 2583681129 0;
+BA_ "GenMsgCycleTime" BO_ 2583681129 100;
+BA_ "GenMsgCycleTimeFast" BO_ 2583681129 100;
+BA_ "GenMsgDelayTime" BO_ 2583681129 0;
+BA_ "GenMsgSendType" BO_ 2583681129 0;
+BA_ "MessageName" BO_ 2583681129 "EVCA command";
+BA_ "CanDootDecode" BO_ 2583681129 1;
+BA_ "CanDootDecodeBus" BO_ 2583681129 3;
+BA_ "CanDootSimulateBus" BO_ 2583681129 3;
+BA_ "VFrameFormat" BO_ 2583681129 3;
+BA_ "CanDootSimulateCycleTime" BO_ 2583680152 100;
+BA_ "VFrameFormat" BO_ 2583680152 1;
+BA_ "CanDootDecode" BO_ 2583680152 1;
+BA_ "CanDootDecodeBus" BO_ 2583680152 2;
+BA_ "CanDootSimulate" BO_ 2583680152 0;
+BA_ "CanDootSimulateBus" BO_ 2583680152 2;
+BA_ "CanDootSimulate" BO_ 2565817377 0;
+BA_ "CanDootSimulateBus" BO_ 2565817377 3;
+BA_ "GenMsgDelayTime" BO_ 2565817377 0;
+BA_ "GenMsgSendType" BO_ 2565817377 0;
+BA_ "GenMsgCycleTime" BO_ 2565817377 1000;
+BA_ "GenMsgCycleTimeFast" BO_ 2565817377 0;
+BA_ "CanDootDecodeBus" BO_ 2565817377 3;
+BA_ "MessageName" BO_ 2565817377 "";
+BA_ "CanDootDecode" BO_ 2565817377 1;
+BA_ "VFrameFormat" BO_ 2565817377 3;
+BA_ "GenMsgSendType" BO_ 2566889540 0;
+BA_ "GenMsgCycleTime" BO_ 2566889540 1000;
+BA_ "CanDootDecode" BO_ 2566889540 1;
+BA_ "CanDootSimulateBus" BO_ 2566889540 2;
+BA_ "CanDootSimulateCycleTime" BO_ 2566889540 500;
+BA_ "CanDootSimulate" BO_ 2566889540 0;
+BA_ "CanDootDecodeBus" BO_ 2566889540 1;
+BA_ "VFrameFormat" BO_ 2566889540 3;
+BA_ "GenMsgSendType" BO_ 2566889796 0;
+BA_ "GenMsgCycleTime" BO_ 2566889796 1000;
+BA_ "CanDootDecode" BO_ 2566889796 1;
+BA_ "CanDootSimulateBus" BO_ 2566889796 2;
+BA_ "CanDootSimulateCycleTime" BO_ 2566889796 500;
+BA_ "CanDootSimulate" BO_ 2566889796 0;
+BA_ "CanDootDecodeBus" BO_ 2566889796 1;
+BA_ "VFrameFormat" BO_ 2566889796 3;
+BA_ "GenMsgSendType" BO_ 2550190223 0;
+BA_ "GenMsgCycleTime" BO_ 2550190223 500;
+BA_ "CanDootDecode" BO_ 2550190223 1;
+BA_ "CanDootSimulateBus" BO_ 2550190223 3;
+BA_ "CanDootSimulateCycleTime" BO_ 2550190223 500;
+BA_ "CanDootSimulate" BO_ 2550190223 0;
+BA_ "CanDootDecodeBus" BO_ 2550190223 3;
+BA_ "VFrameFormat" BO_ 2550190223 3;
+BA_ "GenMsgSendType" BO_ 2550255759 0;
+BA_ "GenMsgCycleTime" BO_ 2550255759 500;
+BA_ "CanDootDecode" BO_ 2550255759 1;
+BA_ "CanDootSimulateBus" BO_ 2550255759 3;
+BA_ "CanDootSimulateCycleTime" BO_ 2550255759 500;
+BA_ "CanDootSimulate" BO_ 2550255759 0;
+BA_ "CanDootDecodeBus" BO_ 2550255759 3;
+BA_ "VFrameFormat" BO_ 2550255759 3;
+BA_ "CanDootDecodeBus" BO_ 2684354464 0;
+BA_ "CanDootSimulateBus" BO_ 2684354464 0;
+BA_ "CanDootSimulateCycleTime" BO_ 2684354464 500;
+BA_ "CanDootSimulate" BO_ 2684354464 0;
+BA_ "CanDootDecode" BO_ 2684354464 0;
+BA_ "CanDootPaused" BO_ 2684354464 0;
+BA_ "VFrameFormat" BO_ 2684354464 3;
+BA_ "CanDootDecodeBus" BO_ 2684354480 0;
+BA_ "CanDootSimulateBus" BO_ 2684354480 0;
+BA_ "CanDootSimulateCycleTime" BO_ 2684354480 500;
+BA_ "CanDootPaused" BO_ 2684354480 0;
+BA_ "CanDootSimulate" BO_ 2684354480 0;
+BA_ "CanDootDecode" BO_ 2684354480 1;
+BA_ "VFrameFormat" BO_ 2684354480 3;
+BA_ "CanDootDecode" BO_ 2181033632 1;
+BA_ "CanDootSimulateBus" BO_ 2181033632 0;
+BA_ "CanDootDecodeBus" BO_ 2181033632 1;
+BA_ "CanDootSimulate" BO_ 2181033632 0;
+BA_ "CanDootDecode" BO_ 2181033633 1;
+BA_ "CanDootSimulateBus" BO_ 2181033633 0;
+BA_ "CanDootDecodeBus" BO_ 2181033633 1;
+BA_ "CanDootSimulate" BO_ 2181033633 0;
+BA_ "CanDootDecode" BO_ 2181033634 1;
+BA_ "CanDootSimulateBus" BO_ 2181033634 0;
+BA_ "CanDootDecodeBus" BO_ 2181033634 1;
+BA_ "CanDootSimulate" BO_ 2181033634 0;
+BA_ "CanDootDecode" BO_ 2181033635 1;
+BA_ "CanDootSimulateBus" BO_ 2181033635 0;
+BA_ "CanDootDecodeBus" BO_ 2181033635 1;
+BA_ "CanDootSimulate" BO_ 2181033635 0;
+BA_ "CanDootDecode" BO_ 2181033636 1;
+BA_ "CanDootSimulateBus" BO_ 2181033636 0;
+BA_ "CanDootDecodeBus" BO_ 2181033636 1;
+BA_ "CanDootSimulate" BO_ 2181033636 0;
+BA_ "CanDootDecode" BO_ 2181033637 1;
+BA_ "CanDootSimulateBus" BO_ 2181033637 0;
+BA_ "CanDootDecodeBus" BO_ 2181033637 1;
+BA_ "CanDootSimulate" BO_ 2181033637 0;
+BA_ "CanDootDecode" BO_ 2181033638 1;
+BA_ "CanDootSimulateBus" BO_ 2181033638 0;
+BA_ "CanDootDecodeBus" BO_ 2181033638 1;
+BA_ "CanDootSimulate" BO_ 2181033638 0;
+BA_ "CanDootDecode" BO_ 2181033639 1;
+BA_ "CanDootSimulateBus" BO_ 2181033639 0;
+BA_ "CanDootDecodeBus" BO_ 2181033639 1;
+BA_ "CanDootSimulate" BO_ 2181033639 0;
+BA_ "CanDootDecode" BO_ 2181033640 1;
+BA_ "CanDootSimulateBus" BO_ 2181033640 0;
+BA_ "CanDootDecodeBus" BO_ 2181033640 1;
+BA_ "CanDootSimulate" BO_ 2181033640 0;
+BA_ "CanDootDecode" BO_ 2181033641 1;
+BA_ "CanDootSimulateBus" BO_ 2181033641 0;
+BA_ "CanDootDecodeBus" BO_ 2181033641 1;
+BA_ "CanDootSimulate" BO_ 2181033641 0;
+BA_ "CanDootDecode" BO_ 2181033642 1;
+BA_ "CanDootSimulateBus" BO_ 2181033642 0;
+BA_ "CanDootDecodeBus" BO_ 2181033642 1;
+BA_ "CanDootSimulate" BO_ 2181033642 0;
+BA_ "CanDootDecode" BO_ 2181033643 1;
+BA_ "CanDootSimulateBus" BO_ 2181033643 0;
+BA_ "CanDootDecodeBus" BO_ 2181033643 1;
+BA_ "CanDootSimulate" BO_ 2181033643 0;
+BA_ "CanDootDecode" BO_ 2181033644 1;
+BA_ "CanDootSimulateBus" BO_ 2181033644 0;
+BA_ "CanDootDecodeBus" BO_ 2181033644 1;
+BA_ "CanDootSimulate" BO_ 2181033644 0;
+BA_ "CanDootDecode" BO_ 2181033645 1;
+BA_ "CanDootSimulateBus" BO_ 2181033645 0;
+BA_ "CanDootDecodeBus" BO_ 2181033645 1;
+BA_ "CanDootSimulate" BO_ 2181033645 0;
+BA_ "VFrameFormat" BO_ 2181033646 1;
+BA_ "CanDootDecodeBus" BO_ 2181033646 1;
+BA_ "GenMsgCycleTime" BO_ 2181033648 100;
+BA_ "CanDootSimulateBus" BO_ 2181033648 1;
+BA_ "CanDootDecodeBus" BO_ 2181033648 0;
+BA_ "CanDootSimulateCycleTime" BO_ 2181033648 100;
+BA_ "CanDootDecode" BO_ 2181033648 0;
+BA_ "CanDootSimulate" BO_ 2181033648 1;
+BA_ "VFrameFormat" BO_ 2181033648 3;
+BA_ "GenMsgCycleTime" BO_ 2181033649 100;
+BA_ "CanDootSimulateBus" BO_ 2181033649 1;
+BA_ "CanDootDecodeBus" BO_ 2181033649 0;
+BA_ "CanDootSimulateCycleTime" BO_ 2181033649 100;
+BA_ "CanDootDecode" BO_ 2181033649 0;
+BA_ "CanDootSimulate" BO_ 2181033649 1;
+BA_ "VFrameFormat" BO_ 2181033649 3;
+BA_ "GenMsgCycleTime" BO_ 2181033650 100;
+BA_ "CanDootSimulateBus" BO_ 2181033650 1;
+BA_ "CanDootDecodeBus" BO_ 2181033650 0;
+BA_ "CanDootSimulateCycleTime" BO_ 2181033650 100;
+BA_ "CanDootDecode" BO_ 2181033650 0;
+BA_ "CanDootSimulate" BO_ 2181033650 1;
+BA_ "VFrameFormat" BO_ 2181033650 3;
+BA_ "GenMsgCycleTime" BO_ 2181033651 100;
+BA_ "CanDootSimulateBus" BO_ 2181033651 1;
+BA_ "CanDootDecodeBus" BO_ 2181033651 0;
+BA_ "CanDootSimulateCycleTime" BO_ 2181033651 100;
+BA_ "CanDootDecode" BO_ 2181033651 0;
+BA_ "CanDootSimulate" BO_ 2181033651 1;
+BA_ "VFrameFormat" BO_ 2181033651 3;
+BA_ "GenMsgCycleTime" BO_ 2181033652 100;
+BA_ "CanDootSimulateBus" BO_ 2181033652 1;
+BA_ "CanDootDecodeBus" BO_ 2181033652 0;
+BA_ "CanDootSimulateCycleTime" BO_ 2181033652 100;
+BA_ "CanDootDecode" BO_ 2181033652 0;
+BA_ "CanDootSimulate" BO_ 2181033652 1;
+BA_ "VFrameFormat" BO_ 2181033652 3;
+BA_ "GenMsgCycleTime" BO_ 2181033653 100;
+BA_ "CanDootSimulateBus" BO_ 2181033653 1;
+BA_ "CanDootDecodeBus" BO_ 2181033653 0;
+BA_ "CanDootSimulateCycleTime" BO_ 2181033653 100;
+BA_ "CanDootDecode" BO_ 2181033653 0;
+BA_ "CanDootSimulate" BO_ 2181033653 1;
+BA_ "VFrameFormat" BO_ 2181033653 3;
+BA_ "MessageName" BO_ 2181033654 "";
+BA_ "VFrameFormat" BO_ 2181033654 1;
+BA_ "CanDootDecode" BO_ 2181033654 0;
+BA_ "CanDootSimulateBus" BO_ 2181033654 1;
+BA_ "CanDootDecodeBus" BO_ 2181033654 0;
+BA_ "CanDootSimulate" BO_ 2181033654 1;
+BA_ "CanDootSimulate" BO_ 2181033655 1;
+BA_ "CanDootDecodeBus" BO_ 2181033655 1;
+BA_ "CanDootSimulateBus" BO_ 2181033655 1;
+BA_ "VFrameFormat" BO_ 2181033655 1;
+BA_ "GenSigStartValue" SG_ 2365528155 SetpointHeaterControlTemp 57;
+BA_ "GenSigStartValue" SG_ 2365528155 MeasuredControlTemperature 597;
+BA_ "GenSigStartValue" SG_ 2365545936 HVES1_Intake_Coolant_Temperature 40;
+BA_ "GenSigStartValue" SG_ 2365545936 HVES1_Outlet_Coolant_Temperature 40;
+BA_ "GenSigStartValue" SG_ 2365545936 HVES1_Electronics_Temperature 40;
+BA_ "GenSigStartValue" SG_ 2365528528 HeaterTemperature 40;
+BA_ "GenSigStartValue" SG_ 2365528528 AmbientTemperature 80;
+BA_ "GenSigSendType" SG_ 2583681129 ECEnable 0;
+BA_ "SigBroadcasted" SG_ 2583681129 ECEnable 1;
+BA_ "SPN" SG_ 2583681129 ECEnable 0;
+BA_ "GenSigInactiveValue" SG_ 2583681129 ECEnable 0;
+BA_ "GenSigStartValue" SG_ 2583681129 ECEnable 3;
+BA_ "SigType" SG_ 2583681129 ECEnable "DEFAULT";
+BA_ "SignalName" SG_ 2583681129 ECEnable "ECEnable";
+BA_ "GenSigSendType" SG_ 2583681129 ECPowerPermit 0;
+BA_ "SigBroadcasted" SG_ 2583681129 ECPowerPermit 1;
+BA_ "SPN" SG_ 2583681129 ECPowerPermit 0;
+BA_ "GenSigInactiveValue" SG_ 2583681129 ECPowerPermit 0;
+BA_ "GenSigStartValue" SG_ 2583681129 ECPowerPermit 0;
+BA_ "SigType" SG_ 2583681129 ECPowerPermit "DEFAULT";
+BA_ "SignalName" SG_ 2583681129 ECPowerPermit "EC Power Permit";
+BA_ "GenSigSendType" SG_ 2583681129 ECSpeedReq 0;
+BA_ "SigBroadcasted" SG_ 2583681129 ECSpeedReq 1;
+BA_ "SPN" SG_ 2583681129 ECSpeedReq 0;
+BA_ "GenSigInactiveValue" SG_ 2583681129 ECSpeedReq 0;
+BA_ "GenSigStartValue" SG_ 2583681129 ECSpeedReq 0;
+BA_ "SigType" SG_ 2583681129 ECSpeedReq "DEFAULT";
+BA_ "SignalName" SG_ 2583681129 ECSpeedReq "EC Speed Req";
+BA_ "GenSigSendType" SG_ 2583681129 ECHVShutdown 0;
+BA_ "SigBroadcasted" SG_ 2583681129 ECHVShutdown 1;
+BA_ "SPN" SG_ 2583681129 ECHVShutdown 0;
+BA_ "GenSigInactiveValue" SG_ 2583681129 ECHVShutdown 0;
+BA_ "GenSigStartValue" SG_ 2583681129 ECHVShutdown 3;
+BA_ "SigType" SG_ 2583681129 ECHVShutdown "DEFAULT";
+BA_ "SignalName" SG_ 2583681129 ECHVShutdown "ECHVShutdown";
+BA_ "SignalName" SG_ 2583680152 ECTrnstrTemp "EC Trnstr Temp";
+BA_ "SigType" SG_ 2583680152 ECTrnstrTemp "DEFAULT";
+BA_ "GenSigStartValue" SG_ 2583680152 ECTrnstrTemp 255;
+BA_ "GenSigInactiveValue" SG_ 2583680152 ECTrnstrTemp 0;
+BA_ "SPN" SG_ 2583680152 ECTrnstrTemp 0;
+BA_ "SigBroadcasted" SG_ 2583680152 ECTrnstrTemp 1;
+BA_ "GenSigSendType" SG_ 2583680152 ECTrnstrTemp 0;
+BA_ "SignalName" SG_ 2583680152 ECFaultBitmap "EC Fault indication Bitmap";
+BA_ "SigType" SG_ 2583680152 ECFaultBitmap "DEFAULT";
+BA_ "GenSigStartValue" SG_ 2583680152 ECFaultBitmap 0;
+BA_ "GenSigInactiveValue" SG_ 2583680152 ECFaultBitmap 0;
+BA_ "SPN" SG_ 2583680152 ECFaultBitmap 0;
+BA_ "SigBroadcasted" SG_ 2583680152 ECFaultBitmap 1;
+BA_ "GenSigSendType" SG_ 2583680152 ECFaultBitmap 0;
+BA_ "SignalName" SG_ 2583680152 ECSpeedFdbk "EC Speed Feedback";
+BA_ "SigType" SG_ 2583680152 ECSpeedFdbk "DEFAULT";
+BA_ "GenSigStartValue" SG_ 2583680152 ECSpeedFdbk 1000;
+BA_ "GenSigInactiveValue" SG_ 2583680152 ECSpeedFdbk 0;
+BA_ "SPN" SG_ 2583680152 ECSpeedFdbk 0;
+BA_ "SigBroadcasted" SG_ 2583680152 ECSpeedFdbk 1;
+BA_ "GenSigSendType" SG_ 2583680152 ECSpeedFdbk 0;
+BA_ "SignalName" SG_ 2583680152 ECPhaseCurrent "ECPhaseCurrent";
+BA_ "SigType" SG_ 2583680152 ECPhaseCurrent "DEFAULT";
+BA_ "GenSigStartValue" SG_ 2583680152 ECPhaseCurrent 0;
+BA_ "GenSigInactiveValue" SG_ 2583680152 ECPhaseCurrent 0;
+BA_ "SPN" SG_ 2583680152 ECPhaseCurrent 0;
+BA_ "SigBroadcasted" SG_ 2583680152 ECPhaseCurrent 1;
+BA_ "GenSigSendType" SG_ 2583680152 ECPhaseCurrent 0;
+BA_ "SignalName" SG_ 2583680152 ECOpStatus "ECOpStatus";
+BA_ "SigType" SG_ 2583680152 ECOpStatus "DEFAULT";
+BA_ "GenSigStartValue" SG_ 2583680152 ECOpStatus 0;
+BA_ "GenSigInactiveValue" SG_ 2583680152 ECOpStatus 0;
+BA_ "SPN" SG_ 2583680152 ECOpStatus 0;
+BA_ "SigBroadcasted" SG_ 2583680152 ECOpStatus 1;
+BA_ "GenSigSendType" SG_ 2583680152 ECOpStatus 0;
+BA_ "SignalName" SG_ 2583680152 ECDCVoltage "EC DC Voltage";
+BA_ "SigType" SG_ 2583680152 ECDCVoltage "DEFAULT";
+BA_ "GenSigStartValue" SG_ 2583680152 ECDCVoltage 0;
+BA_ "GenSigInactiveValue" SG_ 2583680152 ECDCVoltage 0;
+BA_ "SPN" SG_ 2583680152 ECDCVoltage 0;
+BA_ "SigBroadcasted" SG_ 2583680152 ECDCVoltage 1;
+BA_ "GenSigSendType" SG_ 2583680152 ECDCVoltage 0;
+BA_ "SignalName" SG_ 2583680152 ECDCCurrent "ECDCCurrent";
+BA_ "SigType" SG_ 2583680152 ECDCCurrent "DEFAULT";
+BA_ "GenSigStartValue" SG_ 2583680152 ECDCCurrent 0;
+BA_ "GenSigInactiveValue" SG_ 2583680152 ECDCCurrent 0;
+BA_ "SPN" SG_ 2583680152 ECDCCurrent 0;
+BA_ "SigBroadcasted" SG_ 2583680152 ECDCCurrent 1;
+BA_ "GenSigSendType" SG_ 2583680152 ECDCCurrent 0;
+BA_ "GenSigStartValue" SG_ 2565817377 HVH_TargetCoolantTemp 85;
+BA_ "GenSigStartValue" SG_ 2565817377 HVH_MaxPower 254;
+BA_ "GenSigStartValue" SG_ 2566889540 HVH_ActualPower 0;
+BA_ "GenSigStartValue" SG_ 2566889540 HVH_HVIL_Status 0;
+BA_ "GenSigStartValue" SG_ 2566889540 HVH_HV_Current 0;
+BA_ "GenSigStartValue" SG_ 2566889540 HVH_HV_Voltage 0;
+BA_ "GenSigStartValue" SG_ 2566889540 HVH_Coolant_Out_Temp 50;
+BA_ "GenSigStartValue" SG_ 2566889540 HVH_Coolant_In_Temp 50;
+BA_ "GenSigStartValue" SG_ 2684354464 Z_DI_72 1;
+BA_ "GenSigStartValue" SG_ 2684354464 Z_DI_74 1;
+BA_ "GenSigStartValue" SG_ 2684354464 Z_DI_78 0;
+BA_ "GenSigStartValue" SG_ 2684354464 Z_DI_73 0;
+BA_ "GenSigStartValue" SG_ 2684354464 Z_DI_75 0;
+BA_ "GenSigStartValue" SG_ 2684354464 Z_DI_77 0;
+BA_ "GenSigStartValue" SG_ 2684354464 Z_DI_79 0;
+BA_ "GenSigStartValue" SG_ 2684354464 Z_AI_00 10000;
+BA_ "GenSigStartValue" SG_ 2684354464 Z_AI_10 10000;
+BA_ "GenSigStartValue" SG_ 2684354464 Z_AI_12 10000;
+BA_ "GenSigStartValue" SG_ 2684354464 Z_AI_14 10000;
+BA_ "GenSigStartValue" SG_ 2684354464 Z_AI_11 10000;
+BA_ "GenSigStartValue" SG_ 2684354464 Z_AI_01 10000;
+BA_ "GenSigStartValue" SG_ 2684354464 Z_AI_02 10000;
+BA_ "GenSigStartValue" SG_ 2684354464 Z_AI_04 10000;
+BA_ "GenSigStartValue" SG_ 2684354464 Z_AI_05 10000;
+BA_ "GenSigStartValue" SG_ 2684354464 Z_AI_06 10000;
+BA_ "CanDootHidden" SG_ 2684354464 Z_pin_id 1;
+BA_ "CanDootBroadcast" SG_ 2684354464 Z_pin_id 0;
+BA_ "GenSigStartValue" SG_ 2684354480 Z_PWM_04 32767;
+BA_ "CanDootHidden" SG_ 2684354480 Z_pin_outputs 1;
+BA_ "CanDootBroadcast" SG_ 2684354480 Z_pin_outputs 0;
+BA_ "GenSigStartValue" SG_ 2181033649 CompressorSpeedRequest 1000;
+BA_ "GenSigStartValue" SG_ 2181033650 PumpSpeedRequest 4500;
+BA_ "GenSigStartValue" SG_ 2181033651 HeaterTargetTemp 50;
+SIG_GROUP_ 2684354464 Z_RESERVOIR_WARNING_SWITCH 1 : Z_DI_72;
+SIG_GROUP_ 2684354464 Z_RESERVOIR_CRITICAL_SWITCH 1 : Z_DI_74;
+SIG_GROUP_ 2684354464 Z_SUPERHEAT_ALARM 1 : Z_DI_78;
+SIG_GROUP_ 2684354464 Z_FAN_1_DIN 1 : Z_DI_73;
+SIG_GROUP_ 2684354464 Z_FAN_2_DIN 1 : Z_DI_75;
+SIG_GROUP_ 2684354464 Z_FAN_3_DIN 1 : Z_DI_77;
+SIG_GROUP_ 2684354464 Z_FAN_4_DIN 1 : Z_DI_79;
+SIG_GROUP_ 2684354464 Z_HS_P_SENSOR 1 : Z_AI_10;
+SIG_GROUP_ 2684354464 Z_LS_P_SENSOR 1 : Z_AI_00;
+SIG_GROUP_ 2684354464 Z_COOLANT_PRESSURE_OUT 1 : Z_AI_14;
+SIG_GROUP_ 2684354464 Z_LOW_SIDE_TEMP 1 : Z_AI_11;
+SIG_GROUP_ 2684354464 Z_HIGH_SIDE_TEMP 1 : Z_AI_05;
+SIG_GROUP_ 2684354464 Z_COOLANT_PRESSURE_IN 1 : Z_AI_12;
+SIG_GROUP_ 2684354464 Z_AMBIENT_TEMP 1 : Z_AI_01;
+SIG_GROUP_ 2684354464 Z_COOLANT_TEMP_IN 1 : Z_AI_02;
+SIG_GROUP_ 2684354464 Z_COOLANT_TEMP_OUT 1 : Z_AI_04;
+SIG_GROUP_ 2684354464 Z_TEST_COOLANT_TEMP 1 : Z_AI_06;
+SIG_GROUP_ 2684354464 Z_HEATER_CONTACTOR_FB 1 : Z_DI_56;
+SIG_GROUP_ 2684354464 Z_HIGH_SIDE_PRESSURE_SWITCH 1 : Z_DI_57;
+SIG_GROUP_ 2684354464 Z_FAN_COVER_SW_FB 1 : Z_DI_61;
+SIG_GROUP_ 2684354480 Z_SUPERHEAT_CONTROLLER_ENABLE 1 : Z_DO_16;
+SIG_GROUP_ 2684354480 Z_HEATER_ENABLE 1 : Z_DO_30;
+SIG_GROUP_ 2684354480 Z_DCDC_AUX_SUPPLY_PIN 1 : Z_DO_04;
+SIG_GROUP_ 2684354480 Z_HEATER_CONTACTOR_CTRL 1 : Z_DO_23;
+SIG_GROUP_ 2684354480 Z_CIRCULATION_PUMP_PWM 1 : Z_PWM_04;
+SIG_GROUP_ 2684354480 Z_AUX_CIRCUIT_DIGITAL_OUTPUT 1 : Z_DO_34;
+SIG_GROUP_ 2684354480 Z_FAN_PWM_OUTPUT 1 : Z_PWM_09;
+

--- a/decoder/B3SR/send_b3sr.py
+++ b/decoder/B3SR/send_b3sr.py
@@ -2,6 +2,10 @@ import os
 import sys
 import time
 import logging
+import io
+import tempfile
+import ctypes
+import subprocess
 from pathlib import Path
 
 from datetime import datetime, timedelta, timezone
@@ -12,7 +16,7 @@ from itertools import chain
 from concurrent.futures import ThreadPoolExecutor
 from threading import Lock
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Literal, Iterable
+from typing import Literal, Iterable, Any
 
 if __name__ == "__main__":
     sys.path.append(str(Path(__file__).parent.parent.parent))
@@ -214,6 +218,177 @@ def send_files_to_victoriametrics(
     return sent_stats
 
 
+def main_post_s3_streaming_to_victoriametrics(
+    server: str,
+    s3_bucket: str,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    s3_prefix: str = "",
+    newest_first: bool = True,
+    s3_info_list: list[dict] | None = None,
+    streaming_strategy: Literal["auto", "memory", "tempfile"] = "auto",
+    memory_fraction: float = 0.35,
+    decode_overhead_factor: float = 2.5,
+    max_active_files: int = 1,
+    max_batch_size: int = 10_000,
+    skip_signal_range_check: bool = False,
+    posted_after: datetime | None = None,
+):
+    start_ts = time.time()
+
+    if start_date is None:
+        start_date = datetime.now(tz=timezone.utc) - timedelta(days=1)
+
+    if end_date is None:
+        end_date = datetime.now(tz=timezone.utc)
+
+    if s3_info_list is None:
+        s3_info_list = get_mf4_files_list_from_s3(
+            bucket_name=s3_bucket,
+            start_time=start_date,
+            end_time=end_date,
+            Prefix=s3_prefix,
+            posted_after=posted_after,
+        )
+
+    if not s3_info_list:
+        logging.warning("⚠️ No B3SR S3 files found to stream.")
+        return {}
+
+    s3_info_list = [
+        item
+        for item in s3_info_list
+        if isinstance(item, dict)
+        and isinstance(item.get("Key", None), str)
+        and item["Key"].lower().endswith(".mf4")
+    ]
+
+    if not s3_info_list:
+        logging.warning("⚠️ No B3SR MF4 S3 files left after filtering.")
+        return {}
+
+    s3_info_list.sort(
+        key=lambda x: x.get("Timestamp", datetime.min.replace(tzinfo=timezone.utc)),
+        reverse=newest_first,
+    )
+
+    dbc_files = normalize_dbc_entries([get_dbc_file_path()])
+    if not dbc_files:
+        logging.error("❌ B3SR DBC files could not be normalized.")
+        return {}
+
+    selected_strategy, profile = _select_s3_streaming_strategy(
+        s3_info_list=s3_info_list,
+        requested_strategy=streaming_strategy,
+        memory_fraction=memory_fraction,
+        decode_overhead_factor=decode_overhead_factor,
+        max_active_files=max_active_files,
+    )
+    logging.info(
+        "🧠 B3SR S3 streaming preflight | files=%s largest=%sB "
+        "worst_parallel=%sB projected_peak=%sB available_ram=%sB "
+        "ram_budget=%sB strategy=%s",
+        profile["file_count"],
+        profile["largest_file_bytes"],
+        profile["worst_parallel_bytes"],
+        profile["projected_peak_bytes"],
+        profile["available_ram_bytes"],
+        profile["ram_budget_bytes"],
+        selected_strategy,
+    )
+
+    max_retries = 10
+    retry_interval_seconds = 60
+    for attempt in range(1, max_retries + 1):
+        if is_victoriametrics_online(server):
+            break
+        if attempt < max_retries:
+            logging.warning(
+                f" -> ⚠️ {server} not available (attempt {attempt}/{max_retries}). Retrying in 1 minute..."
+            )
+            time.sleep(retry_interval_seconds)
+        else:
+            logging.error(
+                f" -> ❌ {server} not available after {max_retries} attempts. Exiting..."
+            )
+            exit(1)
+
+    s3c = create_s3_client(max_pool_connections=max(1, max_active_files))
+    total_counts: dict[str, int] = {}
+    total = len(s3_info_list)
+
+    for idx, item in enumerate(s3_info_list, start=1):
+        key = item["Key"]
+        count_str = f"[{idx} of {total}]"
+        start_ts_single = time.time()
+        result: dict[str, int] = {}
+
+        if selected_strategy == "memory":
+            blob = download_file_bytes_from_s3(
+                bucket_name=s3_bucket,
+                key=key,
+                s3_client=s3c,
+            )
+            if blob is None:
+                continue
+            try:
+                with MDF(io.BytesIO(blob)) as mdf:
+                    result = _decode_and_send_b3sr_mdf(
+                        mdf=mdf,
+                        server=server,
+                        dbc_files=dbc_files,
+                        skip_signal_range_check=skip_signal_range_check,
+                        max_batch_size=max_batch_size,
+                    )
+            except Exception as e:
+                logging.error(f"❌ {count_str} Error processing in memory {key}: {e}")
+            del blob
+        else:
+            tmp_path: Path | None = None
+            try:
+                with tempfile.NamedTemporaryFile(suffix=".mf4", delete=False) as tmp_file:
+                    tmp_path = Path(tmp_file.name)
+                ok = download_file_to_path_from_s3(
+                    bucket_name=s3_bucket,
+                    key=key,
+                    local_path=tmp_path,
+                    s3_client=s3c,
+                )
+                if not ok:
+                    continue
+                with MDF(tmp_path) as mdf:
+                    result = _decode_and_send_b3sr_mdf(
+                        mdf=mdf,
+                        server=server,
+                        dbc_files=dbc_files,
+                        skip_signal_range_check=skip_signal_range_check,
+                        max_batch_size=max_batch_size,
+                    )
+            except Exception as e:
+                logging.error(f"❌ {count_str} Error processing temp file {key}: {e}")
+            finally:
+                if tmp_path and tmp_path.exists():
+                    tmp_path.unlink()
+
+        sent = sum(result.values())
+        logging.info(
+            f"✅ {count_str} streamed {shortpath(Path(key))} in {get_time_str(start_ts_single)} ({convert_to_eng(sent)} samples)"
+        )
+        for signal_name, count in result.items():
+            total_counts[signal_name] = total_counts.get(signal_name, 0) + count
+
+    end_ts = time.time()
+    total_signals_sent = len(total_counts.keys())
+    total_samples_sent = sum(total_counts.values())
+    logging.info(
+        f"🏁 Streamed {total} B3SR S3 files in {get_time_str(start_ts, end_ts)} "
+        f"({total_signals_sent} signals | {convert_to_eng(total_samples_sent)} samples | "
+        f"{convert_to_eng(total_samples_sent / max(end_ts - start_ts, 1e-9))} samples/s)."
+    )
+
+    return total_counts
+
+
 def get_files_in_range(
     dir_path: Path, start: datetime, end: datetime
 ) -> list[CSVContent]:
@@ -333,6 +508,125 @@ def parse_time_offset(offset_str: str) -> timedelta:
         raise ValueError(f"Unknown time unit: {unit}")
 
 
+def _get_available_ram_bytes() -> int | None:
+    if os.name == "nt":
+        class MEMORYSTATUSEX(ctypes.Structure):
+            _fields_ = [
+                ("dwLength", ctypes.c_ulong),
+                ("dwMemoryLoad", ctypes.c_ulong),
+                ("ullTotalPhys", ctypes.c_ulonglong),
+                ("ullAvailPhys", ctypes.c_ulonglong),
+                ("ullTotalPageFile", ctypes.c_ulonglong),
+                ("ullAvailPageFile", ctypes.c_ulonglong),
+                ("ullTotalVirtual", ctypes.c_ulonglong),
+                ("ullAvailVirtual", ctypes.c_ulonglong),
+                ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+            ]
+
+        stat = MEMORYSTATUSEX()
+        stat.dwLength = ctypes.sizeof(MEMORYSTATUSEX)
+        if ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(stat)):
+            return int(stat.ullAvailPhys)
+        return None
+
+    if sys.platform == "darwin":
+        try:
+            out = subprocess.check_output(
+                ["vm_stat"], text=True, stderr=subprocess.DEVNULL
+            )
+            page_size = 4096
+            m = re.search(r"page size of (\d+) bytes", out)
+            if m:
+                page_size = int(m.group(1))
+
+            pages = 0
+            for key in ("Pages free", "Pages inactive", "Pages speculative"):
+                mm = re.search(rf"{key}:\s+(\d+)\.", out)
+                if mm:
+                    pages += int(mm.group(1))
+            if pages > 0:
+                return int(pages * page_size)
+        except Exception:
+            return None
+
+    try:
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        avail_pages = os.sysconf("SC_AVPHYS_PAGES")
+        return int(page_size * avail_pages)
+    except Exception:
+        return None
+
+
+def _select_s3_streaming_strategy(
+    s3_info_list: list[dict],
+    requested_strategy: Literal["auto", "memory", "tempfile"],
+    memory_fraction: float,
+    decode_overhead_factor: float,
+    max_active_files: int,
+) -> tuple[Literal["memory", "tempfile"], dict[str, int | float | None]]:
+    sizes = [
+        int(item["Size"])
+        for item in s3_info_list
+        if isinstance(item, dict) and "Size" in item
+    ]
+    sizes.sort(reverse=True)
+
+    max_active = max(1, max_active_files)
+    worst_parallel_bytes = sum(sizes[:max_active]) if sizes else 0
+    projected_peak_bytes = int(worst_parallel_bytes * decode_overhead_factor)
+    available_ram_bytes = _get_available_ram_bytes()
+    ram_budget_bytes = (
+        int(available_ram_bytes * memory_fraction)
+        if available_ram_bytes is not None
+        else None
+    )
+
+    if requested_strategy == "memory":
+        selected: Literal["memory", "tempfile"] = "memory"
+    elif requested_strategy == "tempfile":
+        selected = "tempfile"
+    else:
+        if ram_budget_bytes is not None and projected_peak_bytes <= ram_budget_bytes:
+            selected = "memory"
+        else:
+            selected = "tempfile"
+
+    profile: dict[str, int | float | None] = {
+        "file_count": len(sizes),
+        "largest_file_bytes": sizes[0] if sizes else 0,
+        "worst_parallel_bytes": worst_parallel_bytes,
+        "projected_peak_bytes": projected_peak_bytes,
+        "available_ram_bytes": available_ram_bytes,
+        "ram_budget_bytes": ram_budget_bytes,
+        "max_active_files": max_active,
+        "decode_overhead_factor": decode_overhead_factor,
+    }
+    return selected, profile
+
+
+def _decode_and_send_b3sr_mdf(
+    mdf: MDF,
+    server: str,
+    dbc_files: list[DbcFileType],
+    skip_signal_range_check: bool,
+    max_batch_size: int,
+) -> dict[str, int]:
+    decoded = mdf.extract_bus_logging(
+        database_files={"CAN": dbc_files},
+        ignore_value2text_conversion=True,
+    )
+    if not list(decoded.iter_channels()):
+        return {}
+    return send_decoded(
+        decoded=decoded,
+        server=server,
+        job=B3SR_JOB,
+        skip_signal_fn=None,
+        skip_signal_range_check=skip_signal_range_check,
+        batch_size=max_batch_size,
+    )
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Send B3SR MF4 files from CANEdge folder to VictoriaMetrics server."
@@ -366,6 +660,53 @@ if __name__ == "__main__":
         action="store_true",
         help="Send to test node (server_vm_test_dump) instead of main B3SR node.",
     )
+    parser.add_argument(
+        "--s3-streaming",
+        action="store_true",
+        help="Stream MF4 files directly from S3 instead of scanning local disk.",
+    )
+    parser.add_argument(
+        "--s3-bucket",
+        type=str,
+        default="",
+        help="S3 bucket for streaming mode.",
+    )
+    parser.add_argument(
+        "--s3-prefix",
+        type=str,
+        default="",
+        help="Optional S3 prefix for streaming mode.",
+    )
+    parser.add_argument(
+        "--streaming-strategy",
+        type=str,
+        choices=["auto", "memory", "tempfile"],
+        default="auto",
+        help="Streaming strategy to use for S3 mode.",
+    )
+    parser.add_argument(
+        "--memory-fraction",
+        type=float,
+        default=0.35,
+        help="Fraction of available RAM allowed for streaming mode.",
+    )
+    parser.add_argument(
+        "--decode-overhead-factor",
+        type=float,
+        default=2.5,
+        help="Decode RAM overhead multiplier for streaming mode.",
+    )
+    parser.add_argument(
+        "--max-active-files",
+        type=int,
+        default=1,
+        help="Max S3 objects to consider in preflight memory estimate.",
+    )
+    parser.add_argument(
+        "--skip-signal-range-check",
+        action="store_true",
+        help="Skip signal range checks while sending decoded data.",
+    )
 
     args = parser.parse_args()
 
@@ -384,9 +725,26 @@ if __name__ == "__main__":
     else:
         end_date = now - parse_time_offset(args.end)
 
-    main_post_to_victoriametrics(
-        server=server,
-        start_date=start_date,
-        end_date=end_date,
-        newest_first=args.oldest_first is False,
-    )
+    if args.s3_streaming:
+        if not args.s3_bucket.strip():
+            parser.error("--s3-bucket is required when --s3-streaming is set")
+        main_post_s3_streaming_to_victoriametrics(
+            server=server,
+            s3_bucket=args.s3_bucket,
+            start_date=start_date,
+            end_date=end_date,
+            s3_prefix=args.s3_prefix,
+            newest_first=args.oldest_first is False,
+            streaming_strategy=args.streaming_strategy,
+            memory_fraction=args.memory_fraction,
+            decode_overhead_factor=args.decode_overhead_factor,
+            max_active_files=args.max_active_files,
+            skip_signal_range_check=args.skip_signal_range_check,
+        )
+    else:
+        main_post_to_victoriametrics(
+            server=server,
+            start_date=start_date,
+            end_date=end_date,
+            newest_first=args.oldest_first is False,
+        )

--- a/decoder/B3SR/send_b3sr.py
+++ b/decoder/B3SR/send_b3sr.py
@@ -23,7 +23,7 @@ from decoder.utils import (
     convert_to_eng,
     is_victoriametrics_online,
 )
-from decoder.sending import send_decoded
+from decoder.sending import send_decoded, normalize_dbc_entries
 from decoder.config import (
     LOG_FORMAT,
     server_vm_b3sr,
@@ -100,6 +100,8 @@ def send_files_to_victoriametrics(
         stack_size = 1
         logging.warning(" ⚠️ stack_size cannot be less than 1, setting to 1.")
 
+    can_dbc_files = normalize_dbc_entries([dbc_file])
+
     total_files = len(files)
     if stack_size == 1:
         for i, (f, d) in enumerate(files):
@@ -114,7 +116,7 @@ def send_files_to_victoriametrics(
                         f" ⏳ {count_str} Decoding file {shortpath(f)} ..."
                     )
                     decoded = mdf.extract_bus_logging(
-                        database_files={"CAN": [(dbc_file, 0)]},
+                        database_files={"CAN": can_dbc_files},
                         ignore_value2text_conversion=True,
                     )
 
@@ -169,7 +171,7 @@ def send_files_to_victoriametrics(
 
                 try:
                     decoded = mdf.extract_bus_logging(
-                        database_files={"CAN": [(dbc_file, 0)]},
+                        database_files={"CAN": can_dbc_files},
                         ignore_value2text_conversion=True,
                     )
 

--- a/decoder/B3SR/send_b3sr.py
+++ b/decoder/B3SR/send_b3sr.py
@@ -27,6 +27,7 @@ from decoder.sending import send_decoded, normalize_dbc_entries
 from decoder.config import (
     LOG_FORMAT,
     server_vm_b3sr,
+    server_vm_test_dump,
 )
 from decoder.s3_helper import *
 import argparse
@@ -360,8 +361,15 @@ if __name__ == "__main__":
         action="store_true",
         help="Process oldest files first.",
     )
+    parser.add_argument(
+        "--test",
+        action="store_true",
+        help="Send to test node (server_vm_test_dump) instead of main B3SR node.",
+    )
 
     args = parser.parse_args()
+
+    server = server_vm_test_dump if args.test else server_vm_b3sr
 
     # Parse start time
     now = datetime.now().astimezone(ZoneInfo("America/Vancouver"))
@@ -377,7 +385,7 @@ if __name__ == "__main__":
         end_date = now - parse_time_offset(args.end)
 
     main_post_to_victoriametrics(
-        server=args.server,
+        server=server,
         start_date=start_date,
         end_date=end_date,
         newest_first=args.oldest_first is False,

--- a/decoder/B3SR/send_b3sr.py
+++ b/decoder/B3SR/send_b3sr.py
@@ -42,6 +42,7 @@ logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 CSVContent = tuple[Path, datetime]
 
 B3SR_JOB = "B3SR"
+DBC_FOLDER_OVERRIDE: str | None = None
 
 canedge_folder = Path.joinpath(
     get_windows_home_path(),
@@ -61,8 +62,25 @@ def shortpath(p: Path) -> str:
     return "../" + "/".join(p.parts[-3:])
 
 
-def get_dbc_file_path() -> Path:
-    return canedge_folder.joinpath("b3sr_base.dbc")
+def resolve_dbc_folder(dbc_folder: str | None = None) -> Path:
+    value = DBC_FOLDER_OVERRIDE if dbc_folder is None else dbc_folder
+    default_folder = Path(__file__).resolve().parent / "dbc"
+    legacy_folder = canedge_folder
+
+    if value is None or not str(value).strip():
+        return default_folder
+
+    if str(value).strip().lower() in {"old", "compatibility"}:
+        return legacy_folder
+
+    resolved = Path(os.path.expanduser(os.path.expandvars(str(value).strip())))
+    if not resolved.is_absolute():
+        resolved = Path.cwd() / resolved
+    return resolved
+
+
+def get_dbc_file_path(dbc_folder: str | None = None) -> Path:
+    return resolve_dbc_folder(dbc_folder).joinpath("b3sr_base.dbc")
 
 
 def send_files_to_victoriametrics(
@@ -707,8 +725,15 @@ if __name__ == "__main__":
         action="store_true",
         help="Skip signal range checks while sending decoded data.",
     )
+    parser.add_argument(
+        "--dbc-folder",
+        type=str,
+        default="",
+        help="DBC folder path, or 'old'/'compatibility' for workstation lookup. Defaults to decoder/B3SR/dbc.",
+    )
 
     args = parser.parse_args()
+    DBC_FOLDER_OVERRIDE = args.dbc_folder
 
     server = server_vm_test_dump if args.test else server_vm_b3sr
 

--- a/decoder/D65/dbc/D65_CH0_NV.dbc
+++ b/decoder/D65/dbc/D65_CH0_NV.dbc
@@ -1,0 +1,558 @@
+VERSION "created by canmatrix"
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+s
+BS_:
+
+BU_: Master_ECU HVH_ECU pBMU ACO0 RX TX
+
+
+BO_ 2364642139 VPC_HVESSP1D3: 8 ACO0
+ SG_ Core_Lowest_Cell_Temp : 16|16@1+ (0.03125,-273) [-273|1774.96875] "deg C"  RX
+ SG_ Core_Highest_Cell_Temp : 0|16@1+ (0.03125,-273) [-273|1774.96875] "deg C"  RX
+
+BO_ 2350603013 VPC_HVESSC1: 8 pBMU
+ SG_ HV_Bus_Connect_Command : 0|2@1+ (1,0) [0|3] "bit"  ACO0
+ SG_ Active_Isolation_Test_Command : 4|2@1+ (1,0) [0|3] "bit"  ACO0
+ SG_ Cell_Balancing_Command : 8|2@1+ (1,0) [0|3] "bit"  ACO0
+ SG_ Operation_Consent : 12|2@1+ (1,0) [0|3] "bit"  ACO0
+
+BO_ 2364575835 VPC_HVESSD1: 8 ACO0
+ SG_ Available_Discharge_Power : 0|16@1+ (0.05,0) [0|3276.75] "kW"  RX
+ SG_ Available_Charge_Power : 16|16@1+ (0.05,0) [0|3276.75] "kW"  RX
+ SG_ Voltage_Level : 32|16@1+ (0.05,0) [0|3276.75] "V"  RX
+ SG_ Current : 48|16@1+ (0.05,-1600) [-1600|1676.75] "A"  RX
+
+BO_ 2364576091 VPC_HVESSD2: 8 ACO0
+ SG_ Fast_Update_SOC : 0|16@1+ (0.0015625,0) [0|102.3984375] "%"  RX
+ SG_ Highest_Cell_Voltage : 16|16@1+ (0.001,0) [0|65.535] "V"  RX
+ SG_ Lowest_Cell_Voltage : 32|16@1+ (0.001,0) [0|65.535] "V"  RX
+
+BO_ 2364576347 VPC_HVESSD3: 8 ACO0
+ SG_ Highest_Cell_Temperature : 0|16@1+ (0.03125,-273) [-273|1774.96875] "deg C"  RX
+ SG_ Lowest_Cell_Temperature : 16|16@1+ (0.03125,-273) [-273|1774.96875] "deg C"  RX
+ SG_ Average_Cell_Temperature : 32|16@1+ (0.03125,-273) [-273|1774.96875] "deg C"  RX
+
+BO_ 2364576603 VPC_HVESSD4: 8 ACO0
+ SG_ Discharge_Capacity : 0|16@1+ (0.01,0) [0|655.35] "Ah"  RX
+ SG_ Charge_Capacity : 16|16@1+ (0.01,0) [0|655.35] "Ah"  RX
+ SG_ Cell_Balancing_Count : 32|16@1+ (1,0) [0|65535] "count"  RX
+
+BO_ 2364576859 VPC_HVESSD5: 8 ACO0
+ SG_ Discharge_Current_Limit : 0|16@1+ (0.05,-1600) [-1600|1676.75] "A"  RX
+ SG_ Charge_Current_Limit : 16|16@1+ (0.05,-1600) [-1600|1676.75] "A"  RX
+ SG_ Lowest_Cell_SOC : 32|16@1+ (0.0015625,0) [0|102.3984375] "%"  RX
+ SG_ Highest_Cell_SOC : 48|16@1+ (0.0015625,0) [0|102.3984375] "%"  RX
+
+BO_ 2364577115 VPC_HVESSD6: 8 ACO0
+ SG_ Bus_Voltage : 0|16@1+ (0.05,0) [0|3276.75] "V"  RX
+ SG_ Ignition_Voltage : 16|16@1+ (0.01,0) [0|655.35] "V"  RX
+ SG_ Electronics_Temperature : 48|8@1+ (1,-40) [-40|215] "degC"  RX
+
+BO_ 2364577371 VPC_HVESSS1: 8 ACO0
+ SG_ HV_Bus_Disconnect_Forewarning : 4|4@1+ (1,0) [0|15] "bit"  RX
+ SG_ HV_Bus_Active_Isolation_Test_St : 12|4@1+ (1,0) [0|15] "bit"  RX
+ SG_ HVIL_Status : 20|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ Cell_Balance_Status : 28|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ Cell_Balancing_Active : 30|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ HV_Bus_Connection_Status : 40|4@1+ (1,0) [0|15] "bit"  RX
+ SG_ Operational_Status : 44|4@1+ (1,0) [0|15] "bit"  RX
+
+BO_ 2364579931 VPC_HVESSD7: 8 ACO0
+ SG_ Discharge_Energy_Capacity : 0|24@1+ (0.001,0) [0|16777.215] "kWh"  RX
+ SG_ Charge_Energy_Capacity : 24|24@1+ (0.001,0) [0|16777.215] "kWh"  RX
+ SG_ Maximum_Charge_Voltage_Limit : 48|16@1+ (0.05,0) [0|3276.75] "V"  RX
+
+BO_ 2364607067 VPC_HVESSD8: 8 ACO0
+ SG_ Highest_Cell_Voltage_Module_Nr : 0|8@1+ (1,0) [0|255] "count"  RX
+ SG_ Highest_Cell_Voltage_Cell_Nr : 8|8@1+ (1,0) [0|255] "count"  RX
+ SG_ Lowest_Cell_Voltage_Module_Nr : 16|8@1+ (1,0) [0|255] "count"  RX
+ SG_ Lowest_Cell_Voltage_Cell_Nr : 24|8@1+ (1,0) [0|255] "count"  RX
+ SG_ Average_Cell_Voltage : 32|16@1+ (0.001,0) [0|65.535] "V"  RX
+
+BO_ 2364607323 VPC_HVESSD9: 8 ACO0
+ SG_ Highest_Cell_Temperature_Module : 0|8@1+ (1,0) [0|255] "count"  RX
+ SG_ Highest_Cell_Temperature_Cell_N : 8|8@1+ (1,0) [0|255] "count"  RX
+ SG_ Lowest_Cell_Temperature_Module_ : 16|8@1+ (1,0) [0|255] "count"  RX
+ SG_ Lowest_Cell_Temperature_Cell_Nr : 24|8@1+ (1,0) [0|255] "count"  RX
+
+BO_ 2364607579 VPC_HVESSD10: 8 ACO0
+ SG_ Highest_Cell_SOC_Module_Nr : 0|8@1+ (1,0) [0|255] "count"  RX
+ SG_ Highest_Cell_SOC_Cell_Nr : 8|8@1+ (1,0) [0|255] "count"  RX
+ SG_ Lowest_Cell_SOC_Module_Nr : 16|8@1+ (1,0) [0|255] "count"  RX
+ SG_ Lowest_Cell_SOC_Cell_Nr : 24|8@1+ (1,0) [0|255] "count"  RX
+ SG_ Passive_Isolation_Test_Results : 48|16@1+ (0.1,0) [0|6553.5] "ohm/V"  RX
+
+BO_ 2365522011 VPC_PropB_00: 8 ACO0
+ SG_ P1_HV_Bus_Contactor_State : 0|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ P2_HV_Bus_Contactor_State : 2|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ Vehicle_Contactor_Pos_Closed : 12|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ Vehicle_Contactor_Neg_Closed : 14|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ External_HVIL_Open : 16|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ Emergency_stop_1_Active : 18|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ Emergency_stop_2_Active : 20|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ Self_discharge_time : 22|8@1+ (1,0) [0|255] "bit"  RX
+ SG_ Critical_cell_temperature : 30|2@1+ (1,0) [0|3] "bool"  RX
+ SG_ Expect_system_int_HVIL_break : 32|2@1+ (1,0) [0|3] "bool"  RX
+
+BO_ 2364641627 VPC_HVESSP1D1: 8 ACO0
+ SG_ Core_Voltage_Level : 32|16@1+ (0.05,0) [0|3276.75] "V"  RX
+ SG_ Core_Current : 48|16@1+ (0.05,-1600) [-1600|1676.75] "A"  RX
+
+BO_ 2364645467 VPC_HVESSP2D1: 8 ACO0
+ SG_ Core_Voltage_Level : 32|16@1+ (0.05,0) [0|3276.75] "V"  RX
+ SG_ Core_Current : 48|16@1+ (0.05,-1600) [-1600|1676.75] "A"  RX
+
+BO_ 2364645979 VPC_HVESSP2D3: 8 ACO0
+ SG_ Core_Highest_Cell_Temp : 0|16@1+ (0.03125,-273) [-273|1774.96875] "deg C"  RX
+ SG_ Core_Lowest_Cell_Temp : 16|16@1+ (0.03125,-273) [-273|1774.96875] "deg C"  RX
+
+BO_ 2364641883 VPC_HVESSP1D2: 8 ACO0
+ SG_ Core_Fast_Update_SOC : 0|16@1+ (0.0015625,0) [0|102.3984375] "%"  RX
+ SG_ Core_Highest_Cell_Voltage : 16|16@1+ (0.001,0) [0|65.535] "V"  RX
+ SG_ Core_Lowest_Cell_Voltage : 32|16@1+ (0.001,0) [0|65.535] "V"  RX
+
+BO_ 2364645723 VPC_HVESSP2D2: 8 ACO0
+ SG_ Core_Fast_Update_SOC : 0|16@1+ (0.0015625,0) [0|102.3984375] "%"  RX
+ SG_ Core_Highest_Cell_Voltage : 16|16@1+ (0.001,0) [0|65.535] "V"  RX
+ SG_ Core_Lowest_Cell_Voltage : 32|16@1+ (0.001,0) [0|65.535] "V"  RX
+
+BO_ 2365522437 VPC_PropB_01: 8 pBMU
+ SG_ Expect_int_HVIL_open_outside_pa : 6|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ External_Clear_DMs_Request : 8|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ External_Enable_TMS_Request : 10|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ External_Disable_TMS_Request : 12|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ Vehicle_Cont_Pos_Close_Request : 14|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ Vehicle_Cont_Neg_Close_Request : 16|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ Disable_Pack_1_Command : 18|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ Disable_Pack_2_Command : 20|2@1+ (1,0) [0|3] "bit"  RX
+ SG_ Charge_mode : 30|2@1+ (1,0) [0|3] "bit"  RX
+
+BO_ 2365522949 VPC_PropB_02: 8 pBMU
+ SG_ System_Number_Of_Subpacks : 0|4@1+ (1,0) [0|15] ""  RX
+
+
+
+CM_ SG_ 2364642139 Core_Lowest_Cell_Temp "The lowest temperature level reported by any cell in this High Voltage Energy Storage Pack instance.";
+CM_ SG_ 2364642139 Core_Highest_Cell_Temp "The highest temperature level reported by any cell in this High Voltage Energy Storage Pack instance. ";
+CM_ SG_ 2350603013 HV_Bus_Connect_Command "Command to connect the High Voltage Energy Storage System (or Pack 1 in systems with only one pack) to the high-voltage bus.";
+CM_ SG_ 2350603013 Active_Isolation_Test_Command "Command for the High Voltage Energy Storage System (or Pack 1 in systems with only one pack) to perform an active electrical isolation test on the high voltage bus.";
+CM_ SG_ 2350603013 Cell_Balancing_Command "Command for the High Voltage Energy Storage System (or Pack 1 in systems with only one pack) to perform cell balancing.";
+CM_ SG_ 2350603013 Operation_Consent "This parameter provides an indication to the HVES1 pack (or system) that an external device is ready for HVES1 to proceed with high voltage operation.";
+CM_ SG_ 2364575835 Available_Discharge_Power "The rate at which this High Voltage Energy Storage System instance can currently provide energy for propulsion or other uses.";
+CM_ SG_ 2364575835 Available_Charge_Power "The rate at which this High Voltage Energy Storage System instance can currently receive energy from a regenerative or recharging system.";
+CM_ SG_ 2364575835 Voltage_Level "The voltage level of the High Voltage Energy Storage System.";
+CM_ SG_ 2364575835 Current "The current in or out of the High Voltage Energy Storage System.";
+CM_ SG_ 2364576091 Fast_Update_SOC "Indicates the High Voltage Energy Storage System (or Pack 1 in systems with only one pack) state of charge.";
+CM_ SG_ 2364576091 Highest_Cell_Voltage "The highest voltage level reported by any cell in the High Voltage Energy Storage System (or Pack 1 in systems with only one pack).";
+CM_ SG_ 2364576091 Lowest_Cell_Voltage "The lowest voltage level reported by any cell in the High Voltage Energy Storage System (or Pack 1 in systems with only one pack).";
+CM_ SG_ 2364576347 Highest_Cell_Temperature "Indicates the High Voltage Energy Storage System (or Pack 1 in systems with only one pack) state of charge.";
+CM_ SG_ 2364576347 Lowest_Cell_Temperature "The highest voltage level reported by any cell in the High Voltage Energy Storage System (or Pack 1 in systems with only one pack).";
+CM_ SG_ 2364576347 Average_Cell_Temperature "The lowest voltage level reported by any cell in the High Voltage Energy Storage System (or Pack 1 in systems with only one pack).";
+CM_ SG_ 2364576603 Discharge_Capacity "The amount of stored electrical charge in the High Voltage Energy Storage System (or Pack 1 in systems with only one pack) that is available for use by the hybrid system.";
+CM_ SG_ 2364576603 Charge_Capacity "The amount of unused electrical charge storage in the High Voltage Energy Storage System (or Pack 1 in systems with only one pack) that is available to be filled by charging. ";
+CM_ SG_ 2364576603 Cell_Balancing_Count "The number of cells that are currently being balanced in the High Voltage Energy Storage System (or Pack 1 in systems with only one pack).";
+CM_ SG_ 2364576859 Discharge_Current_Limit "The maximum permissible current flow out of this High Voltage Energy Storage Pack instance.";
+CM_ SG_ 2364576859 Charge_Current_Limit "The maximum permissible current flow into this High Voltage Energy Storage Pack instance.";
+CM_ SG_ 2364576859 Lowest_Cell_SOC "Indicates the state of charge of the lowest-charged cell in this High Voltage Energy Storage Pack instance.";
+CM_ SG_ 2364576859 Highest_Cell_SOC "Indicates the state of charge of the highest-charged cell in this High Voltage Energy Storage Pack instance.";
+CM_ SG_ 2364577115 Bus_Voltage "The voltage level of the high voltage bus, as measured by the High Voltage Energy Storage System (or Pack 1 in systems with only one pack) on the bus side (not the battery side) of its contactors.";
+CM_ SG_ 2364577115 Ignition_Voltage "The voltage level at the ignition input of the High Voltage Energy Storage System (or Pack 1 in systems with only one pack) controller.";
+CM_ SG_ 2364577115 Electronics_Temperature "The temperature of the electronics or control modules in the High Voltage Energy Storage System (or Pack 1 in systems with only one pack). If there are multiple temperature sensors then this parameter would be set to the maximum sensor reading.";
+CM_ SG_ 2364577371 HV_Bus_Disconnect_Forewarning "Indicates that the High Voltage Energy Storage System (or Pack 1 in systems with only one pack) is about to disconnect from the high voltage bus due to unacceptable conditions.";
+CM_ SG_ 2364577371 HV_Bus_Active_Isolation_Test_St "Status of the high-voltage bus electrical active isolation test as performed by the High Voltage Energy Storage System (or Pack 1 in systems with only one pack).";
+CM_ SG_ 2364577371 HVIL_Status "Status of the High Voltage Interlock Loop from the viewpoint of the High Voltage Energy Storage System (or Pack 1 in systems with only one pack).";
+CM_ SG_ 2364577371 Cell_Balance_Status "Indicates whether or not the cells in the High Voltage Energy Storage System (or Pack 1 in systems with only one pack) are balanced.";
+CM_ SG_ 2364577371 Cell_Balancing_Active "Indicates whether or not the cells in the High Voltage Energy Storage System (or Pack 1 in systems with only one pack) are currently being balanced.";
+CM_ SG_ 2364577371 HV_Bus_Connection_Status "This parameter provides high level feedback on the High Voltage Energy Storage System (or Pack 1 in systems with only one pack) high voltage bus connection.";
+CM_ SG_ 2364577371 Operational_Status "Provides feedback on where the High Voltage Energy Storage System (or Pack 1 in systems with only one pack) is in its operating spectrum.";
+CM_ SG_ 2364579931 Discharge_Energy_Capacity "The amount of stored electrical energy in this High Voltage Energy Storage Pack instance that is available for use by the hybrid system, i.e. how full is the tank.";
+CM_ SG_ 2364579931 Charge_Energy_Capacity "The amount of unused electrical energy storage available to be filled by charging this High Voltage Energy Storage Pack instance, i.e. how much empty space is remaining in the tank.";
+CM_ SG_ 2364579931 Maximum_Charge_Voltage_Limit "The maximum voltage level not to be exceeded while charging this High Voltage Energy Storage Pack instance.";
+CM_ SG_ 2364607067 Highest_Cell_Voltage_Module_Nr "Identifies the location of the module containing SPN 5922 (HVESS Highest Cell Voltage).";
+CM_ SG_ 2364607067 Highest_Cell_Voltage_Cell_Nr "Identifies the location of SPN 5922 (HVESS Highest Cell Voltage) within SPN 8236 (HVESS Highest Cell Voltage Module Number).";
+CM_ SG_ 2364607067 Lowest_Cell_Voltage_Module_Nr "Identifies the location of the module containing SPN 5923 (HVESS Lowest Cell Voltage).";
+CM_ SG_ 2364607067 Lowest_Cell_Voltage_Cell_Nr "Identifies the location of SPN 5923 (HVESS Lowest Cell Voltage) within SPN 8238 (HVESS Lowest Cell Voltage Module Number).";
+CM_ SG_ 2364607067 Average_Cell_Voltage "The average cell voltage in the High Voltage Energy Storage System (or Pack 1 in systems with only one pack).";
+CM_ SG_ 2364607323 Highest_Cell_Temperature_Module "Identifies the location of the module containing SPN 8075 (HVESS Highest Cell Temperature).";
+CM_ SG_ 2364607323 Highest_Cell_Temperature_Cell_N "Identifies the location of SPN 8075 (HVESS Highest Cell Temperature) within SPN 8241 (HVESS Highest Cell Temperature Module Number).";
+CM_ SG_ 2364607323 Lowest_Cell_Temperature_Module_ "Identifies the location of the module containing SPN 8076 (HVESS Lowest Cell Temperature ).";
+CM_ SG_ 2364607323 Lowest_Cell_Temperature_Cell_Nr "Identifies the location of SPN 8076 (HVESS Lowest Cell Temperature) within SPN 8243 (HVESS Lowest Cell Temperature Module Number).";
+CM_ SG_ 2364607579 Highest_Cell_SOC_Module_Nr "Identifies the location of the module containing SPN 8085 (HVESS Highest Cell State of Charge).";
+CM_ SG_ 2364607579 Highest_Cell_SOC_Cell_Nr "Identifies the location of SPN 8085 (HVESS Highest Cell State of Charge) within SPN 8245 (HVESS Highest Cell State of Charge Module Number).";
+CM_ SG_ 2364607579 Lowest_Cell_SOC_Module_Nr "Identifies the location of the module containing SPN 8084 (HVESS Lowest Cell State of Charge).";
+CM_ SG_ 2364607579 Lowest_Cell_SOC_Cell_Nr "Identifies the location of SPN 8084 (HVESS Lowest Cell State of Charge) within SPN 8247 (HVESS Lowest Cell State of Charge Module Number).";
+CM_ SG_ 2364607579 Passive_Isolation_Test_Results "The isolation resistance expressed in Ohms per Volt that resulted from the High-Voltage Bus Passive Isolation Test.";
+CM_ SG_ 2365522011 P1_HV_Bus_Contactor_State "Status of the High Voltage Energy Storage Pack 1 contactor.";
+CM_ SG_ 2365522011 P2_HV_Bus_Contactor_State "Status of the High Voltage Energy Storage Pack 2 contactor.";
+CM_ SG_ 2365522011 Vehicle_Contactor_Pos_Closed "Status of the High Voltage Energy Storage Pack 3 contactor.";
+CM_ SG_ 2365522011 Vehicle_Contactor_Neg_Closed "Status of the High Voltage Energy Storage Pack 4 contactor.";
+CM_ SG_ 2365522011 External_HVIL_Open "Status of the external HVIL for the master subpack";
+CM_ SG_ 2365522011 Emergency_stop_1_Active "Status of the emergency stop 1";
+CM_ SG_ 2365522011 Emergency_stop_2_Active "Status of the emergency stop 2";
+CM_ SG_ 2365522011 Self_discharge_time "Self discharge time in minutes (limited to 15 min)";
+CM_ SG_ 2365522011 Critical_cell_temperature "Sound external alarm unit. ";
+CM_ SG_ 2365522011 Expect_system_int_HVIL_break "Warning from the system that one or more cores will open HVIL ";
+CM_ SG_ 2364641627 Core_Voltage_Level "The voltage level of this High Voltage Energy Storage Pack instance.";
+CM_ SG_ 2364641627 Core_Current "The current in or out of this High Voltage Energy Storage Pack instance.";
+CM_ SG_ 2364645467 Core_Voltage_Level "The voltage level of this High Voltage Energy Storage Pack instance.";
+CM_ SG_ 2364645467 Core_Current "The current in or out of this High Voltage Energy Storage Pack instance.";
+CM_ SG_ 2364645979 Core_Highest_Cell_Temp "The highest temperature level reported by any cell in this High Voltage Energy Storage Pack instance. ";
+CM_ SG_ 2364645979 Core_Lowest_Cell_Temp "The lowest temperature level reported by any cell in this High Voltage Energy Storage Pack instance.";
+CM_ SG_ 2364641883 Core_Fast_Update_SOC "Indicates this High Voltage Energy Storage Pack instance state of charge.";
+CM_ SG_ 2364641883 Core_Highest_Cell_Voltage "The highest voltage level reported by any cell in this High Voltage Energy Storage Pack instance.";
+CM_ SG_ 2364641883 Core_Lowest_Cell_Voltage "The lowest voltage level reported by any cell in this High Voltage Energy Storage Pack instance.";
+CM_ SG_ 2364645723 Core_Fast_Update_SOC "Indicates this High Voltage Energy Storage Pack instance state of charge.";
+CM_ SG_ 2364645723 Core_Highest_Cell_Voltage "The highest voltage level reported by any cell in this High Voltage Energy Storage Pack instance.";
+CM_ SG_ 2364645723 Core_Lowest_Cell_Voltage "The lowest voltage level reported by any cell in this High Voltage Energy Storage Pack instance.";
+CM_ SG_ 2365522437 Expect_int_HVIL_open_outside_pa "Internal HVIL break warning from an external (outside the pack) ECU";
+CM_ SG_ 2365522437 External_Clear_DMs_Request "External request to clear DMs";
+CM_ SG_ 2365522437 External_Enable_TMS_Request "Enable TMS Request";
+CM_ SG_ 2365522437 External_Disable_TMS_Request "Disable TMS Request";
+CM_ SG_ 2365522437 Vehicle_Cont_Pos_Close_Request "Status of the High Voltage Energy Storage Pack 1 contactor.";
+CM_ SG_ 2365522437 Vehicle_Cont_Neg_Close_Request "Status of the High Voltage Energy Storage Pack 2 contactor.";
+CM_ SG_ 2365522437 Disable_Pack_1_Command "Subpack 1 Disabled from Vehicle CAN";
+CM_ SG_ 2365522437 Disable_Pack_2_Command "Subpack 2 Disabled from Vehicle CAN";
+CM_ SG_ 2365522437 Charge_mode "Tells the system that it will be charging.";
+CM_ SG_ 2365522949 System_Number_Of_Subpacks "Number of slave subpacks present in the system.";
+BA_DEF_ BO_  "CG_MessageInstName" STRING ;
+BA_DEF_ BO_  "CI_MsgDefinition" STRING ;
+BA_DEF_ BO_  "CI_MsgId" INT 0 2147483647;
+BA_DEF_ BO_  "CI_MsgName" STRING ;
+BA_DEF_ BO_  "CanDootDecode" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootDecodeBus" INT 0 6;
+BA_DEF_ BO_  "CanDootHideAll" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootPaused" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulate" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulateBus" INT 0 6;
+BA_DEF_ BO_  "CanDootSimulateCycleTime" INT 0 50000;
+BA_DEF_ BO_  "DiagConnection" INT 0 65535;
+BA_DEF_ BO_  "DiagRequest" ENUM  "No","Yes";
+BA_DEF_ BO_  "DiagResponse" ENUM  "No","Yes";
+BA_DEF_ BO_  "DiagState" ENUM  "No","Yes";
+BA_DEF_ BO_  "DiagUUDTResponse" ENUM  "No","Yes";
+BA_DEF_ BO_  "GenMsgCycleTime" INT 0 3600000;
+BA_DEF_ BO_  "GenMsgCycleTimeFast" INT 0 3600000;
+BA_DEF_ BO_  "GenMsgDelayTime" INT 0 3600000;
+BA_DEF_ BO_  "GenMsgILSupport" ENUM  "No","Yes";
+BA_DEF_ BO_  "GenMsgNrOfRepetition" INT 0 1000000;
+BA_DEF_ BO_  "GenMsgRequestable" INT 0 1;
+BA_DEF_ BO_  "GenMsgSendType" ENUM  "cyclic","On request","NotUsed","NotUsed","NotUsed","NotUsed","IfActiveWithRepetion","IfActive","noMsgSendType";
+BA_DEF_ BO_  "GenMsgStartDelayTime" INT 0 100000;
+BA_DEF_ BO_  "TpJ1939VarDlc" ENUM  "No","Yes";
+BA_DEF_ BO_  "VFrameFormat" ENUM  "StandardCAN","ExtendedCAN","reserved","J1939PG";
+BA_DEF_ SG_  "CG_VarType" ENUM  "bool","uint8_t","int8_t","uint16_t","int16_t","uint32_t","int32_t","float","double";
+BA_DEF_ SG_  "CI_ParId" STRING ;
+BA_DEF_ SG_  "CI_SigId" INT 0 2147483647;
+BA_DEF_ SG_  "CI_SigName" STRING ;
+BA_DEF_ SG_  "CanDootBroadcast" ENUM  "No","Yes";
+BA_DEF_ SG_  "CanDootGroup" ENUM  "None","g1","g2","g3","g4","g5","g6","g7","g8","g9","gA","gB","gC","gD","gE","gF";
+BA_DEF_ SG_  "CanDootHidden" ENUM  "No","Yes";
+BA_DEF_ SG_  "GenSigEVName" STRING ;
+BA_DEF_ SG_  "GenSigILSupport" ENUM  "No","Yes";
+BA_DEF_ SG_  "GenSigInactiveValue" INT 0 2147483647;
+BA_DEF_ SG_  "GenSigSendType" ENUM  "Cyclic","OnWrite","OnWriteWithRepetition","OnChange","OnChangeWithRepetition","IfActive","IfActiveWithRepetition","NoSigSendType";
+BA_DEF_ SG_  "GenSigStartValue" INT 0 2147483647;
+BA_DEF_ SG_  "GenSigTimeoutTime_AHW" INT 0 3600000;
+BA_DEF_ SG_  "SPN" INT 0 524287;
+BA_DEF_ SG_  "SigType" ENUM  "Default","Range","RangeSigned","ASCII","Discrete","Control","ReferencePGN","DTC","StringDelimiter","StringLength","StringLengthControl";
+BA_DEF_ BU_  "ECU" STRING ;
+BA_DEF_ BU_  "ILUsed" ENUM  "No","Yes";
+BA_DEF_ BU_  "IsOBDrelevant" ENUM  "No","Yes";
+BA_DEF_ BU_  "NmJ1939AAC" INT 0 1;
+BA_DEF_ BU_  "NmJ1939ECUInstance" INT 0 7;
+BA_DEF_ BU_  "NmJ1939Function" INT 0 255;
+BA_DEF_ BU_  "NmJ1939FunctionInstance" INT 0 7;
+BA_DEF_ BU_  "NmJ1939IdentityNumber" INT 0 2097151;
+BA_DEF_ BU_  "NmJ1939IndustryGroup" INT 0 7;
+BA_DEF_ BU_  "NmJ1939ManufacturerCode" INT 0 2047;
+BA_DEF_ BU_  "NmJ1939System" INT 0 127;
+BA_DEF_ BU_  "NmJ1939SystemInstance" INT 0 15;
+BA_DEF_ BU_  "NmStationAddress" INT 0 255;
+BA_DEF_ BU_  "NodeLayerModules" STRING ;
+BA_DEF_  "Baudrate" INT 0 1000000;
+BA_DEF_  "BusType" STRING ;
+BA_DEF_  "CI_CcdVersion" STRING ;
+BA_DEF_  "CI_MakeDbcSwLastRevDate" STRING ;
+BA_DEF_  "Manufacturer" STRING ;
+BA_DEF_  "ProtocolType" STRING ;
+BA_DEF_DEF_  "CG_MessageInstName" "";
+BA_DEF_DEF_  "CI_MsgDefinition" "";
+BA_DEF_DEF_  "CI_MsgId" 0;
+BA_DEF_DEF_  "CI_MsgName" "";
+BA_DEF_DEF_  "CanDootDecode" "Yes";
+BA_DEF_DEF_  "CanDootDecodeBus" 1;
+BA_DEF_DEF_  "CanDootHideAll" "No";
+BA_DEF_DEF_  "CanDootPaused" "No";
+BA_DEF_DEF_  "CanDootSimulate" "No";
+BA_DEF_DEF_  "CanDootSimulateBus" 1;
+BA_DEF_DEF_  "CanDootSimulateCycleTime" 100;
+BA_DEF_DEF_  "DiagConnection" 0;
+BA_DEF_DEF_  "DiagRequest" "No";
+BA_DEF_DEF_  "DiagResponse" "No";
+BA_DEF_DEF_  "DiagState" "No";
+BA_DEF_DEF_  "DiagUUDTResponse" "No";
+BA_DEF_DEF_  "GenMsgCycleTime" 0;
+BA_DEF_DEF_  "GenMsgCycleTimeFast" 0;
+BA_DEF_DEF_  "GenMsgDelayTime" 1;
+BA_DEF_DEF_  "GenMsgILSupport" "Yes";
+BA_DEF_DEF_  "GenMsgNrOfRepetition" 0;
+BA_DEF_DEF_  "GenMsgRequestable" 0;
+BA_DEF_DEF_  "GenMsgSendType" "noMsgSendType";
+BA_DEF_DEF_  "GenMsgStartDelayTime" 0;
+BA_DEF_DEF_  "TpJ1939VarDlc" "No";
+BA_DEF_DEF_  "VFrameFormat" "J1939PG";
+BA_DEF_DEF_  "CG_VarType" "uint8_t";
+BA_DEF_DEF_  "CI_ParId" "";
+BA_DEF_DEF_  "CI_SigId" 0;
+BA_DEF_DEF_  "CI_SigName" "";
+BA_DEF_DEF_  "CanDootBroadcast" "No";
+BA_DEF_DEF_  "CanDootGroup" "None";
+BA_DEF_DEF_  "CanDootHidden" "No";
+BA_DEF_DEF_  "GenSigEVName" "Env@Nodename_@Signame";
+BA_DEF_DEF_  "GenSigILSupport" "Yes";
+BA_DEF_DEF_  "GenSigInactiveValue" 0;
+BA_DEF_DEF_  "GenSigSendType" "NoSigSendType";
+BA_DEF_DEF_  "GenSigStartValue" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_AHW" 0;
+BA_DEF_DEF_  "SPN" 0;
+BA_DEF_DEF_  "SigType" "Default";
+BA_DEF_DEF_  "ECU" "";
+BA_DEF_DEF_  "ILUsed" "Yes";
+BA_DEF_DEF_  "IsOBDrelevant" "No";
+BA_DEF_DEF_  "NmJ1939AAC" 0;
+BA_DEF_DEF_  "NmJ1939ECUInstance" 0;
+BA_DEF_DEF_  "NmJ1939Function" 0;
+BA_DEF_DEF_  "NmJ1939FunctionInstance" 0;
+BA_DEF_DEF_  "NmJ1939IdentityNumber" 0;
+BA_DEF_DEF_  "NmJ1939IndustryGroup" 0;
+BA_DEF_DEF_  "NmJ1939ManufacturerCode" 0;
+BA_DEF_DEF_  "NmJ1939System" 0;
+BA_DEF_DEF_  "NmJ1939SystemInstance" 0;
+BA_DEF_DEF_  "NmStationAddress" 254;
+BA_DEF_DEF_  "NodeLayerModules" "J1939_IL.dll";
+BA_DEF_DEF_  "Baudrate" 0;
+BA_DEF_DEF_  "BusType" "";
+BA_DEF_DEF_  "CI_CcdVersion" "";
+BA_DEF_DEF_  "CI_MakeDbcSwLastRevDate" "";
+BA_DEF_DEF_  "Manufacturer" "";
+BA_DEF_DEF_  "ProtocolType" "";
+BA_ "Baudrate" 500000;
+BA_ "BusType" "CAN";
+BA_ "CI_CcdVersion" "AE";
+BA_ "Manufacturer" "Vector";
+BA_ "NmStationAddress" BU_ Master_ECU 33;
+BA_ "ECU" BU_ HVH_ECU "HVH_ECU";
+BA_ "NmJ1939ECUInstance" BU_ HVH_ECU 1;
+BA_ "NmJ1939IdentityNumber" BU_ HVH_ECU 68;
+BA_ "NmStationAddress" BU_ HVH_ECU 68;
+BA_ "CanDootDecode" BO_ 2364642139 1;
+BA_ "CanDootDecodeBus" BO_ 2364642139 0;
+BA_ "CanDootPaused" BO_ 2364642139 0;
+BA_ "CanDootSimulate" BO_ 2364642139 0;
+BA_ "CanDootSimulateBus" BO_ 2364642139 0;
+BA_ "GenMsgCycleTime" BO_ 2364642139 20;
+BA_ "VFrameFormat" BO_ 2364642139 3;
+BA_ "CanDootDecodeBus" BO_ 2350603013 0;
+BA_ "CanDootSimulateBus" BO_ 2350603013 0;
+BA_ "CanDootSimulateCycleTime" BO_ 2350603013 20;
+BA_ "GenMsgCycleTime" BO_ 2350603013 20;
+BA_ "CanDootDecode" BO_ 2350603013 1;
+BA_ "CanDootPaused" BO_ 2350603013 0;
+BA_ "CanDootSimulate" BO_ 2350603013 0;
+BA_ "VFrameFormat" BO_ 2350603013 3;
+BA_ "CanDootDecodeBus" BO_ 2364575835 0;
+BA_ "CanDootSimulateBus" BO_ 2364575835 0;
+BA_ "GenMsgCycleTime" BO_ 2364575835 20;
+BA_ "CanDootDecode" BO_ 2364575835 1;
+BA_ "CanDootPaused" BO_ 2364575835 0;
+BA_ "CanDootSimulate" BO_ 2364575835 0;
+BA_ "VFrameFormat" BO_ 2364575835 3;
+BA_ "CanDootDecodeBus" BO_ 2364576091 0;
+BA_ "CanDootSimulateBus" BO_ 2364576091 0;
+BA_ "GenMsgCycleTime" BO_ 2364576091 20;
+BA_ "CanDootDecode" BO_ 2364576091 1;
+BA_ "CanDootPaused" BO_ 2364576091 0;
+BA_ "CanDootSimulate" BO_ 2364576091 0;
+BA_ "VFrameFormat" BO_ 2364576091 3;
+BA_ "CanDootDecodeBus" BO_ 2364576347 0;
+BA_ "CanDootSimulateBus" BO_ 2364576347 0;
+BA_ "GenMsgCycleTime" BO_ 2364576347 20;
+BA_ "CanDootDecode" BO_ 2364576347 1;
+BA_ "CanDootPaused" BO_ 2364576347 0;
+BA_ "CanDootSimulate" BO_ 2364576347 0;
+BA_ "VFrameFormat" BO_ 2364576347 3;
+BA_ "CanDootDecodeBus" BO_ 2364576603 0;
+BA_ "CanDootSimulateBus" BO_ 2364576603 0;
+BA_ "GenMsgCycleTime" BO_ 2364576603 100;
+BA_ "CanDootDecode" BO_ 2364576603 1;
+BA_ "CanDootPaused" BO_ 2364576603 0;
+BA_ "CanDootSimulate" BO_ 2364576603 0;
+BA_ "VFrameFormat" BO_ 2364576603 3;
+BA_ "CanDootDecodeBus" BO_ 2364576859 0;
+BA_ "CanDootSimulateBus" BO_ 2364576859 0;
+BA_ "GenMsgCycleTime" BO_ 2364576859 20;
+BA_ "CanDootDecode" BO_ 2364576859 1;
+BA_ "CanDootPaused" BO_ 2364576859 0;
+BA_ "CanDootSimulate" BO_ 2364576859 0;
+BA_ "VFrameFormat" BO_ 2364576859 3;
+BA_ "CanDootDecodeBus" BO_ 2364577115 0;
+BA_ "CanDootSimulateBus" BO_ 2364577115 0;
+BA_ "GenMsgCycleTime" BO_ 2364577115 100;
+BA_ "CanDootDecode" BO_ 2364577115 1;
+BA_ "CanDootPaused" BO_ 2364577115 0;
+BA_ "CanDootSimulate" BO_ 2364577115 0;
+BA_ "VFrameFormat" BO_ 2364577115 3;
+BA_ "CanDootDecodeBus" BO_ 2364577371 0;
+BA_ "CanDootSimulateBus" BO_ 2364577371 0;
+BA_ "GenMsgCycleTime" BO_ 2364577371 100;
+BA_ "CanDootDecode" BO_ 2364577371 1;
+BA_ "CanDootPaused" BO_ 2364577371 0;
+BA_ "CanDootSimulate" BO_ 2364577371 0;
+BA_ "VFrameFormat" BO_ 2364577371 3;
+BA_ "CanDootDecodeBus" BO_ 2364579931 0;
+BA_ "CanDootSimulateBus" BO_ 2364579931 0;
+BA_ "GenMsgCycleTime" BO_ 2364579931 20;
+BA_ "CanDootDecode" BO_ 2364579931 1;
+BA_ "CanDootPaused" BO_ 2364579931 0;
+BA_ "CanDootSimulate" BO_ 2364579931 0;
+BA_ "VFrameFormat" BO_ 2364579931 3;
+BA_ "CanDootDecodeBus" BO_ 2364607067 0;
+BA_ "CanDootSimulateBus" BO_ 2364607067 0;
+BA_ "GenMsgCycleTime" BO_ 2364607067 100;
+BA_ "CanDootDecode" BO_ 2364607067 1;
+BA_ "CanDootPaused" BO_ 2364607067 0;
+BA_ "CanDootSimulate" BO_ 2364607067 0;
+BA_ "VFrameFormat" BO_ 2364607067 3;
+BA_ "CanDootDecodeBus" BO_ 2364607323 0;
+BA_ "CanDootSimulateBus" BO_ 2364607323 0;
+BA_ "GenMsgCycleTime" BO_ 2364607323 100;
+BA_ "CanDootDecode" BO_ 2364607323 1;
+BA_ "CanDootPaused" BO_ 2364607323 0;
+BA_ "CanDootSimulate" BO_ 2364607323 0;
+BA_ "VFrameFormat" BO_ 2364607323 3;
+BA_ "CanDootDecodeBus" BO_ 2364607579 0;
+BA_ "CanDootSimulateBus" BO_ 2364607579 0;
+BA_ "GenMsgCycleTime" BO_ 2364607579 100;
+BA_ "CanDootDecode" BO_ 2364607579 1;
+BA_ "CanDootPaused" BO_ 2364607579 0;
+BA_ "CanDootSimulate" BO_ 2364607579 0;
+BA_ "VFrameFormat" BO_ 2364607579 3;
+BA_ "CanDootDecodeBus" BO_ 2365522011 0;
+BA_ "CanDootSimulateBus" BO_ 2365522011 0;
+BA_ "GenMsgCycleTime" BO_ 2365522011 100;
+BA_ "CanDootDecode" BO_ 2365522011 1;
+BA_ "CanDootPaused" BO_ 2365522011 0;
+BA_ "CanDootSimulate" BO_ 2365522011 0;
+BA_ "VFrameFormat" BO_ 2365522011 3;
+BA_ "CanDootDecodeBus" BO_ 2364641627 0;
+BA_ "CanDootSimulateBus" BO_ 2364641627 0;
+BA_ "GenMsgCycleTime" BO_ 2364641627 20;
+BA_ "CanDootDecode" BO_ 2364641627 1;
+BA_ "CanDootPaused" BO_ 2364641627 0;
+BA_ "CanDootSimulate" BO_ 2364641627 0;
+BA_ "VFrameFormat" BO_ 2364641627 3;
+BA_ "CanDootDecodeBus" BO_ 2364645467 0;
+BA_ "CanDootSimulateBus" BO_ 2364645467 0;
+BA_ "GenMsgCycleTime" BO_ 2364645467 20;
+BA_ "CanDootDecode" BO_ 2364645467 1;
+BA_ "CanDootPaused" BO_ 2364645467 0;
+BA_ "CanDootSimulate" BO_ 2364645467 0;
+BA_ "VFrameFormat" BO_ 2364645467 3;
+BA_ "CanDootDecodeBus" BO_ 2364645979 0;
+BA_ "CanDootSimulateBus" BO_ 2364645979 0;
+BA_ "GenMsgCycleTime" BO_ 2364645979 20;
+BA_ "CanDootDecode" BO_ 2364645979 1;
+BA_ "CanDootPaused" BO_ 2364645979 0;
+BA_ "CanDootSimulate" BO_ 2364645979 0;
+BA_ "VFrameFormat" BO_ 2364645979 3;
+BA_ "CanDootDecodeBus" BO_ 2364641883 0;
+BA_ "CanDootSimulateBus" BO_ 2364641883 0;
+BA_ "GenMsgCycleTime" BO_ 2364641883 20;
+BA_ "CanDootDecode" BO_ 2364641883 1;
+BA_ "CanDootPaused" BO_ 2364641883 0;
+BA_ "CanDootSimulate" BO_ 2364641883 0;
+BA_ "VFrameFormat" BO_ 2364641883 3;
+BA_ "CanDootDecodeBus" BO_ 2364645723 0;
+BA_ "CanDootSimulateBus" BO_ 2364645723 0;
+BA_ "GenMsgCycleTime" BO_ 2364645723 20;
+BA_ "CanDootDecode" BO_ 2364645723 1;
+BA_ "CanDootPaused" BO_ 2364645723 0;
+BA_ "CanDootSimulate" BO_ 2364645723 0;
+BA_ "VFrameFormat" BO_ 2364645723 3;
+BA_ "CanDootDecode" BO_ 2365522437 1;
+BA_ "CanDootDecodeBus" BO_ 2365522437 0;
+BA_ "CanDootSimulate" BO_ 2365522437 0;
+BA_ "CanDootSimulateBus" BO_ 2365522437 0;
+BA_ "GenMsgCycleTime" BO_ 2365522437 10;
+BA_ "CanDootPaused" BO_ 2365522437 0;
+BA_ "VFrameFormat" BO_ 2365522437 3;
+BA_ "CanDootDecode" BO_ 2365522949 1;
+BA_ "CanDootDecodeBus" BO_ 2365522949 0;
+BA_ "CanDootSimulate" BO_ 2365522949 0;
+BA_ "CanDootSimulateBus" BO_ 2365522949 0;
+BA_ "CanDootSimulateCycleTime" BO_ 2365522949 500;
+BA_ "GenMsgCycleTime" BO_ 2365522949 1000;
+BA_ "CanDootPaused" BO_ 2365522949 0;
+BA_ "VFrameFormat" BO_ 2365522949 3;
+BA_ "GenSigStartValue" SG_ 2364642139 Core_Lowest_Cell_Temp 8736;
+BA_ "GenSigStartValue" SG_ 2364642139 Core_Highest_Cell_Temp 8736;
+BA_ "CanDootBroadcast" SG_ 2350603013 HV_Bus_Connect_Command 1;
+BA_ "CanDootBroadcast" SG_ 2364575835 Current 1;
+BA_ "GenSigStartValue" SG_ 2364575835 Current 32000;
+BA_ "CanDootBroadcast" SG_ 2364576347 Highest_Cell_Temperature 1;
+BA_ "GenSigStartValue" SG_ 2364576347 Highest_Cell_Temperature 8736;
+BA_ "GenSigStartValue" SG_ 2364576347 Lowest_Cell_Temperature 8736;
+BA_ "GenSigStartValue" SG_ 2364576347 Average_Cell_Temperature 8736;
+BA_ "GenSigStartValue" SG_ 2364576859 Discharge_Current_Limit 32000;
+BA_ "GenSigStartValue" SG_ 2364576859 Charge_Current_Limit 32000;
+BA_ "CanDootBroadcast" SG_ 2364577115 Bus_Voltage 1;
+BA_ "CanDootBroadcast" SG_ 2364577115 Ignition_Voltage 1;
+BA_ "CanDootBroadcast" SG_ 2364577115 Electronics_Temperature 1;
+BA_ "GenSigStartValue" SG_ 2364577115 Electronics_Temperature 40;
+BA_ "CanDootBroadcast" SG_ 2364577371 HV_Bus_Disconnect_Forewarning 1;
+BA_ "CanDootBroadcast" SG_ 2364577371 HVIL_Status 1;
+BA_ "CanDootBroadcast" SG_ 2364577371 HV_Bus_Connection_Status 1;
+BA_ "CanDootBroadcast" SG_ 2364577371 Operational_Status 1;
+BA_ "CanDootBroadcast" SG_ 2364607067 Average_Cell_Voltage 1;
+BA_ "CanDootBroadcast" SG_ 2365522011 Vehicle_Contactor_Pos_Closed 1;
+BA_ "CanDootBroadcast" SG_ 2365522011 Vehicle_Contactor_Neg_Closed 1;
+BA_ "CanDootBroadcast" SG_ 2365522011 Emergency_stop_1_Active 1;
+BA_ "CanDootBroadcast" SG_ 2365522011 Emergency_stop_2_Active 1;
+BA_ "CanDootBroadcast" SG_ 2365522011 Expect_system_int_HVIL_break 1;
+BA_ "GenSigStartValue" SG_ 2364641627 Core_Current 32000;
+BA_ "GenSigStartValue" SG_ 2364645467 Core_Current 32000;
+BA_ "GenSigStartValue" SG_ 2364645979 Core_Highest_Cell_Temp 8736;
+BA_ "GenSigStartValue" SG_ 2364645979 Core_Lowest_Cell_Temp 8736;
+BA_ "CanDootHidden" SG_ 2365522437 Disable_Pack_2_Command 1;
+BA_ "GenSigStartValue" SG_ 2365522949 System_Number_Of_Subpacks 0;
+

--- a/decoder/D65/dbc/D65_CH1_LV_PDU.dbc
+++ b/decoder/D65/dbc/D65_CH1_LV_PDU.dbc
@@ -1,0 +1,141 @@
+VERSION "v0.0.1"
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: CVC CAN_simulator
+
+
+BO_ 1697 IO_EXP_MDI1: 8 Vector__XXX
+ SG_ MDI_BoardTemp5 : 48|16@1- (0.1,0) [-3276.8|3276.7] "C" Vector__XXX
+ SG_ MDI_H3 : 32|16@1+ (1,0) [0|65535] "mV" Vector__XXX
+ SG_ MDI_L1 : 16|16@1+ (1,0) [0|65535] "mV" Vector__XXX
+ SG_ MDI_M1 : 0|16@1+ (1,0) [0|65535] "mV" Vector__XXX
+
+BO_ 1696 AIN_Curr_FB: 8 Vector__XXX
+ SG_ AIN_H4 : 16|16@1+ (1,0) [0|65535] "uA" Vector__XXX
+ SG_ AIN_J4 : 0|16@1+ (1,0) [0|65535] "uA" Vector__XXX
+ SG_ AIN_A4 : 32|16@1+ (1,0) [0|65535] "uA" Vector__XXX
+ SG_ AIN_A3 : 48|16@1+ (1,0) [0|65535] "uA" Vector__XXX
+
+BO_ 522 IOEXP_DO: 8 Vector__XXX
+ SG_ DO_K1 : 0|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ DO_J1 : 1|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ DO_G1 : 8|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ DO_H1 : 9|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ DO_E1 : 17|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ DO_D1 : 18|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ DO_C1 : 19|1@1+ (1,0) [0|1] "" Vector__XXX
+
+BO_ 1162 IOEXP_DO_FB1: 8 Vector__XXX
+ SG_ DO_K1_FB : 0|16@1+ (1,0) [0|65535] "mV" Vector__XXX
+ SG_ DO_J1_FB : 16|16@1+ (1,0) [0|65535] "mV" Vector__XXX
+ SG_ DO_H1_FB : 32|16@1+ (1,0) [0|65535] "mA" Vector__XXX
+ SG_ DO_G1_FB : 48|16@1+ (1,0) [0|65535] "mA" Vector__XXX
+
+BO_ 1698 IO_EXP_DO_FB2: 8 Vector__XXX
+ SG_ DO_F1_FB : 0|16@1+ (1,0) [0|65535] "mA" Vector__XXX
+ SG_ DO_E1_FB : 16|16@1+ (1,0) [0|65535] "mA" Vector__XXX
+ SG_ DO_D1_FB : 32|16@1+ (1,0) [0|65535] "mA" Vector__XXX
+ SG_ DO_C1_FB : 48|16@1+ (1,0) [0|65535] "mA" Vector__XXX
+
+BO_ 906 IOEXP_ERR: 8 Vector__XXX
+ SG_ Err_E4 : 0|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ Err_D4 : 8|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ Err_C4 : 16|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ Err_B4 : 24|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ Err_G4 : 32|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ Err_F4 : 40|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ Err_J4 : 48|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ Err_H4 : 56|8@1+ (1,0) [0|255] "" Vector__XXX
+
+BO_ 650 IOEXP_DI_FB: 8 Vector__XXX
+ SG_ DIN_F4 : 1|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ DIN_G4 : 0|1@1+ (1,0) [0|1] "" Vector__XXX
+
+BO_ 778 IOEXP_PWM: 2 Vector__XXX
+ SG_ PWM_F1_DutyCycle : 0|16@1+ (0.00152590218966964,0) [0|100] "%" Vector__XXX
+
+BO_ 394 IOEXP_AIN_FB: 8 Vector__XXX
+ SG_ AIN_B4 : 48|16@1+ (1,0) [0|65535] "mV" Vector__XXX
+ SG_ AIN_C4 : 32|16@1+ (1,0) [0|65535] "mV" Vector__XXX
+ SG_ AIN_D4 : 16|16@1+ (1,0) [0|65535] "mV" Vector__XXX
+ SG_ AIN_E4 : 0|16@1+ (1,0) [0|65535] "mV" Vector__XXX
+
+
+
+BA_DEF_ SG_  "GenSigStartValue" INT 0 2147483647;
+BA_DEF_ BU_  "NodeLayerModules" STRING ;
+BA_DEF_ BU_  "ECU" STRING ;
+BA_DEF_  "DBName" STRING ;
+BA_DEF_  "BusType" STRING ;
+BA_DEF_  "ProtocolType" STRING ;
+BA_DEF_ BU_  "NmStationAddress" INT 0 255;
+BA_DEF_ BU_  "DeviceInfo" STRING ;
+BA_DEF_ BO_  "CanDootDecode" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootPaused" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulate" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulateCycleTime" INT 0 50000;
+BA_DEF_ SG_  "CanDootHidden" ENUM  "No","Yes";
+BA_DEF_ SG_  "CanDootGroup" ENUM  "None","g1","g2","g3","g4","g5","g6","g7","g8","g9","gA","gB","gC","gD","gE","gF";
+BA_DEF_ BO_  "VFrameFormat" ENUM  "StandardCAN","ExtendedCAN","reserved","J1939PG","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","StandardCAN_FD","ExtendedCAN_FD";
+BA_DEF_ BO_  "CanDootDecodeBus" INT 0 6;
+BA_DEF_ BO_  "CanDootSimulateBus" INT 0 6;
+BA_DEF_ BO_  "CG_MessageInstName" STRING ;
+BA_DEF_ SG_  "CanDootBroadcast" ENUM  "No","Yes";
+BA_DEF_ SG_  "CG_VarType" ENUM  "bool","uint8_t","int8_t","uint16_t","int16_t","uint32_t","int32_t","float","double";
+BA_DEF_ BO_  "GenMsgCycleTime" INT 0 65535;
+BA_DEF_DEF_  "GenSigStartValue" 0;
+BA_DEF_DEF_  "NodeLayerModules" "";
+BA_DEF_DEF_  "ECU" "";
+BA_DEF_DEF_  "DBName" "";
+BA_DEF_DEF_  "BusType" "CAN";
+BA_DEF_DEF_  "ProtocolType" "";
+BA_DEF_DEF_  "NmStationAddress" 254;
+BA_DEF_DEF_  "DeviceInfo" "";
+BA_DEF_DEF_  "CanDootDecode" "Yes";
+BA_DEF_DEF_  "CanDootPaused" "No";
+BA_DEF_DEF_  "CanDootSimulate" "No";
+BA_DEF_DEF_  "CanDootSimulateCycleTime" 1500;
+BA_DEF_DEF_  "CanDootHidden" "Yes";
+BA_DEF_DEF_  "CanDootGroup" "None";
+BA_DEF_DEF_  "VFrameFormat" "StandardCAN";
+BA_DEF_DEF_  "CanDootDecodeBus" 1;
+BA_DEF_DEF_  "CanDootSimulateBus" 1;
+BA_DEF_DEF_  "CG_MessageInstName" "";
+BA_DEF_DEF_  "CanDootBroadcast" "Yes";
+BA_DEF_DEF_  "CG_VarType" "uint8_t";
+BA_DEF_DEF_  "GenMsgCycleTime" 0;
+BA_ "BusType" "CAN FD";
+BA_ "DBName" "candoot_Tester";
+

--- a/decoder/D65/dbc/D65_CH2_RCS_J1939.dbc
+++ b/decoder/D65/dbc/D65_CH2_RCS_J1939.dbc
@@ -1,0 +1,1823 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: PowertrainControlModule AtmosphericSensor SafetyRestraintSystem2 Aftertreatment_2_GasOutlet Aftertreatment_2_GasIntake DieselParticulateFilterControl Turbocharger SafetyRestraintSystem1 CabDisplay2 Aftertreatment_1_GasOutlet Aftertreatment_1_GasIntake OnBoardDataLogger OffBoardDiagnosticTool2 OffBoardDiagnosticTool1 FileServer ParkingBrakeController SeatController2 FanDriveController SteeringColumnUnit CommunicationUnitRadio CommunicationUnitSatellite CommunicationUnitCellular PropulsionBatteryCharger ChassisController2 ChassisController1 EngineValveControl AuxiliaryHeater2 AuxiliaryHeater1 ClutchUnit RampControl InformationSystem1 SuspensionSystemController2 OilSensor VehicleDynamicStability ExhaustEmissionController TransmissionDisplay2 TransmissionDisplay1 ClimateControl2 WaterPumpController RearAxleSteeringController LightingOperatorControl SeatController1 IgnitionController2 IgnitionController1 TirePressureController CabController2 CabController1 PneumaticSystemController SuspensionSystemController1 HydraulicPumpController EnduranceBrakingSystem RetarderExhaustEngine2 OnBoardDiagnosticUnit HeadwayController RetarderExhaustEngine1 CabDisplay1 ManagementComputer VirtualTerminal OffVehicleGateway PowerTakeOffFront HitchControl AuxiliaryValveControl BodyController TractorTrailerBridge1 StarterSystem ElectricalSystem VehicleSecurity VehicleNavigation AerodynamicControl ElectricalChargingSystem ClimateControl1 TripRecorder InstrumentCluster SuspensionDriveAxle2 SuspensionDriveAxle1 SuspensionSteerAxle SteeringController FuelSystem CruiseControl RetarderDriveline RetarderEngine BrakesDriveAxle2 BrakesDriveAxle1 BrakesSystemController BrakesSteerAxle AxleDrive2 AxleDrive1 AxleSteering PowerTakeOff ShiftConsoleSecondary ShiftConsolePrimary Transmission2 Transmission1 Engine2 Engine1
+
+
+BO_ 2566699264 C15_AT1S2: 8 Vector__XXX
+ SG_ SCRSysTimeSinceLastSysCleanEvent : 32|32@1+ (1,0) [0|4211081215] "s" Vector__XXX
+ SG_ DPFTimeToNextActiveRegen : 0|32@1+ (1,0) [0|4211081215] "s" Vector__XXX
+
+BO_ 2566749184 C15_DPFC1: 8 Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnInhbt5629 : 58|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ AFT1DPFCondNotMetForActiveRegen : 60|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ HydrocarbonDoserPurgingEnable : 56|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnFrcdSttus : 53|3@1+ (1,0) [0|7] "" Vector__XXX
+ SG_ ExhaustSystemHighTempLampCmd : 50|3@1+ (1,0) [0|7] "" Vector__XXX
+ SG_ DslPrtcltFltrAtmtcActvRgnrtnIntt : 48|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnInhbt3717 : 46|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnInhbtdDTE : 44|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnInhbt3715 : 42|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnInhbtdDTT : 40|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnInhbt3713 : 38|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnInhbt3712 : 36|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnInhbtdDTL : 34|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnInhbt3710 : 32|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnInhbtdDTV : 30|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnInhbtdDTO : 28|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnInhbtdDTA : 26|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnInhbtdDTP : 24|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnInhbtdDTS : 22|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnInhbtdDTC : 20|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnInhbtdDTI : 18|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DslPrtcltFltrActvRgnrtnInhbtdStt : 16|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ AFTDPFStatus : 12|3@1+ (1,0) [0|7] "" Vector__XXX
+ SG_ AFTDPFActiveRegenStatus : 10|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ AFTDPFPassiveRegenStatus : 8|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DieselParticulateFilterLampCmd : 0|3@1+ (1,0) [0|7] "" Vector__XXX
+
+BO_ 2365519360 C15_IC1: 8 Vector__XXX
+ SG_ EngCoolantFilterDiffPress : 56|8@1+ (0.5,0) [0|125] "kPa" Vector__XXX
+ SG_ EngExhaustGasTemp : 40|16@1+ (0.03125,-273) [-273|1734.96875] "�C" Vector__XXX
+ SG_ EngAirFilter1DiffPress : 32|8@1+ (0.05,0) [0|12.5] "kPa" Vector__XXX
+ SG_ EngAirIntakePress : 24|8@1+ (2,0) [0|500] "kPa" Vector__XXX
+ SG_ EngIntakeManifold1Temp : 16|8@1+ (1,-40) [-40|210] "�C" Vector__XXX
+ SG_ EngIntakeManifold1Press : 8|8@1+ (2,0) [0|500] "kPa" Vector__XXX
+ SG_ AFT1DPFInPress : 0|8@1+ (0.5,0) [0|125] "kPa" Vector__XXX
+
+BO_ 2365515008 C15_HOURS: 8 Vector__XXX
+ SG_ EngTotalRevolutions : 32|32@1+ (1000,0) [0|4211081215000] "r" Vector__XXX
+ SG_ EngTotalHoursOfOperation : 0|32@1+ (0.05,0) [0|210554060.75] "h" Vector__XXX
+
+BO_ 2348810288 C15_TSC1: 8 Vector__XXX
+ SG_ MessageChecksum : 60|4@1+ (1,0) [0|15] "" Vector__XXX
+ SG_ MessageCounter : 56|4@1+ (1,0) [0|15] "" Vector__XXX
+ SG_ EngRequestedTorqueHighResolution : 40|4@1+ (0.125,0) [0|0.875] "%" Vector__XXX
+ SG_ TSC1CtrlPurpose : 35|5@1+ (1,0) [0|31] "" Vector__XXX
+ SG_ TSC1TransRate : 32|3@1+ (1,0) [0|7] "" Vector__XXX
+ SG_ EngRequestedTorque_TorqueLimit : 24|8@1+ (1,-125) [-125|125] "%" Vector__XXX
+ SG_ EngRequestedSpeed_SpeedLimit : 8|16@1+ (0.125,0) [0|8031.875] "rpm" Vector__XXX
+ SG_ OverrideCtrlModePriority : 4|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngRequestedSpeedCtrlConditions : 2|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngOverrideCtrlMode : 0|2@1+ (1,0) [0|3] "" Vector__XXX
+
+BO_ 2566841344 C15_SHUTDN: 8 Vector__XXX
+ SG_ ClntLvlEngPrtctionShutdownStatus : 60|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ PTOShutdownHasShutdownEng : 58|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngAirShutoffStatus : 56|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngOverspeedTest : 54|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngAirShutoffCmdStatus : 52|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngAlarmOutputCmdStatus : 50|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngAlarmAcknowledge : 48|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngProtectionSystemConfig : 46|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngProtectionSystemTimerState : 38|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngProtectionSystemTimerOverride : 36|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngPrtctnSystmApprachingShutdown : 34|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngPrtectionSystemHasShutdownEng : 32|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngWaitToStartLamp : 24|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ RefrigerantHighPressSwitch : 20|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ RefrigerantLowPressSwitch : 18|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ A_CHighPressFanSwitch : 16|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngIdleShutdownTimerFunction : 14|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngIdleShutdownTimerState : 6|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngIdleShutdownTimerOverride : 4|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngIdleShutdownDriverAlertMode : 2|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngIdleShutdownHasShutdownEng : 0|2@1+ (1,0) [0|3] "" Vector__XXX
+
+BO_ 2365518336 C15_LFE1: 8 Vector__XXX
+ SG_ EngThrottleValve2Pos : 56|8@1+ (0.4,0) [0|100] "%" Vector__XXX
+ SG_ EngThrottleValve1Pos : 48|8@1+ (0.4,0) [0|100] "%" Vector__XXX
+ SG_ EngAverageFuelEconomy : 32|16@1+ (0.001953125,0) [0|125.498046875] "km/L" Vector__XXX
+ SG_ EngInstantaneousFuelEconomy : 16|16@1+ (0.001953125,0) [0|125.498046875] "km/L" Vector__XXX
+ SG_ EngFuelRate : 0|16@1+ (0.05,0) [0|3212.75] "L/h" Vector__XXX
+
+BO_ 2365516032 C15_LFC1: 8 Vector__XXX
+ SG_ EngTotalFuelUsed : 32|32@1+ (0.5,0) [0|2105540607.5] "L" Vector__XXX
+ SG_ EngTripFuel : 0|32@1+ (0.5,0) [0|2105540607.5] "L" Vector__XXX
+
+BO_ 2364539392 C15_ETC1: 8 Vector__XXX
+ SG_ SrcAddrssOfCntrllngDvcFrTrnsCtrl : 56|8@1+ (1,0) [0|253] "" Vector__XXX
+ SG_ TransInputShaftSpeed : 40|16@1+ (0.125,0) [0|8031.875] "rpm" Vector__XXX
+ SG_ MomentaryEngMaxPowerEnable : 36|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ ProgressiveShiftDisable : 34|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngMomentaryOverspeedEnable : 32|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ PercentClutchSlip : 24|8@1+ (0.4,0) [0|100] "%" Vector__XXX
+ SG_ TransOutputShaftSpeed : 8|16@1+ (0.125,0) [0|8031.875] "rpm" Vector__XXX
+ SG_ TrnsTrqCnvrtrLckpTrnstnInProcess : 6|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ TransShiftInProcess : 4|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ TrnsTorqueConverterLockupEngaged : 2|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ TransDrivelineEngaged : 0|2@1+ (1,0) [0|3] "" Vector__XXX
+
+BO_ 2365517312 C15_ET1: 8 Vector__XXX
+ SG_ EngIntercoolerThermostatOpening : 56|8@1+ (0.4,0) [0|100] "%" Vector__XXX
+ SG_ EngIntercoolerTemp : 48|8@1+ (1,-40) [-40|210] "C" Vector__XXX
+ SG_ EngTurboOilTemp : 32|16@1+ (0.03125,-273) [-273|1734.96875] "C" Vector__XXX
+ SG_ EngOilTemp1 : 16|16@1+ (0.03125,-273) [-273|1734.96875] "C" Vector__XXX
+ SG_ EngFuelTemp1 : 8|8@1+ (1,-40) [-40|210] "C" Vector__XXX
+ SG_ EngCoolantTemp : 0|8@1+ (1,-40) [-40|210] "C" Vector__XXX
+
+BO_ 2566844160 C15_EFL_P1: 8 Vector__XXX
+ SG_ EngCoolantLevel : 56|8@1+ (0.4,0) [0|100] "%" Vector__XXX
+ SG_ EngCoolantPress : 48|8@1+ (2,0) [0|500] "kPa" Vector__XXX
+ SG_ EngCrankcasePress : 32|16@1+ (0.0078125,-250) [-250|251.99] "kPa" Vector__XXX
+ SG_ EngOilPress : 24|8@1+ (4,0) [0|1000] "kPa" Vector__XXX
+ SG_ EngOilLevel : 16|8@1+ (0.4,0) [0|100] "%" Vector__XXX
+ SG_ EngExCrankcaseBlowbyPress : 8|8@1+ (0.05,0) [0|12.5] "kPa" Vector__XXX
+ SG_ EngFuelDeliveryPress : 0|8@1+ (4,0) [0|1000] "kPa" Vector__XXX
+
+BO_ 2566840064 C15_EEC3: 8 Vector__XXX
+ SG_ AFT2ExhDewPoint : 62|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ AFT2InDewPoint : 60|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ AFT1ExhDewPoint : 58|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ AFT1InDewPoint : 56|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ AFT1ExhGasMFR : 40|16@1+ (0.2,0) [0|12851] "kg/h" Vector__XXX
+ SG_ EstEngPrsiticLossesPercentTorque : 32|8@1+ (1,-125) [0|125] "%" Vector__XXX
+ SG_ EngnsDsrdOprtngSpdAsymmtryAdjstm : 24|8@1+ (1,0) [0|250] "" Vector__XXX
+ SG_ EnginesDesiredOperatingSpeed : 8|16@1+ (0.125,0) [0|8031.875] "rpm" Vector__XXX
+ SG_ NominalFrictionPercentTorque : 0|8@1+ (1,-125) [-125|125] "%" Vector__XXX
+
+BO_ 2364539648 C15_EEC2: 8 Vector__XXX
+ SG_ EstPumpingPercentTorque : 56|8@1+ (1,-125) [-125|125] "%" Vector__XXX
+ SG_ ActlMaxAvailableEngPercentTorque : 48|8@1+ (0.4,0) [0|100] "%" Vector__XXX
+ SG_ SCRThermalManagementActive : 46|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DPFThermalManagementActive : 44|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ MmntaryEngMaxPowerEnableFeedback : 42|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ VhcleAccelerationRateLimitStatus : 40|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ AccelPedalPos2 : 32|8@1+ (0.4,0) [0|100] "%" Vector__XXX
+ SG_ RemoteAccelPedalPos : 24|8@1+ (0.4,0) [0|100] "%" Vector__XXX
+ SG_ EngPercentLoadAtCurrentSpeed : 16|8@1+ (1,0) [0|125] "%" Vector__XXX
+ SG_ AccelPedalPos1 : 8|8@1+ (0.4,0) [0|100] "%" Vector__XXX
+ SG_ AccelPedal2LowIdleSwitch : 6|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ RoadSpeedLimitStatus : 4|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ AccelPedalKickdownSwitch : 2|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ AccelPedal1LowIdleSwitch : 0|2@1+ (1,0) [0|3] "" Vector__XXX
+
+BO_ 2364539904 C15_EEC1: 8 Vector__XXX
+ SG_ EngDemandPercentTorque : 56|8@1+ (1,-125) [-125|125] "%" Vector__XXX
+ SG_ EngStarterMode : 48|4@1+ (1,0) [0|15] "" Vector__XXX
+ SG_ SrcAddrssOfCntrllngDvcForEngCtrl : 40|8@1+ (1,0) [0|253] "" Vector__XXX
+ SG_ EngSpeed : 24|16@1+ (0.125,0) [0|8031.875] "rpm" Vector__XXX
+ SG_ ActualEngPercentTorque : 16|8@1+ (1,-125) [0|125] "%" Vector__XXX
+ SG_ DriversDemandEngPercentTorque : 8|8@1+ (1,-125) [0|125] "%" Vector__XXX
+ SG_ ActlEngPrcntTorqueHighResolution : 4|4@1+ (0.125,0) [0|0.875] "%" Vector__XXX
+ SG_ EngTorqueMode : 0|4@1+ (1,0) [0|15] "" Vector__XXX
+
+BO_ 2565865728 C15_EBC1: 8 Vector__XXX
+ SG_ TrctrMntdTrailerABSWarningSignal : 62|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ TrailerABSStatus : 60|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ HaltBrakeSwitch : 58|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ SrcAddrssOfCntrllngDvcFrBrkeCtrl : 48|8@1+ (1,0) [0|253] "" Vector__XXX
+ SG_ ATC_ASRInformationSignal : 46|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ ABS_EBSAmberWarningSignal : 44|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EBSRedWarningSignal : 42|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ ABSFullyOperational : 40|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngRetarderSelection : 32|8@1+ (0.4,0) [0|100] "%" Vector__XXX
+ SG_ RemoteAccelEnableSwitch : 30|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngAuxShutdownSwitch : 28|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngDerateSwitch : 26|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ AccelInterlockSwitch : 24|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ TractionCtrlOverrideSwitch : 22|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ ASRHillHolderSwitch : 20|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ ASROffroadSwitch : 18|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ ABSOffroadSwitch : 16|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ BrakePedalPos : 8|8@1+ (0.4,0) [0|100] "%" Vector__XXX
+ SG_ EBSBrakeSwitch : 6|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ AntiLockBrakingActive : 4|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ ASRBrakeCtrlActive : 2|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ ASREngCtrlActive : 0|2@1+ (1,0) [0|3] "" Vector__XXX
+
+BO_ 2566804992 C15_AT1T1I1: 8 Vector__XXX
+ SG_ HtrPreliminaryFMI : 56|5@1+ (1,0) [0|31] "" Vector__XXX
+ SG_ Htr : 48|8@1+ (0.4,0) [0|100] "%" Vector__XXX
+ SG_ SCROpIndSev : 45|3@1+ (1,0) [0|7] "" Vector__XXX
+ SG_ TempPreliminaryFMI : 40|5@1+ (1,0) [0|31] "" Vector__XXX
+ SG_ DEFTankLowLvlInd : 37|3@1+ (1,0) [0|7] "" Vector__XXX
+ SG_ LvlVolPreliminaryFMI : 32|5@1+ (1,0) [0|31] "" Vector__XXX
+ SG_ Lvl : 16|16@1+ (0.1,0) [0|6425.5] "mm" Vector__XXX
+ SG_ Temp1 : 8|8@1+ (1,-40) [-40|210] "�C" Vector__XXX
+ SG_ Volume : 0|8@1+ (0.4,0) [0|100] "%" Vector__XXX
+
+BO_ 2566748928 C15_AT1S1: 8 Vector__XXX
+ SG_ DPFSootLoadRegenThreshold : 48|16@1+ (0.0025,0) [0|160.6375] "%" Vector__XXX
+ SG_ DPFTimeSinceLastActiveRegen : 16|32@1+ (1,0) [0|4211081215] "s" Vector__XXX
+ SG_ DPFAshLoadPercent : 8|8@1+ (1,0) [0|250] "%" Vector__XXX
+ SG_ DPFSootLoadPercent : 0|8@1+ (1,0) [0|250] "%" Vector__XXX
+
+BO_ 2365428224 C15_EOI: 8 Vector__XXX
+ SG_ EngDesiredTorqueRq : 48|8@1+ (1,-125) [0|125] "%" Vector__XXX
+ SG_ EngColdAmbientElevatedIdleStatus : 46|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngStarterMotorRelayCtrl : 6|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngDerateRq : 56|8@1+ (0.4,0) [0|100] "%" Vector__XXX
+ SG_ EngEmergencyShutdownIndication : 44|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngControlledShutdownRq : 42|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngCoolantCirculatingPumpCtrl : 40|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngBlock_CoolantPreheaterCtrl : 38|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngElctrclSystmPwrCnsrvationCtrl : 36|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngOilPreheaterCtrl : 34|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngOilPrimingPumpCtrl : 32|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngFuelShutoffValveLeakTestCtrl : 30|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngFuelShutoff2Ctrl : 28|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngFuelShutoff1Ctrl : 26|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngFuelShutoffVentCtrl : 24|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ TimeRemainingInEngOperatingState : 8|16@1+ (1,0) [0|64255] "s" Vector__XXX
+ SG_ FuelPumpPrimerCtrl : 4|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ EngOperatingState : 0|4@1+ (1,0) [0|15] "" Vector__XXX
+
+BO_ 2365492224 C15_AAI: 8 Vector__XXX
+ SG_ RelativeHumidity : 48|8@1+ (0.4,0) [0|100] "%" Vector__XXX
+ SG_ AuxLevel : 32|16@1+ (0.1,0) [0|6425.5] "mm" Vector__XXX
+ SG_ AuxPress2 : 24|8@1+ (16,0) [0|4000] "kPa" Vector__XXX
+ SG_ AuxPress1 : 16|8@1+ (16,0) [0|4000] "kPa" Vector__XXX
+ SG_ AuxTemp2 : 8|8@1+ (1,-40) [-40|210] "�C" Vector__XXX
+ SG_ AuxTemp1 : 0|8@1+ (1,-40) [-40|210] "�C" Vector__XXX
+
+BO_ 2365519616 C15_VEP1: 8 Vector__XXX
+ SG_ KeyswitchBatteryPotential : 48|16@1+ (0.05,0) [0|3212.75] "V" Vector__XXX
+ SG_ BatteryPotential_PowerInput1 : 32|16@1+ (0.05,0) [0|3212.75] "V" Vector__XXX
+ SG_ ChargingSystemPotential : 16|16@1+ (0.05,0) [0|3212.75] "V" Vector__XXX
+ SG_ AltCurrent : 8|8@1+ (1,0) [0|250] "A" Vector__XXX
+ SG_ NetBatteryCurrent : 0|8@1+ (1,-125) [-125|125] "A" Vector__XXX
+
+
+
+CM_ BU_ PowertrainControlModule "Electronic control module in charge of controlling and coordinating the operation of a hybrid propulsion system.";
+CM_ BU_ HitchControl "Straight truck hitch (NOT Agricultural hitch � it is in IG 2) ";
+CM_ BO_ 2566699264 "Aftertreatment 1 Service 2
+This PGN contains information about the aftertreatment 1.";
+CM_ SG_ 2566699264 SCRSysTimeSinceLastSysCleanEvent "Indicates the time since the last cleaning event of the SCR system in bank 1.";
+CM_ SG_ 2566699264 DPFTimeToNextActiveRegen "Indicates the time to the next active regeneration event of diesel particulate filter 1.";
+CM_ BO_ 2566749184 "Diesel Particulate Filter Control 1
+This PGN contains information about the diesel particulate filter regeneration control.
+If there are aftertreatment systems on two banks, this PGN represents the composite information from both banks.
+NOTE ...";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt5629 "Indicates the state of diesel particulate filter active regeneration inhibition due to low exhaust pressure.
+00 not inhibited
+01 inhibited
+10 reserved for SAE assignment
+11 not available
+This SPN indicates the reason for the diesel particulate ...";
+CM_ SG_ 2566749184 AFT1DPFCondNotMetForActiveRegen "Indicates that diesel particulate filter 1 is not able to begin or continue an active regenerate event at the current engine operating conditions.
+00 active DPF regeneration not inhibited
+01 active DPF regeneration inhibited
+10 reserved for SAE ...";
+CM_ SG_ 2566749184 HydrocarbonDoserPurgingEnable "Purging enable of the Hydrocarbon Doser (HCD).
+
+00 Purging not enabled
+01 Purging enabled - less urgent
+10 Purging enabled - urgent
+11 Not available";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnFrcdSttus "Indicates the forced execution status of diesel particulate filter regeneration.
+000 Not Active
+001 Active - Forced by Switch (See SPN 3696)
+010 Active - Forced by Service Tool
+011 Reserved for SAE Assignment
+100 Reserved for SAE Assignment
+ ...";
+CM_ SG_ 2566749184 ExhaustSystemHighTempLampCmd "Command to control the exhaust system high temperature lamp.  This lamp indicates that the exhaust system temperature is high.
+000 Off
+001 On - solid
+010 reserved for SAE assignment
+011 reserved for SAE assignment
+100 reserved for SAE ...";
+CM_ SG_ 2566749184 DslPrtcltFltrAtmtcActvRgnrtnIntt "Indicates the configuration of diesel particulate filter active regeneration automatic initiation.
+
+00 not enabled
+01 enabled
+10 reserved for SAE assignment
+11 not available";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt3717 "Indicates the state of diesel particulate filter active regeneration inhibition due to vehicle speed being less than the allowed vehicle speed.
+00 not inhibited
+01 inhibited
+10 reserved for SAE assignment
+11 not available
+This SPN indicates the ...";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTE "Indicates the state of diesel particulate filter active regeneration inhibition due to the engine not being warmed up.
+00 not inhibited
+01 inhibited
+10 reserved for SAE assignment
+11 not available
+This SPN indicates the reason for the diesel ...";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt3715 "Indicates the state of diesel particulate filter active regeneration inhibition due to a permanent system lockout.
+00 not inhibited
+01 inhibited
+10 reserved for SAE assignment
+11 not available
+This SPN indicates the reason for the diesel ...";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTT "Indicates the state of diesel particulate filter active regeneration inhibition due to a temporary system lockout.
+00 not inhibited
+01 inhibited
+10 reserved for SAE assignment
+11 not available
+This SPN indicates the reason for the diesel ...";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt3713 "Indicates the state of diesel particulate filter active regeneration inhibition due to a system timeout.
+00 not inhibited
+01 inhibited
+10 reserved for SAE assignment
+11 not available
+This SPN indicates the reason for the diesel particulate ...";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt3712 "Indicates the state of diesel particulate filter active regeneration inhibition due to a system fault being active.
+00 not inhibited
+01 inhibited
+10 reserved for SAE assignment
+11 not available
+This SPN indicates the reason for the diesel ...";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTL "Indicates the state of diesel particulate filter active regeneration inhibition due to the exhaust temperature being too low.  This implies that the diesel particulate filter and/or oxidation catalyst are likewise too cold for active regeneration.
+ ...";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt3710 "Indicates the state of diesel particulate filter active regeneration inhibition due to the parking brake being not set.
+00 not inhibited
+01 inhibited
+10 reserved for SAE assignment
+11 not available
+This SPN indicates the reason for the diesel ...";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTV "Indicates the state of diesel particulate filter active regeneration inhibition due to the vehicle speed being above an allowed limit.
+00 not inhibited
+01 inhibited
+10 reserved for SAE assignment
+11 not available
+This SPN indicates the reason ...";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTO "Indicates the state of diesel particulate filter active regeneration inhibition due to the transmission being out of neutral.
+00 not inhibited
+01 inhibited
+10 reserved for SAE assignment
+11 not available
+This SPN indicates the reason for the ...";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTA "Indicates the state of diesel particulate filter active regeneration inhibition due to the accelerator pedal being off idle.
+00 not inhibited
+01 inhibited
+10 reserved for SAE assignment
+11 not available
+This SPN indicates the reason for the ...";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTP "Indicates the state of diesel particulate filter active regeneration inhibition due to the PTO being active.
+00 not inhibited
+01 inhibited
+10 reserved for SAE assignment
+11 not available
+This SPN indicates the reason for the diesel particulate ...";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTS "Indicates the state of diesel particulate filter active regeneration inhibition due to the service brake being active.
+00 not inhibited
+01 inhibited
+10 reserved for SAE assignment
+11 not available
+This SPN indicates the reason for the diesel ...";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTC "Indicates the state of diesel particulate filter active regeneration inhibition due to the clutch being disengaged.
+00 not inhibited
+01 inhibited
+10 reserved for SAE assignment
+11 not available
+This SPN indicates the reason for the diesel ...";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTI "Indicates the state of diesel particulate filter active regeneration inhibition due to the Diesel Particulate Filter Regeneration Inhibit Switch.
+00 not inhibited
+01 inhibited
+10 reserved for SAE assignment
+11 not available
+This SPN indicates ...";
+CM_ SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdStt "Indicates the state of diesel particulate filter active regeneration inhibition.
+00 not inhibited
+01 inhibited
+10 reserved for SAE assignment
+11 not available
+This SPN indicates the reason for the diesel particulate filter regeneration not ...";
+CM_ SG_ 2566749184 AFTDPFStatus "Indicates the state of the diesel particulate filter regeneration need and urgency.  This is an aggregate of bank 1 and bank 2.  It is a system status and not individual bank status.
+000 Regeneration not needed
+001 Regeneration needed - lowest ...";
+CM_ SG_ 2566749184 AFTDPFActiveRegenStatus "Indicates the state of diesel particulate filter active regeneration.  This is an aggregate of bank 1 and bank 2.  It is a system status and not individual bank status.
+00 not active
+01 active
+10 regeneration needed - automatically initiated ...";
+CM_ SG_ 2566749184 AFTDPFPassiveRegenStatus "Indicates the state of diesel particulate filter passive regeneration.  This is an aggregate of bank 1 and bank 2.  It is a system status and not individual bank status.
+
+
+00 not active
+01 active
+10 reserved for SAE assignment
+11 not available";
+CM_ SG_ 2566749184 DieselParticulateFilterLampCmd "Command to control the diesel particulate filter lamp.
+000 Off
+001 On - solid
+010 reserved for SAE assignment
+011 reserved for SAE assignment
+100 On - fast blink (1 HZ)
+101 reserved for SAE assignment
+110 reserved for SAE assignment
+111 not ...";
+CM_ BO_ 2365519360 "Intake/Exhaust Conditions 1";
+CM_ SG_ 2365519360 EngCoolantFilterDiffPress "Change in coolant pressure, measured across the filter, due to the filter and any accumulation of solid or semisolid matter on or in the filter.";
+CM_ SG_ 2365519360 EngExhaustGasTemp "Temperature of combustion byproducts leaving the engine.  See SPNs 2433, 2434, 5969 and 5970 for engines with more than one exhaust temperature measurement.";
+CM_ SG_ 2365519360 EngAirFilter1DiffPress "Change in engine air system pressure, measured across the filter, due to the filter and any accumulation of solid foreign matter on or in the filter.
+This is the measurement of the first filter in a multiple air filter system.  In a single air ...";
+CM_ SG_ 2365519360 EngAirIntakePress "Absolute air pressure at input port to intake manifold or air box.";
+CM_ SG_ 2365519360 EngIntakeManifold1Temp "Temperature of pre-combustion air found in intake manifold of engine air supply system.";
+CM_ SG_ 2365519360 EngIntakeManifold1Press "The gage pressure measurement of the air intake manifold. If there are multiple air pressure sensors in the intake stream, this is the last one in flow direction before entering the combustion chamber.  This should be the pressure used to drive ...";
+CM_ SG_ 2365519360 AFT1DPFInPress "Exhaust pressure as a result of particle accumulation on filter media placed in the exhaust stream.  It is recommended that SPN 3609 be used as it has better resolution.";
+CM_ BO_ 2365515008 "Engine Hours, Revolutions";
+CM_ SG_ 2365515008 EngTotalRevolutions "Accumulated number of revolutions of engine crankshaft during its operation.";
+CM_ SG_ 2365515008 EngTotalHoursOfOperation "Accumulated time of operation of engine.";
+CM_ BO_ 2348810288 "Torque/Speed Control 1
+NOTE - Retarder may be disabled by commanding a torque limit of 0%.  Use of the limit mode allows the use of the retarder only up to the limit specified in the request.  This can be used to permit retarding of up to 50%, for ...";
+CM_ SG_ 2348810288 MessageChecksum "The message checksum is used to verify the signal path from the transmitting device to the receiving device.
+The message checksum is calculated using the first 7 data bytes, the message counter and the bytes of the message identifier. It is ...";
+CM_ SG_ 2348810288 MessageCounter "The message counter is used to detect situations where the transmitting ECU malfunction repeats the same frame all the time.  The receiver of the information may use the counter parameter to detect this situation.  The transmitting device will ...";
+CM_ SG_ 2348810288 EngRequestedTorqueHighResolution "This parameter displays an additional torque in percent of the reference engine torque.
+When the MSB is set to 1, this parameter is not available.  When the MSB is set to 0, bits 1 to 3 indicate the desired torque with resolution of 0.125%/bit  ...";
+CM_ SG_ 2348810288 TSC1CtrlPurpose "State signal which indicates which control mode the sending device is using to generate the TSC1 command.  Note that the modes are not in prioritized order. Not all modes may be relevant for a given device. Some devices may not implement all ...";
+CM_ SG_ 2348810288 TSC1TransRate "This parameter indicates the transmission rate at which the sending device will transmit the TSC1 message.  The engine shall adjust its timeout for TSC1 messages accordingly. Variable TSC1 transmission rates shall only apply to messages sent to the ...";
+CM_ SG_ 2348810288 EngRequestedTorque_TorqueLimit "Parameter provided to the engine or retarder in the torque/speed control message for controlling or limiting the output torque.
+Requested torque to the engine is measured in indicated torque as a percentage of reference engine torque (see the ...";
+CM_ SG_ 2348810288 EngRequestedSpeed_SpeedLimit "Parameter provided to the engine from external sources in the torque/speed control message.  This is the engine speed which the engine is expected to operate at if the speed control mode is active or the engine speed which the engine is not expected ...";
+CM_ SG_ 2348810288 OverrideCtrlModePriority "This field is used as an input to the engine or retarder to determine the priority of the Override Control Mode received in the Torque/Speed Control message (see PGN 0).  The default is 11 (Low priority).  It is not required to use the same priority ...";
+CM_ SG_ 2348810288 EngRequestedSpeedCtrlConditions "This mode tells the engine control system the governor characteristics that are desired during speed control.  The four characteristics defined are:
+00 Transient Optimized for driveline disengaged and non-lockup conditions
+01 Stability Optimized ...";
+CM_ SG_ 2348810288 EngOverrideCtrlMode "The override control mode defines which sort of command is used:
+00 Override disabled - Disable any existing control commanded by the source of this command.
+01 Speed control - Govern speed to the included �desired speed� value.
+10 Torque control ...";
+CM_ BO_ 2566841344 "Shutdown";
+CM_ SG_ 2566841344 ClntLvlEngPrtctionShutdownStatus "Parameter which indicates the configuration of the coolant level engine protection shutdown.
+00 - Disabled - calibration does not allow engine protection due to low coolant level or the override is currently active
+01 - Enabled - calibration ...";
+CM_ SG_ 2566841344 PTOShutdownHasShutdownEng "Status signal which identifies whether or not the engine has been shutdown by the PTO shutdown system.
+
+00 - No
+01 - Yes
+10 - Error
+11 - Not available";
+CM_ SG_ 2566841344 EngAirShutoffStatus "State signal which indicates the actual measured position of the Air Shutoff.
+00 - Air flow allowed to engine
+01 - Air flow restricted
+10 - Error
+11 - Not Available
+Note:   This parameter, in conjunction with SPN 2813 - \"Engine Air Shutoff ...";
+CM_ SG_ 2566841344 EngOverspeedTest "The engine overspeed test signal as measured by the reporting ECM.  Engine Overspeed Test is a mechanism to simulate engine overspeed situations, while operating the engine within the engine's safe operating range.
+State signal which indicates when ...";
+CM_ SG_ 2566841344 EngAirShutoffCmdStatus "State signal which indicates when the Air Shutoff  driver output is being driven. Disabled means controller wants air flowing to the engine. Status of the airflow  shutoff as being commanded by the ECU.
+00 Air Shutoff Disabled, not attempting to ...";
+CM_ SG_ 2566841344 EngAlarmOutputCmdStatus "State signal which indicates when the Alarm driver output is being driven. Not active means the Controller has no alarm level conditions.
+00 Engine Alarm Output Command Not Active
+01 Engine Alarm Output Command Active
+10 Reserved
+11 Not ...";
+CM_ SG_ 2566841344 EngAlarmAcknowledge "The Engine Alarm Acknowledge Input signal as measured by the reporting ECU.  The Engine Alarm Acknowledge is a mechanism for external acknowledgement of the SPN 2814,  Engine Alarm Output Command.
+00 Engine Alarm Acknowledge  Not Active
+01 Engine ...";
+CM_ SG_ 2566841344 EngProtectionSystemConfig "Parameter which indicates the configuration of the engine shutdown system.
+
+00 - Disabled in calibration
+01 - Enabled in calibration
+10 - Error
+11 - Not available";
+CM_ SG_ 2566841344 EngProtectionSystemTimerState "Status signal which indicates the current mode of the engine protection system timer system.  See Figure SPN1107_A.
+
+00 - Inactive
+01 - Active
+10 - Error
+11 - Not available";
+CM_ SG_ 2566841344 EngProtectionSystemTimerOverride "Status signal which indicates the status of the override feature of the engine protection system timer. See Figure SPN1107_A.
+
+00 - Inactive
+01 - Active
+10 - Error
+11 - Not available";
+CM_ SG_ 2566841344 EngPrtctnSystmApprachingShutdown "Status signal which indicates that engine shutdown is imminent.  This engine protection signal can be a result of different systems failing, i.e., engine overheating. See Figure SPN1107_A.
+00 - Not approaching
+01 - Approaching
+10 - Error
+11 - ...";
+CM_ SG_ 2566841344 EngPrtectionSystemHasShutdownEng "Status signal which indicates whether or not the engine protection system has shutdown the engine.  See Figure SPN1107_A.
+
+00 - No
+01 - Yes
+10 - Error
+11 - Not available";
+CM_ SG_ 2566841344 EngWaitToStartLamp "Lamp signal which indicates that the engine is too cold to start and the operator should wait until the signal becomes inactive (turns off).  See SPN 5416 for the lamp operating condition.
+
+00 - Off
+01 - On
+10 - Error
+11 - Not available";
+CM_ SG_ 2566841344 RefrigerantHighPressSwitch "Switch signal which indicates the position of the high pressure switch in the coolant circuit of an air conditioning system.  When the switch is enabled, the pressure inside the circuit is too high and the compressor clutch may be disengaged.
+00 - ...";
+CM_ SG_ 2566841344 RefrigerantLowPressSwitch "Switch signal which indicates the position of the low pressure switch in the coolant circuit of an air conditioning system.  When the switch is enabled, the pressure inside the circuit is too low and the compressor clutch may be disengaged.
+00 - ...";
+CM_ SG_ 2566841344 A_CHighPressFanSwitch "Switch signal which indicates that the pressure in the coolant circuit of an air conditioning system is high and the fan may be engaged.
+
+00 - Pressure normal
+01 - Pressure high, fan may be engaged
+10 - Error
+11 - Not available";
+CM_ SG_ 2566841344 EngIdleShutdownTimerFunction "Parameter which indicates the configuration of the idle shutdown timer system.
+
+00 - Disabled in calibration
+01 - Enabled in calibration
+10 - Error
+11 - Not available";
+CM_ SG_ 2566841344 EngIdleShutdownTimerState "Status signal which indicates the current mode of operation of the idle shutdown timer system.  See Figure SPN590_A.
+
+00 - Inactive
+01 - Active
+10 - Error
+11 - Not available";
+CM_ SG_ 2566841344 EngIdleShutdownTimerOverride "Status signal which indicates the status of the override feature of the idle shutdown timer system.  See Figure SPN590_A.
+
+00 - Inactive
+01 - Active
+10 - Error
+11 - Not available";
+CM_ SG_ 2566841344 EngIdleShutdownDriverAlertMode "Status signal which indicates the status of the driver alert mode of the idle shutdown timer system.  While the driver alert mode is active, the idle shutdown timer may be overridden.  See Figure SPN590_A.
+00 - Inactive
+01 - Active
+10 - Error
+11 ...";
+CM_ SG_ 2566841344 EngIdleShutdownHasShutdownEng "Status signal which identifies whether or not the engine has been shutdown by the idle shutdown timer system.  See Figure SPN590_A.
+
+00 - No
+01 - Yes
+10 - Error
+11 - Not available";
+CM_ BO_ 2365518336 "Fuel Economy (Liquid)";
+CM_ SG_ 2365518336 EngThrottleValve2Pos "The sensed position feedback of the valve, coming from a second electrical actuator for a second throttle plate, used to regulate the supply of a fluid, usually air or fuel//air mixture.  0% represents no supply and 100% is full supply. SPN 51 is ...";
+CM_ SG_ 2365518336 EngThrottleValve1Pos "The position of the valve used to regulate the supply of a fluid, usually air or fuel/air mixture, to an engine.  0% represents no supply and 100% is full supply.";
+CM_ SG_ 2365518336 EngAverageFuelEconomy "Average of instantaneous fuel economy for that segment of vehicle operation of interest.";
+CM_ SG_ 2365518336 EngInstantaneousFuelEconomy "Current fuel economy at current vehicle velocity.
+
+0xFB00 = Infinite (for example, during engine motoring)";
+CM_ SG_ 2365518336 EngFuelRate "Amount of fuel consumed by engine per unit of time.
+
+NOTE - See SPN 1600 for alternate resolution.";
+CM_ BO_ 2365516032 "Fuel Consumption (Liquid) 1
+Engine fuel consumption accumulators.  See PGN 64777 for alternate resolution.";
+CM_ SG_ 2365516032 EngTotalFuelUsed "Accumulated amount of fuel used during vehicle operation.  See SPN 5054 for alternate resolution.";
+CM_ SG_ 2365516032 EngTripFuel "Fuel consumed during all or part of a journey.  See SPN 5053 for alternate resolution.";
+CM_ BO_ 2364539392 "Electronic Transmission Controller 1
+Electronic Transmission Controller #1
+Note:
+Single input shaft transmissions should use SPN 161 (Transmission Input Shaft Speed).
+Multiple input shaft transmissions should use SPN 5960 and 5961 (DCT Input ...";
+CM_ SG_ 2364539392 SrcAddrssOfCntrllngDvcFrTrnsCtrl "The source address of the SAE J1939 device currently controlling the transmission. Its value may be the source address of the ECU transmitting the message (which means that no external SAE J1939 message is providing the active command) or the source ...";
+CM_ SG_ 2364539392 TransInputShaftSpeed "Rotational velocity of the primary shaft transferring power into the transmission.  When a torque converter is present, it is the output of the torque converter.
+Note:
+Single input shaft transmissions should use SPN 161 (Transmission Input Shaft ...";
+CM_ SG_ 2364539392 MomentaryEngMaxPowerEnable "Momentarily Requesting highest torque map from the engine control
+
+00 not requesting maximum power available
+01 momentarily requesting maximum power available
+10 fault
+11 not available";
+CM_ SG_ 2364539392 ProgressiveShiftDisable "Command signal used to indicate that progressive shifting by the engine should be disallowed.
+
+00 Progressive shift is not disabled
+01 Progressive shift is disabled
+10 Reserved
+11 Take no action";
+CM_ SG_ 2364539392 EngMomentaryOverspeedEnable "Command signal used to indicate that the engine speed may be boosted up to the maximum engine overspeed value to accommodate transmission downshifts.  The maximum time for overspeed is limited by the time defined in the engine configuration message ...";
+CM_ SG_ 2364539392 PercentClutchSlip "Parameter which represents the ratio of input shaft speed to current engine speed (in percent).
+
+Percent Clutch Slip = ((Engine rpm - Input shaft rpm)/(Engine rpm)) x 100";
+CM_ SG_ 2364539392 TransOutputShaftSpeed "Calculated speed of the transmission output shaft.";
+CM_ SG_ 2364539392 TrnsTrqCnvrtrLckpTrnstnInProcess "State signal indicating whether or not the transmission torque converter lock up clutch is transitioning between being applied and being released.  The broadcast value should be set to 01 as soon as an apply or release of the lockup clutch is ...";
+CM_ SG_ 2364539392 TransShiftInProcess "Indicates that the transmission is in process of shifting from the current gear to the selected gear. This state is generally ACTIVE during the entire time that the transmission controls the vehicle during a shift. This includes any transmission ...";
+CM_ SG_ 2364539392 TrnsTorqueConverterLockupEngaged "State signal which indicates whether the torque converter lockup is engaged.
+
+00 Torque converter lockup disengaged
+01 Torque converter lockup engaged
+10 Error
+11 Not available";
+CM_ SG_ 2364539392 TransDrivelineEngaged "Driveline engaged indicates the transmission controlled portion of the driveline is engaged sufficiently to allow a transfer of torque through the transmission.  Driveline engaged is ACTIVE whenever the transmission is in gear and the clutch (if ...";
+CM_ BO_ 2365517312 "Engine Temperature 1";
+CM_ SG_ 2365517312 EngIntercoolerThermostatOpening "The current position of the thermostat used to regulate the temperature of the engine charge air cooler.  A value of 0% represents the thermostat being completely closed and 100% represents the thermostat being completely open.";
+CM_ SG_ 2365517312 EngIntercoolerTemp "Temperature of liquid found in the intercooler located after the turbocharger.";
+CM_ SG_ 2365517312 EngTurboOilTemp "Temperature of the turbocharger lubricant.";
+CM_ SG_ 2365517312 EngOilTemp1 "Temperature of the engine lubricant.
+Note:  If there is only one engine oil temperature measurement, this SPN should be used.  This is the SPN that is typically displayed on an on-highway truck instrument cluster.
+See also SPNs 1135 and 5925 for ...";
+CM_ SG_ 2365517312 EngFuelTemp1 "Temperature of fuel (or gas) of the first fuel type. See SPN 3468 for a second temperature measurement of the first fuel type.";
+CM_ SG_ 2365517312 EngCoolantTemp "Temperature of liquid found in engine cooling system.";
+CM_ BO_ 2566844160 "Engine Fluid Level/Pressure 1
+PGN which identifies parameters that are either measuring various pressures within the engine or identifying engine fluid levels";
+CM_ SG_ 2566844160 EngCoolantLevel "Ratio of volume of liquid found in engine cooling system to total cooling system volume.  Typical monitoring location is in the coolant expansion tank.";
+CM_ SG_ 2566844160 EngCoolantPress "Gage pressure of liquid found in engine cooling system.
+
+See SPN 20 for alternate range and resolution.";
+CM_ SG_ 2566844160 EngCrankcasePress "First instance of the gage pressure inside engine crankcase.";
+CM_ SG_ 2566844160 EngOilPress "Gage pressure of oil in engine lubrication system as provided by oil pump.  See SPN 7468 for alternate resolution.";
+CM_ SG_ 2566844160 EngOilLevel "Ratio of current volume of engine sump oil to maximum required volume.";
+CM_ SG_ 2566844160 EngExCrankcaseBlowbyPress "Differential crankcase blow-by pressure as measured through a tube with a venturi. 
+
+(SPN 1264 is not to be used - obsolete)";
+CM_ SG_ 2566844160 EngFuelDeliveryPress "Gage pressure of fuel in system as delivered from supply pump to the injection pump.  See SPN 7469 for alternate resolution.
+
+See also SPN 5578 for Fuel Delivery Absolute Pressure.";
+CM_ BO_ 2566840064 "Electronic Engine Controller 3";
+CM_ SG_ 2566840064 AFT2ExhDewPoint "Indicates that the temperature on the exhaust side of the aftertreatment has exceeded the dew point, as estimated by the ECU in exhaust bank 2.
+
+00 - Not exceeded the dew point
+01 - Exceeded the dew point
+10 - Error
+11 - Not available";
+CM_ SG_ 2566840064 AFT2InDewPoint "Indicates that the temperature on the intake side of the aftertreatment system has exceeded the dew point, as estimated by the ECU in exhaust bank 2.
+
+00 - Not exceeded the dew point
+01 - Exceeded the dew point
+10 - Error
+11 - Not available";
+CM_ SG_ 2566840064 AFT1ExhDewPoint "Indicates that the temperature on the exhaust side of the aftertreatment has exceeded the dew point, as estimated by the ECU in exhaust bank 1.
+
+00 - Not exceeded the dew point
+01 - Exceeded the dew point
+10 - Error
+11 - Not available";
+CM_ SG_ 2566840064 AFT1InDewPoint "Indicates that the temperature on the intake side of the aftertreatment system has exceeded the dew point, as estimated by the ECU in exhaust bank 1.
+
+00 - Not exceeded the dew point
+01 - Exceeded the dew point
+10 - Error
+11 - Not available";
+CM_ SG_ 2566840064 AFT1ExhGasMFR "Measured/calculated exhaust gas mass upstream of the aftertreatment�system in exhaust bank 1 and 2.";
+CM_ SG_ 2566840064 EstEngPrsiticLossesPercentTorque "The calculated torque that indicates the estimated amount of torque loss due to engine parasitics, such as cooling fan, air compressor, air conditioning, etc. It is expressed as a percent of Engine Reference Torque.
+If there are multiple devices on ...";
+CM_ SG_ 2566840064 EngnsDsrdOprtngSpdAsymmtryAdjstm "This byte is utilized in transmission gear selection routines and indicates the engine's preference of lower versus higher engine speeds should its desired speed not be achievable.  This is a scaled ratio such that 125 represents an equal preference ...";
+CM_ SG_ 2566840064 EnginesDesiredOperatingSpeed "An indication by the engine of the optimal operating speed of the engine for the current existing conditions.  These conditions may include the torque generated to accommodate powertrain demands from the operator (via the accelerator pedal), cruise ...";
+CM_ SG_ 2566840064 NominalFrictionPercentTorque "The calculated torque that indicates the amount of torque required by the basic engine itself added by the loss torque of accessories. It contains the frictional and thermodynamic loss of the engine itself, pumping torque loss (SPN 5398), and the ...";
+CM_ BO_ 2364539648 "Electronic Engine Controller 2
+Identifies electronic engine control related parameters.";
+CM_ SG_ 2364539648 EstPumpingPercentTorque "The calculated torque that indicates the estimated amount of torque loss due to the engine air handling system. The value transmitted in this parameter is included in SPN 514 (Nominal Friction - Percent Torque).  The data is transmitted as a percent ...";
+CM_ SG_ 2364539648 ActlMaxAvailableEngPercentTorque "This is the maximum amount of torque that the engine can immediately deliver as a percentage of the reference engine torque (SPN 544).  The Actual Maximum Available Engine - Percent Torque shall take into consideration all engine torque derates ...";
+CM_ SG_ 2364539648 SCRThermalManagementActive "Indicates that the exhaust temperatures have been elevated for regeneration of the SCR aftertreatment system or in preparation of regeneration of the SCR aftertreatment system.
+00 - SCR Thermal Management is not active
+01 - SCR Thermal Management ...";
+CM_ SG_ 2364539648 DPFThermalManagementActive "Indicates that the exhaust temperatures have been elevated for regeneration of the diesel particulate filter aftertreatment system or in preparation of regeneration of the diesel particulate aftertreatment system.
+00 - DPF Thermal Management is not ...";
+CM_ SG_ 2364539648 MmntaryEngMaxPowerEnableFeedback "Momentarily requesting Engine Maximum Power Enable - feature support feedback
+
+00 disabled
+01 supported 
+10 reserved
+11 don't care";
+CM_ SG_ 2364539648 VhcleAccelerationRateLimitStatus "Status (active or not active) of the system used to limit maximum forward vehicle acceleration.
+00     Limit not active
+01     Limit active
+10     Reserved
+11     Not available
+NOTE:  The effects of emission control limits, such as engine ...";
+CM_ SG_ 2364539648 AccelPedalPos2 "The ratio of actual position of the second analog engine speed/torque request input device (such as an accelerator pedal or throttle lever) to the maximum position of the input device.  This parameter is intended for secondary accelerator control in ...";
+CM_ SG_ 2364539648 RemoteAccelPedalPos "The ratio of actual position of the remote analog engine speed/torque request input device (such as an accelerator pedal or throttle lever) to the maximum position of the input device.
+For example, in on-highway vehicles this could be an ...";
+CM_ SG_ 2364539648 EngPercentLoadAtCurrentSpeed "The ratio of actual engine percent torque (indicated) to maximum indicated torque available at the current engine speed, clipped to zero torque during engine braking.";
+CM_ SG_ 2364539648 AccelPedalPos1 "The ratio of actual position of the analog engine speed/torque request input device (such as an accelerator pedal or throttle lever) to the maximum position of the input device.  This parameter is intended for the primary accelerator control in an ...";
+CM_ SG_ 2364539648 AccelPedal2LowIdleSwitch "Switch signal which indicates the state of the accelerator pedal 2 low idle switch.  The low idle switch is defined in SAE J1843.
+00    Accelerator pedal 2 not in low idle condition
+01    Accelerator pedal 2 in low idle condition
+10    Error
+11 ...";
+CM_ SG_ 2364539648 RoadSpeedLimitStatus "Status (active or not active) of the system used to limit maximum vehicle velocity.
+00 - Active
+01 - Not Active
+10 - Error
+11 - Not available
+NOTE - While somewhat inconsistent with other J1939 status parameters, the states defining 00 = active ...";
+CM_ SG_ 2364539648 AccelPedalKickdownSwitch "Switch signal which indicates whether the accelerator pedal kickdown switch is opened or closed.  The kickdown switch is defined in SAE J1843.
+
+00 - Kickdown passive
+01 - Kickdown active
+10 - Error
+11 - Not available";
+CM_ SG_ 2364539648 AccelPedal1LowIdleSwitch "Switch signal which indicates the state of the accelerator pedal 1 low idle switch.  The low idle switch is defined in SAE Recommended Practice J1843.
+00 - Accelerator pedal 1 not in low idle condition
+01 - Accelerator pedal 1 in low idle ...";
+CM_ BO_ 2364539904 "Electronic Engine Controller 1
+Engine related parameters";
+CM_ SG_ 2364539904 EngDemandPercentTorque "The requested torque output of the engine by all dynamic internal inputs, including smoke control, noise control and low and high speed governing.";
+CM_ SG_ 2364539904 EngStarterMode "There are several phases in a starting action and different reasons why a start cannot take place.
+0000 start not requested
+0001 starter active, gear not engaged
+0010 starter active, gear engaged
+0011 start finished; starter not active after ...";
+CM_ SG_ 2364539904 SrcAddrssOfCntrllngDvcForEngCtrl "The source address of the SAE J1939 device currently controlling the engine.  It is used to expand the torque mode parameter (see SPN 899) in cases where control is in response to an ECU that is not listed in Table SPN899_A.  Its value may be the ...";
+CM_ SG_ 2364539904 EngSpeed "Actual engine speed which is calculated over a minimum crankshaft angle of 720 degrees divided by the number of cylinders.";
+CM_ SG_ 2364539904 ActualEngPercentTorque "The calculated output torque of the engine.  The data is transmitted in indicated torque as a percent of reference engine torque (see the engine configuration message, PGN 65251).  The engine percent torque value will not be less than zero and it ...";
+CM_ SG_ 2364539904 DriversDemandEngPercentTorque "The requested torque output of the engine by the driver. It is based on input from the following requestors external to the powertrain: operator (via the accelerator pedal), cruise control and/or road speed limit governor. Dynamic commands from ...";
+CM_ SG_ 2364539904 ActlEngPrcntTorqueHighResolution "This parameter displays an additional torque in percent of the reference engine torque.
+When the MSB is set to 1, this parameter is not available.  When the MSB is set to 0, bits 1 to 3 indicate the desired torque with resolution of 0.125%/bit  ...";
+CM_ SG_ 2364539904 EngTorqueMode "State signal which indicates which engine torque mode is currently generating, limiting, or controlling the torque.  Note that the modes are not in prioritized order. Not all modes may be relevant for a given device.  Some devices may not implement ...";
+CM_ BO_ 2565865728 "Electronic Brake Controller 1
+Used for brake control information";
+CM_ SG_ 2565865728 TrctrMntdTrailerABSWarningSignal "This parameter commands the tractor-mounted trailer ABS optical warning signal.
+
+00 Off
+01 On 
+10 Reserved
+11 Take no action";
+CM_ SG_ 2565865728 TrailerABSStatus "State signal which indicates that ABS in the trailer is actively controlling the brakes.  A message is sent to the tractor from the trailer (i.e. by PLC). The receiving device in the tractor transfers this information to the J1939 network.  At the ...";
+CM_ SG_ 2565865728 HaltBrakeSwitch "Switch signal which indicates the position of the halt brake switch.
+
+00    Halt brake switch passive
+01    Halt brake switch active
+10    Error
+11    Not available";
+CM_ SG_ 2565865728 SrcAddrssOfCntrllngDvcFrBrkeCtrl "The source address of the SAE J1939 device currently controlling the brake system. Its value may be the source address of the ECU transmitting the message (which means that no external SAE J1939 message is providing the active command) or the source ...";
+CM_ SG_ 2565865728 ATC_ASRInformationSignal "This parameter commands the ATC/ASR driver information signal, for example a dash lamp.
+
+00 Off
+01 On 
+10 Reserved
+11 Take no action";
+CM_ SG_ 2565865728 ABS_EBSAmberWarningSignal "This parameter commands the ABS/EBS amber/yellow optical warning signal
+
+00 Off
+01 On
+10 Reserved
+11 Take no action";
+CM_ SG_ 2565865728 EBSRedWarningSignal "This parameter commands the EBS red optical warning signal
+
+00 Off
+01 On
+10 Reserved
+11 Take no action";
+CM_ SG_ 2565865728 ABSFullyOperational "Signal which indicates whether an ABS system is fully operational or whether its functionality is reduced by a defect or by an intended action (e.g., by activation of an ABS-off-road switch or during special diagnostic procedures).  There are cases ...";
+CM_ SG_ 2565865728 EngRetarderSelection "The position of the operator controlled selector, expressed as a percentage and determined by the ratio of the current position of the selector to its maximum possible position. Zero percent means no braking torque is requested by the operator from ...";
+CM_ SG_ 2565865728 RemoteAccelEnableSwitch "Switch signal which indicates that the remote accelerator has been enabled and controls the engine.
+00 - Off
+01 - On
+10 - Error
+11 - Not available
+NOTE�The accelerator interlock switch (see SPN 972) must be disabled in order for the remote ...";
+CM_ SG_ 2565865728 EngAuxShutdownSwitch "Switch signal which requests that all engine fueling stop.
+
+00 - Off
+01 - On
+10 - Error
+11 - Not available";
+CM_ SG_ 2565865728 EngDerateSwitch "Switch signal used to activate the torque limiting feature of the engine.  The specific nature of torque limiting should be verified with the manufacturer.
+
+00 - Off
+01 - On
+10 - Error
+11 - Not available";
+CM_ SG_ 2565865728 AccelInterlockSwitch "Switch signal used to disable the accelerator and remote accelerator inputs, causing the engine to return to idle.
+
+00 - Off
+01 - On
+10 - Error
+11 - Not available";
+CM_ SG_ 2565865728 TractionCtrlOverrideSwitch "Switch signal which indicates the position of the traction control override switch.  The traction control override signal disables the automatic traction control function allowing the wheels to spin.
+00 - Off
+01 - On
+10 - Error
+11 - Not ...";
+CM_ SG_ 2565865728 ASRHillHolderSwitch "Switch signal which indicates the position of the ASR �hill holder� switch.
+
+00 - ASR �hill holder� switch passive
+01 - ASR �hill holder� switch active
+10 - Error
+11 - Not available";
+CM_ SG_ 2565865728 ASROffroadSwitch "Switch signal which indicates the position of the ASR off-road switch.
+
+00 - ASR off-road switch passive
+01 - ASR off-road switch active
+10 - Error
+11 - Not available";
+CM_ SG_ 2565865728 ABSOffroadSwitch "Switch signal which indicates the position of the ABS off-road switch.
+
+00 - ABS off-road switch passive
+01 - ABS off-road switch active
+10 - Error
+11 - Not available";
+CM_ SG_ 2565865728 BrakePedalPos "Ratio of brake pedal position to maximum pedal position.  Used for electric brake applications. 0% means no braking. Also when there are two brake pedals on the machine (Left Brake Pedal Position SPN 3033 and Right Brake Pedal Position SPN 3032) the ...";
+CM_ SG_ 2565865728 EBSBrakeSwitch "Switch signal which indicates that the brake pedal is being pressed.  The EBS brake switch is independent of the brake light switch and has no provisions for external connections.
+00 - Brake pedal is not being pressed
+01 - Brake pedal is being ...";
+CM_ SG_ 2565865728 AntiLockBrakingActive "State signal which indicates that the ABS is active.  The signal is set active when wheel brake pressure actually starts to be modulated by ABS and is reset to passive when all wheels are in a stable condition for a certain time.  The signal can ...";
+CM_ SG_ 2565865728 ASRBrakeCtrlActive "State signal which indicates that ASR brake control is active. Active means that ASR actually controls wheel brake pressure at one or more wheels of the driven axle(s).
+00 - ASR brake control passive but installed
+01 - ASR brake control active
+10 ...";
+CM_ SG_ 2565865728 ASREngCtrlActive "State signal which indicates that ASR engine control has been commanded to be active. Active means that ASR actually tries to control the engine. This state signal is independent of other control commands to the engine (e.g., from the transmission) ...";
+CM_ BO_ 2566804992 "Aftertreatment 1 Diesel Exhaust Fluid Tank 1 Information 1
+Contains information on various tank levels";
+CM_ SG_ 2566804992 HtrPreliminaryFMI "Used to identify the applicable J1939-73 FMI detected for the heater of the diesel exhaust fluid tank for aftertreatment system 1 (exhaust bank 1), as detected by the manufacturer's control software.  When there is no failure, FMI 31 is sent. In the ...";
+CM_ SG_ 2566804992 Htr "Percentage of heating applied to the aftertreatment 1 diesel exhaust fluid tank heater.  A value of 0% means no heating applied, a value of 100% means full heating applied.  The diesel exhaust fluid tank heater warms the diesel exhaust fluid in the ...";
+CM_ SG_ 2566804992 SCROpIndSev "Severity status of the operator inducement system for anomalies with the SCR system, such as tampering, low DEF quality, and DEF tank level.  Higher numerical levels indicate more severe levels of inducement.  Level 1 is the least severe.
+000 - ...";
+CM_ SG_ 2566804992 TempPreliminaryFMI "Used to identify the applicable J1939-73 FMI detected for the diesel exhaust fluid tank temperature for aftertreatment system 1 (exhaust bank 1), as detected by the manufacturer�s control software. When there is no failure, FMI 31 is sent. In the ...";
+CM_ SG_ 2566804992 DEFTankLowLvlInd "The desired illumination of the driver's warning indicator for diesel exhaust fluid (DEF) tank low level.
+000 - Off -  indicates adequate DEF level
+e.g., for Euro VI this is used to indicate the driver warning system is non-active for diesel ...";
+CM_ SG_ 2566804992 LvlVolPreliminaryFMI "Used to identify the applicable J1939-73 FMI detected in the diesel exhaust fluid tank level sensor by the manufacturer's sensor control software.  This FMI is applicable to either the diesel exhaust fluid tank level or diesel exhaust fluid tank ...";
+CM_ SG_ 2566804992 Lvl "The diesel exhaust fluid level height in mm in the diesel exhaust fluid storage container for aftertreatment system 1 (exhaust bank 1).  See SPN 1761 and SPN 7530 for alternate measurements.
+Parameter Specific Indicator:
+A value of 0xFB indicates ...";
+CM_ SG_ 2566804992 Temp1 "Temperature of the diesel exhaust fluid in the storage tank.";
+CM_ SG_ 2566804992 Volume "Ratio of volume of diesel exhaust fluid to the total volume of diesel exhaust fluid storage container for aftertreatment system 1 (exhaust bank 1).  0% is empty and 100% is full.  See SPN 3517 and SPN 7530 for alternate measurements.
+Parameter ...";
+CM_ BO_ 2566748928 "Aftertreatment 1 Service 1
+This PGN contains information about the aftertreatment 1 (diesel particulate filter 1 soot and ash load).";
+CM_ SG_ 2566748928 DPFSootLoadRegenThreshold "This parameter indicates the value that will first cause DPF regeneration in aftertreatment 1. There may be multiple parameters that cause DPF regeneration (e.g. Percent Soot Load, DPF delta pressure converted to normalized percentage, etc.).  If ...";
+CM_ SG_ 2566748928 DPFTimeSinceLastActiveRegen "Indicates the time since the last active regeneration event of diesel particulate filter 1.";
+CM_ SG_ 2566748928 DPFAshLoadPercent "Indicates the ash load percent of diesel particulate filter 1.  100% is the level at which diesel particulate filter ash service should be performed.
+100% level is the target ash service interval (and if ash service is not immediately performed, ...";
+CM_ SG_ 2566748928 DPFSootLoadPercent "Indicates the soot load percent of diesel particulate filter 1.  100% is the level at which active diesel particulate filter regeneration should be triggered.
+100% level is the active regeneration trigger level (and if conditions are not favorable ...";
+CM_ BO_ 2365428224 "Engine Operating Information
+Contains engine parameters related to operation.";
+CM_ SG_ 2365428224 EngDesiredTorqueRq "This is the torque that the ECM desires to provide. It is a request made from the ECM to an external system. A valid value within the operating range indicates the engine is requesting an external controller to change the operation of the system so ...";
+CM_ SG_ 2365428224 EngColdAmbientElevatedIdleStatus "Indicates that the engine is elevating the idle speed due to cold strategies.
+
+00 No Idle Elevation Active - standard idle speed
+01 Idle Elevation Active
+10 Reserved for SAE assignment
+11 Unavailable";
+CM_ SG_ 2365428224 EngStarterMotorRelayCtrl "Command signal used to energize or de-energize the engine starter motor relay.
+
+00 Off
+01 On
+10 Reserved for SAE assignment
+11 Don't care/take no action";
+CM_ SG_ 2365428224 EngDerateRq "This parameter is a derate request made from the engine control system to an external system, where the engine is requesting an external device to reduce the load being applied.  A zero value indicates that there is no derate being requested and ...";
+CM_ SG_ 2365428224 EngEmergencyShutdownIndication "A signal issued by the engine control system to a user or external system indicating that it is immediately shutting the engine down.  This indication is made when engine protection diagnostics determine a condition necessitates an immediate ...";
+CM_ SG_ 2365428224 EngControlledShutdownRq "A signal issued by the engine control system to a user or external system requesting for a controlled shutdown.  This request is made when engine protection diagnostics determine a condition warrants a shutdown soon, but it is not severe enough to ...";
+CM_ SG_ 2365428224 EngCoolantCirculatingPumpCtrl "Control setting for an electrically actuated engine coolant circulating pump. 
+
+00 = Off
+01 = On
+10 = Reserved
+11 = Don't care / take no action
+.";
+CM_ SG_ 2365428224 EngBlock_CoolantPreheaterCtrl "Control setting for an electrically actuated engine block or coolant pre-heating device.
+
+00 - Off 
+01 - On
+10 - Reserved
+11 - Unavailable";
+CM_ SG_ 2365428224 EngElctrclSystmPwrCnsrvationCtrl "Control setting for cutting power to various devices when the engine is not in use.  Useful if it is desired to keep the engine in standby, with main control ECU still powered on and communictaing with outside world, but actuators and certain other ...";
+CM_ SG_ 2365428224 EngOilPreheaterCtrl "Control setting for an electrically actuated oil pre-heating device.
+00 = Off
+01 = On
+10 = Reserved
+11 = Don't care / take no action
+In addition to communicating desired action of the electrically actuated oil pre-heater and its driver status, ...";
+CM_ SG_ 2365428224 EngOilPrimingPumpCtrl "This control is used to activate a pump that lubricates the engine, particularly prior to initial engine startup.
+
+00 = Off
+01 = On
+10 = Reserved
+11 = unavailable";
+CM_ SG_ 2365428224 EngFuelShutoffValveLeakTestCtrl "Control setting for fuel shutoff valve proving system test.  Typically, this type of system can only be used with a dual fuel shutoff system.  The test consists of a small pump to pressurize the chamber between the dual fuel shutoffs when they are ...";
+CM_ SG_ 2365428224 EngFuelShutoff2Ctrl "Control setting for fuel shutoff 2.  First instance is SPN 632.  For a dual fuel shutoff system, this SPN is representative of the downstream fuel shutoff commanded position.  When fuel (gas) is desired at the engine, the fuel shutoff is opened ...";
+CM_ SG_ 2365428224 EngFuelShutoff1Ctrl "Control setting for fuel shutoff 1.  The second instance is SPN 2807.  For a single fuel shutoff system, this represents its commanded position.  For a dual fuel shutoff system, this SPN is representative of the upstream fuel shutoff commanded ...";
+CM_ SG_ 2365428224 EngFuelShutoffVentCtrl "Control setting for a fuel shutoff vent.  Typically, for a dual fuel shutoff system, the vent line is located between them and is plumbed to vent outside to atmosphere.  The vent control typically always actuates opposite to that of the fuel ...";
+CM_ SG_ 2365428224 TimeRemainingInEngOperatingState "This parameter is used to indicate the time remaining in the current engine operating state, based on the state defined in the SPN \"Engine Operating State\" (SPN 3543). For the states in which time remaining is not applicable, use 65535 ($FFFF).";
+CM_ SG_ 2365428224 FuelPumpPrimerCtrl "Parameter used to activate or deactivate a priming system on the fuel transfer system. The fuel priming system is a system that purges air in the fuel lines and may assist fuel delivery to a second pump at lower speeds.
+00 = Deactivate
+01 = ...";
+CM_ SG_ 2365428224 EngOperatingState "This parameter is used to indicate the current state, or mode, of operation by the engine.  This is a status parameter.
+Bit state 0000 = Engine Stopped
+Bit state 0001 = Pre-Start
+Bit state 0010 = Starting
+Bit state 0011 = Warm-Up
+Bit state 0100 ...";
+CM_ BO_ 2365492224 "Auxiliary Analog Information
+Auxiliary Analog Information";
+CM_ SG_ 2365492224 RelativeHumidity "Measures humidity of combustion air prior to entry into turbocharger";
+CM_ SG_ 2365492224 AuxLevel "Level measured by a sensor.";
+CM_ SG_ 2365492224 AuxPress2 "Pressure measured by auxiliary pressure sensor #2.  Not to be used in place of existing SPNs.";
+CM_ SG_ 2365492224 AuxPress1 "Pressure measured by auxiliary pressure sensor #1.  Not to be used in place of existing SPNs.";
+CM_ SG_ 2365492224 AuxTemp2 "Temperature measured by auxiliary temperature sensor #2.  Not to be used in place of existing SPNs.";
+CM_ SG_ 2365492224 AuxTemp1 "Temperature measured by auxiliary temperature sensor #1.  Not to be used in place of existing SPNs.";
+CM_ BO_ 2365519616 "Vehicle Electrical Power 1";
+CM_ SG_ 2365519616 KeyswitchBatteryPotential "Battery potential measured at the input of the electronic control unit supplied through a key switch or similar switching device.";
+CM_ SG_ 2365519616 BatteryPotential_PowerInput1 "This parameter measures the first source of battery potential as measured at the input of the ECU/actuator etc. coming from one or more batteries, irrespective of the distance between the component and the battery.  This SPN is also used when ECUs ...";
+CM_ SG_ 2365519616 ChargingSystemPotential "Electrical potential measured at the charging system output.  The charging system may be any device charging the batteries.  This includes alternators, generators, solid state charger and other charging devices.";
+CM_ SG_ 2365519616 AltCurrent "Measure of electrical current flow from the alternator.  Alternator Current (High Range/Resolution) parameter SPN 1795 has a higher range and resolution of the same parameter.";
+CM_ SG_ 2365519616 NetBatteryCurrent "Net flow of electrical current into/out of the first battery or first set of batteries used for starting the engine, for lighting, and for ignition (SLI). See SPN 2579 for alternate range and resolution.";
+BA_DEF_  "DBName" STRING ;
+BA_DEF_ SG_  "GenSigInactiveValue" INT 0 0;
+BA_DEF_ SG_  "SigType" ENUM  "Default","Range","RangeSigned","ASCII","Discrete","Control","ReferencePGN","DTC","StringDelimiter","StringLength","StringLengthControl","MessageCounter","MessageChecksum";
+BA_DEF_ SG_  "GenSigStartValue" INT 0 2147483647;
+BA_DEF_ SG_  "GenSigSendType" ENUM  "Cyclic","OnWrite","OnWriteWithRepetition","OnChange","OnChangeWithRepetition","IfActive","IfActiveWithRepetition","NoSigSendType";
+BA_DEF_ SG_  "GenSigILSupport" ENUM  "No","Yes";
+BA_DEF_ SG_  "GenSigEVName" STRING ;
+BA_DEF_ SG_  "SPN" INT 0 524287;
+BA_DEF_ BO_  "TpJ1939VarDlc" ENUM  "No","Yes";
+BA_DEF_ BO_  "GenMsgNrOfRepetition" INT 0 1000000;
+BA_DEF_ BO_  "GenMsgCycleTimeFast" INT 0 3600000;
+BA_DEF_ BO_  "GenMsgFastOnStart" INT 0 100000;
+BA_DEF_ BO_  "GenMsgStartDelayTime" INT 0 100000;
+BA_DEF_ BO_  "GenMsgILSupport" ENUM  "No","Yes";
+BA_DEF_ BO_  "GenMsgDelayTime" INT 0 1000;
+BA_DEF_ BO_  "GenMsgRequestable" INT 0 1;
+BA_DEF_ BO_  "GenMsgSendType" ENUM  "cyclic","NotUsed","NotUsed","NotUsed","NotUsed","NotUsed","NotUsed","IfActive","noMsgSendType";
+BA_DEF_ BO_  "VFrameFormat" ENUM  "StandardCAN","ExtendedCAN","reserved","J1939PG";
+BA_DEF_ BO_  "GenMsgCycleTime" INT 0 3600000;
+BA_DEF_ BU_  "NodeLayerModules" STRING ;
+BA_DEF_ BU_  "NmStationAddress" INT 0 255;
+BA_DEF_ BU_  "NmJ1939AAC" INT 0 1;
+BA_DEF_ BU_  "NmJ1939IndustryGroup" INT 0 7;
+BA_DEF_ BU_  "NmJ1939System" INT 0 127;
+BA_DEF_ BU_  "NmJ1939SystemInstance" INT 0 15;
+BA_DEF_ BU_  "NmJ1939Function" INT 0 255;
+BA_DEF_ BU_  "NmJ1939FunctionInstance" INT 0 7;
+BA_DEF_ BU_  "NmJ1939ECUInstance" INT 0 3;
+BA_DEF_ BU_  "NmJ1939ManufacturerCode" INT 0 2047;
+BA_DEF_ BU_  "NmJ1939IdentityNumber" INT 0 2097151;
+BA_DEF_ BU_  "ECU" STRING ;
+BA_DEF_  "SAE_J1939_DA_SpecVersion" STRING ;
+BA_DEF_  "SAE_J1939_81_SpecVersion" STRING ;
+BA_DEF_  "DatabaseVersion" STRING ;
+BA_DEF_  "BusType" STRING ;
+BA_DEF_  "ProtocolType" STRING ;
+BA_DEF_  "SAE_J1939_75_SpecVersion" STRING ;
+BA_DEF_  "SAE_J1939_21_SpecVersion" STRING ;
+BA_DEF_  "SAE_J1939_73_SpecVersion" STRING ;
+BA_DEF_  "SAE_J1939_71_SpecVersion" STRING ;
+BA_DEF_ BO_  "CanDootDecode" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootDecodeBus" INT 0 6;
+BA_DEF_ BO_  "CanDootPaused" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulate" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulateBus" INT 0 6;
+BA_DEF_ BO_  "CanDootSimulateCycleTime" INT 0 50000;
+BA_DEF_ SG_  "CanDootGroup" ENUM  "None","g1","g2","g3","g4","g5","g6","g7","g8","g9","gA","gB","gC","gD","gE","gF";
+BA_DEF_ SG_  "CanDootHidden" ENUM  "No","Yes";
+BA_DEF_ SG_  "CanDootBroadcast" ENUM  "No","Yes";
+BA_DEF_DEF_  "DBName" "";
+BA_DEF_DEF_  "GenSigInactiveValue" 0;
+BA_DEF_DEF_  "SigType" "Default";
+BA_DEF_DEF_  "GenSigStartValue" 0;
+BA_DEF_DEF_  "GenSigSendType" "NoSigSendType";
+BA_DEF_DEF_  "GenSigILSupport" "Yes";
+BA_DEF_DEF_  "GenSigEVName" "Env@Nodename_@Signame";
+BA_DEF_DEF_  "SPN" 0;
+BA_DEF_DEF_  "TpJ1939VarDlc" "No";
+BA_DEF_DEF_  "GenMsgNrOfRepetition" 0;
+BA_DEF_DEF_  "GenMsgCycleTimeFast" 0;
+BA_DEF_DEF_  "GenMsgFastOnStart" 0;
+BA_DEF_DEF_  "GenMsgStartDelayTime" 0;
+BA_DEF_DEF_  "GenMsgILSupport" "Yes";
+BA_DEF_DEF_  "GenMsgDelayTime" 0;
+BA_DEF_DEF_  "GenMsgRequestable" 1;
+BA_DEF_DEF_  "GenMsgSendType" "noMsgSendType";
+BA_DEF_DEF_  "VFrameFormat" "J1939PG";
+BA_DEF_DEF_  "GenMsgCycleTime" 0;
+BA_DEF_DEF_  "NodeLayerModules" "";
+BA_DEF_DEF_  "NmStationAddress" 254;
+BA_DEF_DEF_  "NmJ1939AAC" 0;
+BA_DEF_DEF_  "NmJ1939IndustryGroup" 0;
+BA_DEF_DEF_  "NmJ1939System" 0;
+BA_DEF_DEF_  "NmJ1939SystemInstance" 0;
+BA_DEF_DEF_  "NmJ1939Function" 0;
+BA_DEF_DEF_  "NmJ1939FunctionInstance" 0;
+BA_DEF_DEF_  "NmJ1939ECUInstance" 0;
+BA_DEF_DEF_  "NmJ1939ManufacturerCode" 0;
+BA_DEF_DEF_  "NmJ1939IdentityNumber" 0;
+BA_DEF_DEF_  "ECU" "";
+BA_DEF_DEF_  "SAE_J1939_DA_SpecVersion" "";
+BA_DEF_DEF_  "SAE_J1939_81_SpecVersion" "";
+BA_DEF_DEF_  "DatabaseVersion" "";
+BA_DEF_DEF_  "BusType" "";
+BA_DEF_DEF_  "ProtocolType" "";
+BA_DEF_DEF_  "SAE_J1939_75_SpecVersion" "";
+BA_DEF_DEF_  "SAE_J1939_21_SpecVersion" "";
+BA_DEF_DEF_  "SAE_J1939_73_SpecVersion" "";
+BA_DEF_DEF_  "SAE_J1939_71_SpecVersion" "";
+BA_DEF_DEF_  "CanDootDecode" "Yes";
+BA_DEF_DEF_  "CanDootDecodeBus" 1;
+BA_DEF_DEF_  "CanDootPaused" "No";
+BA_DEF_DEF_  "CanDootSimulate" "No";
+BA_DEF_DEF_  "CanDootSimulateBus" 1;
+BA_DEF_DEF_  "CanDootSimulateCycleTime" 100;
+BA_DEF_DEF_  "CanDootGroup" "None";
+BA_DEF_DEF_  "CanDootHidden" "No";
+BA_DEF_DEF_  "CanDootBroadcast" "Yes";
+BA_ "SAE_J1939_DA_SpecVersion" "2015-01";
+BA_ "SAE_J1939_81_SpecVersion" "2012-05";
+BA_ "DatabaseVersion" "8.5";
+BA_ "BusType" "CAN";
+BA_ "ProtocolType" "J1939";
+BA_ "SAE_J1939_75_SpecVersion" "2012-05";
+BA_ "SAE_J1939_21_SpecVersion" "2006-10";
+BA_ "SAE_J1939_73_SpecVersion" "2012-10";
+BA_ "SAE_J1939_71_SpecVersion" "2012-10";
+BA_ "DBName" "J1939";
+BA_ "NmStationAddress" BU_ PowertrainControlModule 90;
+BA_ "NmStationAddress" BU_ AtmosphericSensor 89;
+BA_ "NmJ1939Function" BU_ AtmosphericSensor 76;
+BA_ "NmStationAddress" BU_ SafetyRestraintSystem2 88;
+BA_ "NmJ1939IndustryGroup" BU_ SafetyRestraintSystem2 0;
+BA_ "NmJ1939System" BU_ SafetyRestraintSystem2 0;
+BA_ "NmJ1939Function" BU_ SafetyRestraintSystem2 132;
+BA_ "NmJ1939FunctionInstance" BU_ SafetyRestraintSystem2 1;
+BA_ "NmStationAddress" BU_ Aftertreatment_2_GasOutlet 87;
+BA_ "NmJ1939Function" BU_ Aftertreatment_2_GasOutlet 68;
+BA_ "NmJ1939FunctionInstance" BU_ Aftertreatment_2_GasOutlet 1;
+BA_ "NmJ1939ECUInstance" BU_ Aftertreatment_2_GasOutlet 1;
+BA_ "NmStationAddress" BU_ Aftertreatment_2_GasIntake 86;
+BA_ "NmJ1939Function" BU_ Aftertreatment_2_GasIntake 68;
+BA_ "NmJ1939FunctionInstance" BU_ Aftertreatment_2_GasIntake 1;
+BA_ "NmJ1939ECUInstance" BU_ Aftertreatment_2_GasIntake 0;
+BA_ "NmStationAddress" BU_ DieselParticulateFilterControl 85;
+BA_ "NmJ1939Function" BU_ DieselParticulateFilterControl 69;
+BA_ "NmStationAddress" BU_ Turbocharger 2;
+BA_ "NmJ1939IndustryGroup" BU_ Turbocharger 0;
+BA_ "NmJ1939System" BU_ Turbocharger 0;
+BA_ "NmJ1939Function" BU_ Turbocharger 133;
+BA_ "NmStationAddress" BU_ SafetyRestraintSystem1 83;
+BA_ "NmJ1939IndustryGroup" BU_ SafetyRestraintSystem1 0;
+BA_ "NmJ1939System" BU_ SafetyRestraintSystem1 0;
+BA_ "NmJ1939Function" BU_ SafetyRestraintSystem1 132;
+BA_ "NmJ1939FunctionInstance" BU_ SafetyRestraintSystem1 0;
+BA_ "NmStationAddress" BU_ CabDisplay2 84;
+BA_ "NmJ1939Function" BU_ CabDisplay2 60;
+BA_ "NmJ1939FunctionInstance" BU_ CabDisplay2 1;
+BA_ "NmStationAddress" BU_ Aftertreatment_1_GasOutlet 82;
+BA_ "NmJ1939Function" BU_ Aftertreatment_1_GasOutlet 68;
+BA_ "NmJ1939FunctionInstance" BU_ Aftertreatment_1_GasOutlet 0;
+BA_ "NmJ1939ECUInstance" BU_ Aftertreatment_1_GasOutlet 1;
+BA_ "NmStationAddress" BU_ Aftertreatment_1_GasIntake 81;
+BA_ "NmJ1939Function" BU_ Aftertreatment_1_GasIntake 68;
+BA_ "NmJ1939FunctionInstance" BU_ Aftertreatment_1_GasIntake 0;
+BA_ "NmJ1939ECUInstance" BU_ Aftertreatment_1_GasIntake 0;
+BA_ "NmStationAddress" BU_ OnBoardDataLogger 251;
+BA_ "NmJ1939IndustryGroup" BU_ OnBoardDataLogger 0;
+BA_ "NmJ1939System" BU_ OnBoardDataLogger 0;
+BA_ "NmJ1939Function" BU_ OnBoardDataLogger 130;
+BA_ "NmStationAddress" BU_ OffBoardDiagnosticTool2 250;
+BA_ "NmJ1939IndustryGroup" BU_ OffBoardDiagnosticTool2 0;
+BA_ "NmJ1939System" BU_ OffBoardDiagnosticTool2 0;
+BA_ "NmJ1939Function" BU_ OffBoardDiagnosticTool2 129;
+BA_ "NmJ1939FunctionInstance" BU_ OffBoardDiagnosticTool2 1;
+BA_ "NmStationAddress" BU_ OffBoardDiagnosticTool1 249;
+BA_ "NmJ1939IndustryGroup" BU_ OffBoardDiagnosticTool1 0;
+BA_ "NmJ1939System" BU_ OffBoardDiagnosticTool1 0;
+BA_ "NmJ1939Function" BU_ OffBoardDiagnosticTool1 129;
+BA_ "NmJ1939FunctionInstance" BU_ OffBoardDiagnosticTool1 0;
+BA_ "NmStationAddress" BU_ FileServer 248;
+BA_ "NmJ1939Function" BU_ FileServer 61;
+BA_ "NmStationAddress" BU_ ParkingBrakeController 80;
+BA_ "NmJ1939Function" BU_ ParkingBrakeController 9;
+BA_ "NmJ1939FunctionInstance" BU_ ParkingBrakeController 1;
+BA_ "NmStationAddress" BU_ SeatController2 79;
+BA_ "NmJ1939Function" BU_ SeatController2 40;
+BA_ "NmJ1939FunctionInstance" BU_ SeatController2 1;
+BA_ "NmStationAddress" BU_ FanDriveController 78;
+BA_ "NmJ1939Function" BU_ FanDriveController 58;
+BA_ "NmStationAddress" BU_ SteeringColumnUnit 77;
+BA_ "NmJ1939Function" BU_ SteeringColumnUnit 57;
+BA_ "NmStationAddress" BU_ CommunicationUnitRadio 76;
+BA_ "NmJ1939Function" BU_ CommunicationUnitRadio 56;
+BA_ "NmStationAddress" BU_ CommunicationUnitSatellite 75;
+BA_ "NmJ1939Function" BU_ CommunicationUnitSatellite 55;
+BA_ "NmStationAddress" BU_ CommunicationUnitCellular 74;
+BA_ "NmJ1939Function" BU_ CommunicationUnitCellular 54;
+BA_ "NmStationAddress" BU_ PropulsionBatteryCharger 73;
+BA_ "NmJ1939Function" BU_ PropulsionBatteryCharger 31;
+BA_ "NmStationAddress" BU_ ChassisController2 72;
+BA_ "NmJ1939Function" BU_ ChassisController2 52;
+BA_ "NmJ1939FunctionInstance" BU_ ChassisController2 1;
+BA_ "NmStationAddress" BU_ ChassisController1 71;
+BA_ "NmJ1939Function" BU_ ChassisController1 52;
+BA_ "NmJ1939FunctionInstance" BU_ ChassisController1 0;
+BA_ "NmStationAddress" BU_ EngineValveControl 70;
+BA_ "NmJ1939Function" BU_ EngineValveControl 63;
+BA_ "NmStationAddress" BU_ AuxiliaryHeater2 69;
+BA_ "NmJ1939Function" BU_ AuxiliaryHeater2 50;
+BA_ "NmJ1939FunctionInstance" BU_ AuxiliaryHeater2 1;
+BA_ "NmStationAddress" BU_ AuxiliaryHeater1 68;
+BA_ "NmJ1939Function" BU_ AuxiliaryHeater1 50;
+BA_ "NmJ1939FunctionInstance" BU_ AuxiliaryHeater1 0;
+BA_ "NmStationAddress" BU_ ClutchUnit 67;
+BA_ "NmJ1939Function" BU_ ClutchUnit 49;
+BA_ "NmStationAddress" BU_ RampControl 66;
+BA_ "NmJ1939Function" BU_ RampControl 48;
+BA_ "NmStationAddress" BU_ InformationSystem1 65;
+BA_ "NmJ1939Function" BU_ InformationSystem1 47;
+BA_ "NmStationAddress" BU_ SuspensionSystemController2 64;
+BA_ "NmJ1939Function" BU_ SuspensionSystemController2 35;
+BA_ "NmJ1939FunctionInstance" BU_ SuspensionSystemController2 1;
+BA_ "NmStationAddress" BU_ OilSensor 63;
+BA_ "NmJ1939Function" BU_ OilSensor 46;
+BA_ "NmStationAddress" BU_ VehicleDynamicStability 62;
+BA_ "NmJ1939Function" BU_ VehicleDynamicStability 45;
+BA_ "NmStationAddress" BU_ ExhaustEmissionController 61;
+BA_ "NmJ1939Function" BU_ ExhaustEmissionController 44;
+BA_ "NmStationAddress" BU_ TransmissionDisplay2 60;
+BA_ "NmJ1939Function" BU_ TransmissionDisplay2 43;
+BA_ "NmJ1939FunctionInstance" BU_ TransmissionDisplay2 1;
+BA_ "NmStationAddress" BU_ TransmissionDisplay1 59;
+BA_ "NmJ1939Function" BU_ TransmissionDisplay1 43;
+BA_ "NmJ1939FunctionInstance" BU_ TransmissionDisplay1 0;
+BA_ "NmStationAddress" BU_ ClimateControl2 58;
+BA_ "NmJ1939Function" BU_ ClimateControl2 21;
+BA_ "NmJ1939FunctionInstance" BU_ ClimateControl2 1;
+BA_ "NmStationAddress" BU_ WaterPumpController 57;
+BA_ "NmJ1939Function" BU_ WaterPumpController 42;
+BA_ "NmStationAddress" BU_ RearAxleSteeringController 56;
+BA_ "NmJ1939Function" BU_ RearAxleSteeringController 16;
+BA_ "NmJ1939FunctionInstance" BU_ RearAxleSteeringController 1;
+BA_ "NmStationAddress" BU_ LightingOperatorControl 55;
+BA_ "NmJ1939Function" BU_ LightingOperatorControl 41;
+BA_ "NmStationAddress" BU_ SeatController1 54;
+BA_ "NmJ1939Function" BU_ SeatController1 40;
+BA_ "NmJ1939FunctionInstance" BU_ SeatController1 0;
+BA_ "NmStationAddress" BU_ IgnitionController2 53;
+BA_ "NmJ1939Function" BU_ IgnitionController2 39;
+BA_ "NmJ1939FunctionInstance" BU_ IgnitionController2 1;
+BA_ "NmStationAddress" BU_ IgnitionController1 52;
+BA_ "NmJ1939Function" BU_ IgnitionController1 39;
+BA_ "NmJ1939FunctionInstance" BU_ IgnitionController1 0;
+BA_ "NmStationAddress" BU_ TirePressureController 51;
+BA_ "NmJ1939Function" BU_ TirePressureController 38;
+BA_ "NmStationAddress" BU_ CabController2 50;
+BA_ "NmJ1939Function" BU_ CabController2 37;
+BA_ "NmJ1939FunctionInstance" BU_ CabController2 1;
+BA_ "NmStationAddress" BU_ CabController1 49;
+BA_ "NmJ1939Function" BU_ CabController1 37;
+BA_ "NmJ1939FunctionInstance" BU_ CabController1 0;
+BA_ "NmStationAddress" BU_ PneumaticSystemController 48;
+BA_ "NmJ1939Function" BU_ PneumaticSystemController 36;
+BA_ "NmStationAddress" BU_ SuspensionSystemController1 47;
+BA_ "NmJ1939Function" BU_ SuspensionSystemController1 35;
+BA_ "NmJ1939FunctionInstance" BU_ SuspensionSystemController1 0;
+BA_ "NmStationAddress" BU_ HydraulicPumpController 46;
+BA_ "NmJ1939Function" BU_ HydraulicPumpController 34;
+BA_ "NmStationAddress" BU_ EnduranceBrakingSystem 45;
+BA_ "NmJ1939Function" BU_ EnduranceBrakingSystem 64;
+BA_ "NmStationAddress" BU_ RetarderExhaustEngine2 44;
+BA_ "NmJ1939Function" BU_ RetarderExhaustEngine2 12;
+BA_ "NmJ1939FunctionInstance" BU_ RetarderExhaustEngine2 1;
+BA_ "NmStationAddress" BU_ OnBoardDiagnosticUnit 43;
+BA_ "NmJ1939Function" BU_ OnBoardDiagnosticUnit 62;
+BA_ "NmStationAddress" BU_ HeadwayController 42;
+BA_ "NmJ1939Function" BU_ HeadwayController 32;
+BA_ "NmStationAddress" BU_ RetarderExhaustEngine1 41;
+BA_ "NmJ1939Function" BU_ RetarderExhaustEngine1 12;
+BA_ "NmJ1939FunctionInstance" BU_ RetarderExhaustEngine1 0;
+BA_ "NmStationAddress" BU_ CabDisplay1 40;
+BA_ "NmJ1939Function" BU_ CabDisplay1 60;
+BA_ "NmJ1939FunctionInstance" BU_ CabDisplay1 0;
+BA_ "NmStationAddress" BU_ ManagementComputer 39;
+BA_ "NmJ1939Function" BU_ ManagementComputer 30;
+BA_ "NmStationAddress" BU_ VirtualTerminal 38;
+BA_ "NmJ1939Function" BU_ VirtualTerminal 29;
+BA_ "NmStationAddress" BU_ OffVehicleGateway 37;
+BA_ "NmJ1939Function" BU_ OffVehicleGateway 28;
+BA_ "NmStationAddress" BU_ PowerTakeOffFront 36;
+BA_ "NmJ1939Function" BU_ PowerTakeOffFront 27;
+BA_ "NmStationAddress" BU_ HitchControl 35;
+BA_ "NmStationAddress" BU_ AuxiliaryValveControl 34;
+BA_ "NmJ1939IndustryGroup" BU_ AuxiliaryValveControl 2;
+BA_ "NmJ1939System" BU_ AuxiliaryValveControl 1;
+BA_ "NmJ1939Function" BU_ AuxiliaryValveControl 129;
+BA_ "NmStationAddress" BU_ BodyController 33;
+BA_ "NmJ1939Function" BU_ BodyController 26;
+BA_ "NmStationAddress" BU_ TractorTrailerBridge1 32;
+BA_ "NmJ1939Function" BU_ TractorTrailerBridge1 25;
+BA_ "NmStationAddress" BU_ StarterSystem 31;
+BA_ "NmJ1939Function" BU_ StarterSystem 59;
+BA_ "NmStationAddress" BU_ ElectricalSystem 30;
+BA_ "NmJ1939Function" BU_ ElectricalSystem 67;
+BA_ "NmStationAddress" BU_ VehicleSecurity 29;
+BA_ "NmJ1939Function" BU_ VehicleSecurity 24;
+BA_ "NmStationAddress" BU_ VehicleNavigation 28;
+BA_ "NmJ1939Function" BU_ VehicleNavigation 23;
+BA_ "NmStationAddress" BU_ AerodynamicControl 27;
+BA_ "NmJ1939Function" BU_ AerodynamicControl 22;
+BA_ "NmStationAddress" BU_ ElectricalChargingSystem 26;
+BA_ "NmJ1939Function" BU_ ElectricalChargingSystem 53;
+BA_ "NmStationAddress" BU_ ClimateControl1 25;
+BA_ "NmJ1939Function" BU_ ClimateControl1 21;
+BA_ "NmJ1939FunctionInstance" BU_ ClimateControl1 0;
+BA_ "NmStationAddress" BU_ TripRecorder 24;
+BA_ "NmJ1939Function" BU_ TripRecorder 20;
+BA_ "NmStationAddress" BU_ InstrumentCluster 23;
+BA_ "NmJ1939Function" BU_ InstrumentCluster 19;
+BA_ "NmStationAddress" BU_ SuspensionDriveAxle2 22;
+BA_ "NmJ1939Function" BU_ SuspensionDriveAxle2 18;
+BA_ "NmJ1939FunctionInstance" BU_ SuspensionDriveAxle2 1;
+BA_ "NmStationAddress" BU_ SuspensionDriveAxle1 21;
+BA_ "NmJ1939Function" BU_ SuspensionDriveAxle1 18;
+BA_ "NmJ1939FunctionInstance" BU_ SuspensionDriveAxle1 0;
+BA_ "NmStationAddress" BU_ SuspensionSteerAxle 20;
+BA_ "NmJ1939Function" BU_ SuspensionSteerAxle 17;
+BA_ "NmStationAddress" BU_ SteeringController 19;
+BA_ "NmJ1939Function" BU_ SteeringController 16;
+BA_ "NmJ1939FunctionInstance" BU_ SteeringController 0;
+BA_ "NmStationAddress" BU_ FuelSystem 18;
+BA_ "NmJ1939Function" BU_ FuelSystem 15;
+BA_ "NmStationAddress" BU_ CruiseControl 17;
+BA_ "NmJ1939Function" BU_ CruiseControl 14;
+BA_ "NmStationAddress" BU_ RetarderDriveline 16;
+BA_ "NmJ1939Function" BU_ RetarderDriveline 13;
+BA_ "NmStationAddress" BU_ RetarderEngine 15;
+BA_ "NmJ1939Function" BU_ RetarderEngine 12;
+BA_ "NmStationAddress" BU_ BrakesDriveAxle2 14;
+BA_ "NmJ1939Function" BU_ BrakesDriveAxle2 11;
+BA_ "NmJ1939FunctionInstance" BU_ BrakesDriveAxle2 1;
+BA_ "NmStationAddress" BU_ BrakesDriveAxle1 13;
+BA_ "NmJ1939Function" BU_ BrakesDriveAxle1 11;
+BA_ "NmJ1939FunctionInstance" BU_ BrakesDriveAxle1 0;
+BA_ "NmStationAddress" BU_ BrakesSystemController 11;
+BA_ "NmJ1939Function" BU_ BrakesSystemController 9;
+BA_ "NmJ1939FunctionInstance" BU_ BrakesSystemController 0;
+BA_ "NmStationAddress" BU_ BrakesSteerAxle 12;
+BA_ "NmJ1939Function" BU_ BrakesSteerAxle 10;
+BA_ "NmStationAddress" BU_ AxleDrive2 10;
+BA_ "NmJ1939Function" BU_ AxleDrive2 8;
+BA_ "NmJ1939FunctionInstance" BU_ AxleDrive2 1;
+BA_ "NmStationAddress" BU_ AxleDrive1 9;
+BA_ "NmJ1939Function" BU_ AxleDrive1 8;
+BA_ "NmJ1939FunctionInstance" BU_ AxleDrive1 0;
+BA_ "NmStationAddress" BU_ AxleSteering 8;
+BA_ "NmJ1939Function" BU_ AxleSteering 7;
+BA_ "NmStationAddress" BU_ PowerTakeOff 7;
+BA_ "NmJ1939Function" BU_ PowerTakeOff 6;
+BA_ "NmStationAddress" BU_ ShiftConsoleSecondary 6;
+BA_ "NmJ1939Function" BU_ ShiftConsoleSecondary 5;
+BA_ "NmJ1939FunctionInstance" BU_ ShiftConsoleSecondary 1;
+BA_ "NmStationAddress" BU_ ShiftConsolePrimary 5;
+BA_ "NmJ1939Function" BU_ ShiftConsolePrimary 5;
+BA_ "NmJ1939FunctionInstance" BU_ ShiftConsolePrimary 0;
+BA_ "NmStationAddress" BU_ Transmission2 4;
+BA_ "NmJ1939Function" BU_ Transmission2 3;
+BA_ "NmJ1939FunctionInstance" BU_ Transmission2 1;
+BA_ "NmStationAddress" BU_ Transmission1 3;
+BA_ "NmJ1939Function" BU_ Transmission1 3;
+BA_ "NmJ1939FunctionInstance" BU_ Transmission1 0;
+BA_ "NmStationAddress" BU_ Engine2 1;
+BA_ "NmJ1939Function" BU_ Engine2 0;
+BA_ "NmJ1939FunctionInstance" BU_ Engine2 1;
+BA_ "NmStationAddress" BU_ Engine1 0;
+BA_ "NmJ1939Function" BU_ Engine1 0;
+BA_ "NmJ1939FunctionInstance" BU_ Engine1 0;
+BA_ "CanDootPaused" BO_ 2566699264 0;
+BA_ "CanDootDecode" BO_ 2566699264 1;
+BA_ "CanDootDecodeBus" BO_ 2566699264 2;
+BA_ "CanDootSimulate" BO_ 2566699264 0;
+BA_ "CanDootSimulateBus" BO_ 2566699264 2;
+BA_ "VFrameFormat" BO_ 2566699264 3;
+BA_ "GenMsgDelayTime" BO_ 2566749184 100;
+BA_ "GenMsgSendType" BO_ 2566749184 0;
+BA_ "GenMsgCycleTime" BO_ 2566749184 1000;
+BA_ "CanDootPaused" BO_ 2566749184 0;
+BA_ "CanDootDecode" BO_ 2566749184 1;
+BA_ "CanDootDecodeBus" BO_ 2566749184 2;
+BA_ "CanDootSimulate" BO_ 2566749184 0;
+BA_ "CanDootSimulateBus" BO_ 2566749184 2;
+BA_ "VFrameFormat" BO_ 2566749184 3;
+BA_ "GenMsgSendType" BO_ 2365519360 0;
+BA_ "GenMsgCycleTime" BO_ 2365519360 5000;
+BA_ "CanDootPaused" BO_ 2365519360 0;
+BA_ "CanDootDecode" BO_ 2365519360 1;
+BA_ "CanDootDecodeBus" BO_ 2365519360 2;
+BA_ "CanDootSimulate" BO_ 2365519360 0;
+BA_ "CanDootSimulateBus" BO_ 2365519360 2;
+BA_ "VFrameFormat" BO_ 2365519360 3;
+BA_ "CanDootPaused" BO_ 2365515008 0;
+BA_ "CanDootDecode" BO_ 2365515008 1;
+BA_ "CanDootDecodeBus" BO_ 2365515008 2;
+BA_ "CanDootSimulate" BO_ 2365515008 0;
+BA_ "CanDootSimulateBus" BO_ 2365515008 2;
+BA_ "VFrameFormat" BO_ 2365515008 3;
+BA_ "GenMsgSendType" BO_ 2348810288 0;
+BA_ "GenMsgCycleTime" BO_ 2348810288 10;
+BA_ "CanDootPaused" BO_ 2348810288 0;
+BA_ "CanDootDecode" BO_ 2348810288 1;
+BA_ "CanDootDecodeBus" BO_ 2348810288 2;
+BA_ "CanDootSimulate" BO_ 2348810288 0;
+BA_ "CanDootSimulateBus" BO_ 2348810288 2;
+BA_ "VFrameFormat" BO_ 2348810288 3;
+BA_ "GenMsgSendType" BO_ 2566841344 0;
+BA_ "GenMsgCycleTime" BO_ 2566841344 1000;
+BA_ "CanDootPaused" BO_ 2566841344 0;
+BA_ "CanDootDecode" BO_ 2566841344 1;
+BA_ "CanDootDecodeBus" BO_ 2566841344 2;
+BA_ "CanDootSimulate" BO_ 2566841344 0;
+BA_ "CanDootSimulateBus" BO_ 2566841344 2;
+BA_ "VFrameFormat" BO_ 2566841344 3;
+BA_ "GenMsgSendType" BO_ 2365518336 0;
+BA_ "GenMsgCycleTime" BO_ 2365518336 100;
+BA_ "CanDootPaused" BO_ 2365518336 0;
+BA_ "CanDootDecode" BO_ 2365518336 1;
+BA_ "CanDootDecodeBus" BO_ 2365518336 2;
+BA_ "CanDootSimulate" BO_ 2365518336 0;
+BA_ "CanDootSimulateBus" BO_ 2365518336 2;
+BA_ "VFrameFormat" BO_ 2365518336 3;
+BA_ "CanDootPaused" BO_ 2365516032 0;
+BA_ "CanDootDecode" BO_ 2365516032 1;
+BA_ "CanDootDecodeBus" BO_ 2365516032 2;
+BA_ "CanDootSimulate" BO_ 2365516032 0;
+BA_ "CanDootSimulateBus" BO_ 2365516032 2;
+BA_ "VFrameFormat" BO_ 2365516032 3;
+BA_ "GenMsgSendType" BO_ 2364539392 0;
+BA_ "GenMsgCycleTime" BO_ 2364539392 10;
+BA_ "CanDootPaused" BO_ 2364539392 0;
+BA_ "CanDootDecode" BO_ 2364539392 1;
+BA_ "CanDootDecodeBus" BO_ 2364539392 2;
+BA_ "CanDootSimulate" BO_ 2364539392 0;
+BA_ "CanDootSimulateBus" BO_ 2364539392 2;
+BA_ "VFrameFormat" BO_ 2364539392 3;
+BA_ "GenMsgSendType" BO_ 2365517312 0;
+BA_ "GenMsgCycleTime" BO_ 2365517312 1000;
+BA_ "CanDootPaused" BO_ 2365517312 0;
+BA_ "CanDootDecode" BO_ 2365517312 1;
+BA_ "CanDootDecodeBus" BO_ 2365517312 2;
+BA_ "CanDootSimulate" BO_ 2365517312 0;
+BA_ "CanDootSimulateBus" BO_ 2365517312 2;
+BA_ "VFrameFormat" BO_ 2365517312 3;
+BA_ "GenMsgSendType" BO_ 2566844160 0;
+BA_ "GenMsgCycleTime" BO_ 2566844160 5000;
+BA_ "CanDootPaused" BO_ 2566844160 0;
+BA_ "CanDootDecode" BO_ 2566844160 1;
+BA_ "CanDootDecodeBus" BO_ 2566844160 2;
+BA_ "CanDootSimulate" BO_ 2566844160 0;
+BA_ "CanDootSimulateBus" BO_ 2566844160 2;
+BA_ "VFrameFormat" BO_ 2566844160 3;
+BA_ "GenMsgSendType" BO_ 2566840064 0;
+BA_ "GenMsgCycleTime" BO_ 2566840064 250;
+BA_ "CanDootPaused" BO_ 2566840064 0;
+BA_ "CanDootDecode" BO_ 2566840064 1;
+BA_ "CanDootDecodeBus" BO_ 2566840064 2;
+BA_ "CanDootSimulate" BO_ 2566840064 0;
+BA_ "CanDootSimulateBus" BO_ 2566840064 2;
+BA_ "VFrameFormat" BO_ 2566840064 3;
+BA_ "GenMsgSendType" BO_ 2364539648 0;
+BA_ "GenMsgCycleTime" BO_ 2364539648 50;
+BA_ "CanDootPaused" BO_ 2364539648 0;
+BA_ "CanDootDecode" BO_ 2364539648 1;
+BA_ "CanDootDecodeBus" BO_ 2364539648 2;
+BA_ "CanDootSimulate" BO_ 2364539648 0;
+BA_ "CanDootSimulateBus" BO_ 2364539648 2;
+BA_ "VFrameFormat" BO_ 2364539648 3;
+BA_ "CanDootPaused" BO_ 2364539904 0;
+BA_ "CanDootDecode" BO_ 2364539904 1;
+BA_ "CanDootDecodeBus" BO_ 2364539904 2;
+BA_ "CanDootSimulate" BO_ 2364539904 0;
+BA_ "CanDootSimulateBus" BO_ 2364539904 2;
+BA_ "VFrameFormat" BO_ 2364539904 3;
+BA_ "GenMsgSendType" BO_ 2565865728 0;
+BA_ "GenMsgCycleTime" BO_ 2565865728 100;
+BA_ "CanDootPaused" BO_ 2565865728 0;
+BA_ "CanDootDecode" BO_ 2565865728 1;
+BA_ "CanDootDecodeBus" BO_ 2565865728 2;
+BA_ "CanDootSimulate" BO_ 2565865728 0;
+BA_ "CanDootSimulateBus" BO_ 2565865728 2;
+BA_ "VFrameFormat" BO_ 2565865728 3;
+BA_ "GenMsgSendType" BO_ 2566804992 0;
+BA_ "GenMsgCycleTime" BO_ 2566804992 1000;
+BA_ "CanDootPaused" BO_ 2566804992 0;
+BA_ "CanDootDecode" BO_ 2566804992 1;
+BA_ "CanDootDecodeBus" BO_ 2566804992 2;
+BA_ "CanDootSimulate" BO_ 2566804992 0;
+BA_ "CanDootSimulateBus" BO_ 2566804992 2;
+BA_ "VFrameFormat" BO_ 2566804992 3;
+BA_ "CanDootPaused" BO_ 2566748928 0;
+BA_ "CanDootDecode" BO_ 2566748928 1;
+BA_ "CanDootDecodeBus" BO_ 2566748928 2;
+BA_ "CanDootSimulate" BO_ 2566748928 0;
+BA_ "CanDootSimulateBus" BO_ 2566748928 2;
+BA_ "VFrameFormat" BO_ 2566748928 3;
+BA_ "GenMsgSendType" BO_ 2365428224 0;
+BA_ "GenMsgCycleTime" BO_ 2365428224 250;
+BA_ "CanDootPaused" BO_ 2365428224 0;
+BA_ "CanDootDecode" BO_ 2365428224 1;
+BA_ "CanDootDecodeBus" BO_ 2365428224 2;
+BA_ "CanDootSimulate" BO_ 2365428224 0;
+BA_ "CanDootSimulateBus" BO_ 2365428224 2;
+BA_ "VFrameFormat" BO_ 2365428224 3;
+BA_ "CanDootPaused" BO_ 2365492224 0;
+BA_ "CanDootDecode" BO_ 2365492224 1;
+BA_ "CanDootDecodeBus" BO_ 2365492224 2;
+BA_ "CanDootSimulate" BO_ 2365492224 0;
+BA_ "CanDootSimulateBus" BO_ 2365492224 2;
+BA_ "VFrameFormat" BO_ 2365492224 3;
+BA_ "GenMsgSendType" BO_ 2365519616 0;
+BA_ "GenMsgCycleTime" BO_ 2365519616 1000;
+BA_ "CanDootPaused" BO_ 2365519616 0;
+BA_ "CanDootDecode" BO_ 2365519616 1;
+BA_ "CanDootDecodeBus" BO_ 2365519616 2;
+BA_ "CanDootSimulate" BO_ 2365519616 0;
+BA_ "CanDootSimulateBus" BO_ 2365519616 2;
+BA_ "VFrameFormat" BO_ 2365519616 3;
+BA_ "SigType" SG_ 2566699264 SCRSysTimeSinceLastSysCleanEvent 1;
+BA_ "SPN" SG_ 2566699264 SCRSysTimeSinceLastSysCleanEvent 6941;
+BA_ "SigType" SG_ 2566699264 DPFTimeToNextActiveRegen 1;
+BA_ "SPN" SG_ 2566699264 DPFTimeToNextActiveRegen 5978;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt5629 5;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt5629 5629;
+BA_ "SigType" SG_ 2566749184 AFT1DPFCondNotMetForActiveRegen 5;
+BA_ "SPN" SG_ 2566749184 AFT1DPFCondNotMetForActiveRegen 3750;
+BA_ "SigType" SG_ 2566749184 HydrocarbonDoserPurgingEnable 5;
+BA_ "SPN" SG_ 2566749184 HydrocarbonDoserPurgingEnable 5504;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnFrcdSttus 0;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnFrcdSttus 4175;
+BA_ "SigType" SG_ 2566749184 ExhaustSystemHighTempLampCmd 0;
+BA_ "SPN" SG_ 2566749184 ExhaustSystemHighTempLampCmd 3698;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrAtmtcActvRgnrtnIntt 5;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrAtmtcActvRgnrtnIntt 3718;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt3717 5;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt3717 3717;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTE 5;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTE 3716;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt3715 4;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt3715 3715;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTT 5;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTT 3714;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt3713 5;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt3713 3713;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt3712 5;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt3712 3712;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTL 4;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTL 3711;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt3710 5;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbt3710 3710;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTV 5;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTV 3709;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTO 5;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTO 3708;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTA 5;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTA 3707;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTP 5;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTP 3706;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTS 5;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTS 3705;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTC 5;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTC 3704;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTI 5;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdDTI 3703;
+BA_ "SigType" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdStt 5;
+BA_ "SPN" SG_ 2566749184 DslPrtcltFltrActvRgnrtnInhbtdStt 3702;
+BA_ "SigType" SG_ 2566749184 AFTDPFStatus 0;
+BA_ "SPN" SG_ 2566749184 AFTDPFStatus 3701;
+BA_ "SigType" SG_ 2566749184 AFTDPFActiveRegenStatus 5;
+BA_ "SPN" SG_ 2566749184 AFTDPFActiveRegenStatus 3700;
+BA_ "SigType" SG_ 2566749184 AFTDPFPassiveRegenStatus 5;
+BA_ "SPN" SG_ 2566749184 AFTDPFPassiveRegenStatus 3699;
+BA_ "SigType" SG_ 2566749184 DieselParticulateFilterLampCmd 0;
+BA_ "SPN" SG_ 2566749184 DieselParticulateFilterLampCmd 3697;
+BA_ "SigType" SG_ 2365519360 EngCoolantFilterDiffPress 1;
+BA_ "SPN" SG_ 2365519360 EngCoolantFilterDiffPress 112;
+BA_ "SigType" SG_ 2365519360 EngExhaustGasTemp 1;
+BA_ "SPN" SG_ 2365519360 EngExhaustGasTemp 173;
+BA_ "SigType" SG_ 2365519360 EngAirFilter1DiffPress 1;
+BA_ "SPN" SG_ 2365519360 EngAirFilter1DiffPress 107;
+BA_ "SigType" SG_ 2365519360 EngAirIntakePress 1;
+BA_ "SPN" SG_ 2365519360 EngAirIntakePress 106;
+BA_ "SigType" SG_ 2365519360 EngIntakeManifold1Temp 1;
+BA_ "SPN" SG_ 2365519360 EngIntakeManifold1Temp 105;
+BA_ "SigType" SG_ 2365519360 EngIntakeManifold1Press 1;
+BA_ "SPN" SG_ 2365519360 EngIntakeManifold1Press 102;
+BA_ "SigType" SG_ 2365519360 AFT1DPFInPress 1;
+BA_ "SPN" SG_ 2365519360 AFT1DPFInPress 81;
+BA_ "SigType" SG_ 2365515008 EngTotalRevolutions 1;
+BA_ "SPN" SG_ 2365515008 EngTotalRevolutions 249;
+BA_ "SigType" SG_ 2365515008 EngTotalHoursOfOperation 1;
+BA_ "SPN" SG_ 2365515008 EngTotalHoursOfOperation 247;
+BA_ "SigType" SG_ 2348810288 MessageChecksum 12;
+BA_ "SPN" SG_ 2348810288 MessageChecksum 4207;
+BA_ "SigType" SG_ 2348810288 MessageCounter 11;
+BA_ "SPN" SG_ 2348810288 MessageCounter 4206;
+BA_ "SigType" SG_ 2348810288 EngRequestedTorqueHighResolution 0;
+BA_ "SPN" SG_ 2348810288 EngRequestedTorqueHighResolution 4191;
+BA_ "SigType" SG_ 2348810288 TSC1CtrlPurpose 0;
+BA_ "SPN" SG_ 2348810288 TSC1CtrlPurpose 3350;
+BA_ "SigType" SG_ 2348810288 TSC1TransRate 0;
+BA_ "SPN" SG_ 2348810288 TSC1TransRate 3349;
+BA_ "SigType" SG_ 2348810288 EngRequestedTorque_TorqueLimit 1;
+BA_ "SPN" SG_ 2348810288 EngRequestedTorque_TorqueLimit 518;
+BA_ "SigType" SG_ 2348810288 EngRequestedSpeed_SpeedLimit 1;
+BA_ "SPN" SG_ 2348810288 EngRequestedSpeed_SpeedLimit 898;
+BA_ "SigType" SG_ 2348810288 OverrideCtrlModePriority 5;
+BA_ "SPN" SG_ 2348810288 OverrideCtrlModePriority 897;
+BA_ "SigType" SG_ 2348810288 EngRequestedSpeedCtrlConditions 5;
+BA_ "SPN" SG_ 2348810288 EngRequestedSpeedCtrlConditions 696;
+BA_ "SigType" SG_ 2348810288 EngOverrideCtrlMode 5;
+BA_ "SPN" SG_ 2348810288 EngOverrideCtrlMode 695;
+BA_ "SigType" SG_ 2566841344 ClntLvlEngPrtctionShutdownStatus 5;
+BA_ "SPN" SG_ 2566841344 ClntLvlEngPrtctionShutdownStatus 5566;
+BA_ "SigType" SG_ 2566841344 PTOShutdownHasShutdownEng 5;
+BA_ "SPN" SG_ 2566841344 PTOShutdownHasShutdownEng 5404;
+BA_ "SigType" SG_ 2566841344 EngAirShutoffStatus 5;
+BA_ "SPN" SG_ 2566841344 EngAirShutoffStatus 3667;
+BA_ "SigType" SG_ 2566841344 EngOverspeedTest 4;
+BA_ "SPN" SG_ 2566841344 EngOverspeedTest 2812;
+BA_ "SigType" SG_ 2566841344 EngAirShutoffCmdStatus 5;
+BA_ "SPN" SG_ 2566841344 EngAirShutoffCmdStatus 2813;
+BA_ "SigType" SG_ 2566841344 EngAlarmOutputCmdStatus 5;
+BA_ "SPN" SG_ 2566841344 EngAlarmOutputCmdStatus 2814;
+BA_ "SigType" SG_ 2566841344 EngAlarmAcknowledge 4;
+BA_ "SPN" SG_ 2566841344 EngAlarmAcknowledge 2815;
+BA_ "SigType" SG_ 2566841344 EngProtectionSystemConfig 5;
+BA_ "SPN" SG_ 2566841344 EngProtectionSystemConfig 1111;
+BA_ "SigType" SG_ 2566841344 EngProtectionSystemTimerState 5;
+BA_ "SPN" SG_ 2566841344 EngProtectionSystemTimerState 1107;
+BA_ "SigType" SG_ 2566841344 EngProtectionSystemTimerOverride 5;
+BA_ "SPN" SG_ 2566841344 EngProtectionSystemTimerOverride 1108;
+BA_ "SigType" SG_ 2566841344 EngPrtctnSystmApprachingShutdown 5;
+BA_ "SPN" SG_ 2566841344 EngPrtctnSystmApprachingShutdown 1109;
+BA_ "SigType" SG_ 2566841344 EngPrtectionSystemHasShutdownEng 5;
+BA_ "SPN" SG_ 2566841344 EngPrtectionSystemHasShutdownEng 1110;
+BA_ "SigType" SG_ 2566841344 EngWaitToStartLamp 5;
+BA_ "SPN" SG_ 2566841344 EngWaitToStartLamp 1081;
+BA_ "SigType" SG_ 2566841344 RefrigerantHighPressSwitch 4;
+BA_ "SPN" SG_ 2566841344 RefrigerantHighPressSwitch 605;
+BA_ "SigType" SG_ 2566841344 RefrigerantLowPressSwitch 4;
+BA_ "SPN" SG_ 2566841344 RefrigerantLowPressSwitch 875;
+BA_ "SigType" SG_ 2566841344 A_CHighPressFanSwitch 4;
+BA_ "SPN" SG_ 2566841344 A_CHighPressFanSwitch 985;
+BA_ "SigType" SG_ 2566841344 EngIdleShutdownTimerFunction 4;
+BA_ "SPN" SG_ 2566841344 EngIdleShutdownTimerFunction 591;
+BA_ "SigType" SG_ 2566841344 EngIdleShutdownTimerState 5;
+BA_ "SPN" SG_ 2566841344 EngIdleShutdownTimerState 590;
+BA_ "SigType" SG_ 2566841344 EngIdleShutdownTimerOverride 5;
+BA_ "SPN" SG_ 2566841344 EngIdleShutdownTimerOverride 592;
+BA_ "SigType" SG_ 2566841344 EngIdleShutdownDriverAlertMode 5;
+BA_ "SPN" SG_ 2566841344 EngIdleShutdownDriverAlertMode 594;
+BA_ "SigType" SG_ 2566841344 EngIdleShutdownHasShutdownEng 5;
+BA_ "SPN" SG_ 2566841344 EngIdleShutdownHasShutdownEng 593;
+BA_ "SigType" SG_ 2365518336 EngThrottleValve2Pos 1;
+BA_ "SPN" SG_ 2365518336 EngThrottleValve2Pos 3673;
+BA_ "SigType" SG_ 2365518336 EngThrottleValve1Pos 1;
+BA_ "SPN" SG_ 2365518336 EngThrottleValve1Pos 51;
+BA_ "SigType" SG_ 2365518336 EngAverageFuelEconomy 1;
+BA_ "SPN" SG_ 2365518336 EngAverageFuelEconomy 185;
+BA_ "SigType" SG_ 2365518336 EngInstantaneousFuelEconomy 1;
+BA_ "SPN" SG_ 2365518336 EngInstantaneousFuelEconomy 184;
+BA_ "SigType" SG_ 2365518336 EngFuelRate 1;
+BA_ "SPN" SG_ 2365518336 EngFuelRate 183;
+BA_ "SigType" SG_ 2365516032 EngTotalFuelUsed 1;
+BA_ "SPN" SG_ 2365516032 EngTotalFuelUsed 250;
+BA_ "SigType" SG_ 2365516032 EngTripFuel 1;
+BA_ "SPN" SG_ 2365516032 EngTripFuel 182;
+BA_ "SigType" SG_ 2364539392 SrcAddrssOfCntrllngDvcFrTrnsCtrl 0;
+BA_ "SPN" SG_ 2364539392 SrcAddrssOfCntrllngDvcFrTrnsCtrl 1482;
+BA_ "SigType" SG_ 2364539392 TransInputShaftSpeed 1;
+BA_ "SPN" SG_ 2364539392 TransInputShaftSpeed 161;
+BA_ "SigType" SG_ 2364539392 MomentaryEngMaxPowerEnable 5;
+BA_ "SPN" SG_ 2364539392 MomentaryEngMaxPowerEnable 5015;
+BA_ "SigType" SG_ 2364539392 ProgressiveShiftDisable 5;
+BA_ "SPN" SG_ 2364539392 ProgressiveShiftDisable 607;
+BA_ "SigType" SG_ 2364539392 EngMomentaryOverspeedEnable 5;
+BA_ "SPN" SG_ 2364539392 EngMomentaryOverspeedEnable 606;
+BA_ "SigType" SG_ 2364539392 PercentClutchSlip 1;
+BA_ "SPN" SG_ 2364539392 PercentClutchSlip 522;
+BA_ "SigType" SG_ 2364539392 TransOutputShaftSpeed 1;
+BA_ "SPN" SG_ 2364539392 TransOutputShaftSpeed 191;
+BA_ "SigType" SG_ 2364539392 TrnsTrqCnvrtrLckpTrnstnInProcess 4;
+BA_ "SPN" SG_ 2364539392 TrnsTrqCnvrtrLckpTrnstnInProcess 4816;
+BA_ "SigType" SG_ 2364539392 TransShiftInProcess 4;
+BA_ "SPN" SG_ 2364539392 TransShiftInProcess 574;
+BA_ "SigType" SG_ 2364539392 TrnsTorqueConverterLockupEngaged 5;
+BA_ "SPN" SG_ 2364539392 TrnsTorqueConverterLockupEngaged 573;
+BA_ "SigType" SG_ 2364539392 TransDrivelineEngaged 4;
+BA_ "SPN" SG_ 2364539392 TransDrivelineEngaged 560;
+BA_ "SigType" SG_ 2365517312 EngIntercoolerThermostatOpening 1;
+BA_ "SPN" SG_ 2365517312 EngIntercoolerThermostatOpening 1134;
+BA_ "SigType" SG_ 2365517312 EngIntercoolerTemp 1;
+BA_ "SPN" SG_ 2365517312 EngIntercoolerTemp 52;
+BA_ "SigType" SG_ 2365517312 EngTurboOilTemp 1;
+BA_ "SPN" SG_ 2365517312 EngTurboOilTemp 176;
+BA_ "SigType" SG_ 2365517312 EngOilTemp1 1;
+BA_ "SPN" SG_ 2365517312 EngOilTemp1 175;
+BA_ "SigType" SG_ 2365517312 EngFuelTemp1 1;
+BA_ "SPN" SG_ 2365517312 EngFuelTemp1 174;
+BA_ "SigType" SG_ 2365517312 EngCoolantTemp 1;
+BA_ "SPN" SG_ 2365517312 EngCoolantTemp 110;
+BA_ "SigType" SG_ 2566844160 EngCoolantLevel 1;
+BA_ "SPN" SG_ 2566844160 EngCoolantLevel 111;
+BA_ "SigType" SG_ 2566844160 EngCoolantPress 1;
+BA_ "SPN" SG_ 2566844160 EngCoolantPress 109;
+BA_ "SigType" SG_ 2566844160 EngCrankcasePress 1;
+BA_ "SPN" SG_ 2566844160 EngCrankcasePress 101;
+BA_ "SigType" SG_ 2566844160 EngOilPress 1;
+BA_ "SPN" SG_ 2566844160 EngOilPress 100;
+BA_ "SigType" SG_ 2566844160 EngOilLevel 1;
+BA_ "SPN" SG_ 2566844160 EngOilLevel 98;
+BA_ "SigType" SG_ 2566844160 EngExCrankcaseBlowbyPress 1;
+BA_ "SPN" SG_ 2566844160 EngExCrankcaseBlowbyPress 22;
+BA_ "SigType" SG_ 2566844160 EngFuelDeliveryPress 1;
+BA_ "SPN" SG_ 2566844160 EngFuelDeliveryPress 94;
+BA_ "SigType" SG_ 2566840064 AFT2ExhDewPoint 5;
+BA_ "SPN" SG_ 2566840064 AFT2ExhDewPoint 3240;
+BA_ "SigType" SG_ 2566840064 AFT2InDewPoint 5;
+BA_ "SPN" SG_ 2566840064 AFT2InDewPoint 3239;
+BA_ "SigType" SG_ 2566840064 AFT1ExhDewPoint 5;
+BA_ "SPN" SG_ 2566840064 AFT1ExhDewPoint 3238;
+BA_ "SigType" SG_ 2566840064 AFT1InDewPoint 5;
+BA_ "SPN" SG_ 2566840064 AFT1InDewPoint 3237;
+BA_ "SigType" SG_ 2566840064 AFT1ExhGasMFR 1;
+BA_ "SPN" SG_ 2566840064 AFT1ExhGasMFR 3236;
+BA_ "SigType" SG_ 2566840064 EstEngPrsiticLossesPercentTorque 1;
+BA_ "GenSigStartValue" SG_ 2566840064 EstEngPrsiticLossesPercentTorque 125;
+BA_ "SPN" SG_ 2566840064 EstEngPrsiticLossesPercentTorque 2978;
+BA_ "SigType" SG_ 2566840064 EngnsDsrdOprtngSpdAsymmtryAdjstm 1;
+BA_ "SPN" SG_ 2566840064 EngnsDsrdOprtngSpdAsymmtryAdjstm 519;
+BA_ "SigType" SG_ 2566840064 EnginesDesiredOperatingSpeed 1;
+BA_ "SPN" SG_ 2566840064 EnginesDesiredOperatingSpeed 515;
+BA_ "SigType" SG_ 2566840064 NominalFrictionPercentTorque 1;
+BA_ "SPN" SG_ 2566840064 NominalFrictionPercentTorque 514;
+BA_ "SigType" SG_ 2364539648 EstPumpingPercentTorque 1;
+BA_ "SPN" SG_ 2364539648 EstPumpingPercentTorque 5398;
+BA_ "SigType" SG_ 2364539648 ActlMaxAvailableEngPercentTorque 1;
+BA_ "SPN" SG_ 2364539648 ActlMaxAvailableEngPercentTorque 3357;
+BA_ "SigType" SG_ 2364539648 SCRThermalManagementActive 5;
+BA_ "SPN" SG_ 2364539648 SCRThermalManagementActive 5400;
+BA_ "SigType" SG_ 2364539648 DPFThermalManagementActive 5;
+BA_ "SPN" SG_ 2364539648 DPFThermalManagementActive 5399;
+BA_ "SigType" SG_ 2364539648 MmntaryEngMaxPowerEnableFeedback 5;
+BA_ "SPN" SG_ 2364539648 MmntaryEngMaxPowerEnableFeedback 5021;
+BA_ "SigType" SG_ 2364539648 VhcleAccelerationRateLimitStatus 5;
+BA_ "SPN" SG_ 2364539648 VhcleAccelerationRateLimitStatus 2979;
+BA_ "SigType" SG_ 2364539648 AccelPedalPos2 1;
+BA_ "SPN" SG_ 2364539648 AccelPedalPos2 29;
+BA_ "SigType" SG_ 2364539648 RemoteAccelPedalPos 1;
+BA_ "SPN" SG_ 2364539648 RemoteAccelPedalPos 974;
+BA_ "SigType" SG_ 2364539648 EngPercentLoadAtCurrentSpeed 1;
+BA_ "SPN" SG_ 2364539648 EngPercentLoadAtCurrentSpeed 92;
+BA_ "SigType" SG_ 2364539648 AccelPedalPos1 1;
+BA_ "SPN" SG_ 2364539648 AccelPedalPos1 91;
+BA_ "SigType" SG_ 2364539648 AccelPedal2LowIdleSwitch 4;
+BA_ "SPN" SG_ 2364539648 AccelPedal2LowIdleSwitch 2970;
+BA_ "SigType" SG_ 2364539648 RoadSpeedLimitStatus 5;
+BA_ "SPN" SG_ 2364539648 RoadSpeedLimitStatus 1437;
+BA_ "SigType" SG_ 2364539648 AccelPedalKickdownSwitch 4;
+BA_ "SPN" SG_ 2364539648 AccelPedalKickdownSwitch 559;
+BA_ "SigType" SG_ 2364539648 AccelPedal1LowIdleSwitch 4;
+BA_ "SPN" SG_ 2364539648 AccelPedal1LowIdleSwitch 558;
+BA_ "SigType" SG_ 2364539904 EngDemandPercentTorque 1;
+BA_ "SPN" SG_ 2364539904 EngDemandPercentTorque 2432;
+BA_ "SigType" SG_ 2364539904 EngStarterMode 0;
+BA_ "SPN" SG_ 2364539904 EngStarterMode 1675;
+BA_ "SigType" SG_ 2364539904 SrcAddrssOfCntrllngDvcForEngCtrl 0;
+BA_ "SPN" SG_ 2364539904 SrcAddrssOfCntrllngDvcForEngCtrl 1483;
+BA_ "SigType" SG_ 2364539904 EngSpeed 1;
+BA_ "SPN" SG_ 2364539904 EngSpeed 190;
+BA_ "SigType" SG_ 2364539904 ActualEngPercentTorque 1;
+BA_ "GenSigStartValue" SG_ 2364539904 ActualEngPercentTorque 125;
+BA_ "SPN" SG_ 2364539904 ActualEngPercentTorque 513;
+BA_ "SigType" SG_ 2364539904 DriversDemandEngPercentTorque 1;
+BA_ "GenSigStartValue" SG_ 2364539904 DriversDemandEngPercentTorque 125;
+BA_ "SPN" SG_ 2364539904 DriversDemandEngPercentTorque 512;
+BA_ "SigType" SG_ 2364539904 ActlEngPrcntTorqueHighResolution 0;
+BA_ "SPN" SG_ 2364539904 ActlEngPrcntTorqueHighResolution 4154;
+BA_ "SigType" SG_ 2364539904 EngTorqueMode 0;
+BA_ "SPN" SG_ 2364539904 EngTorqueMode 899;
+BA_ "SigType" SG_ 2565865728 TrctrMntdTrailerABSWarningSignal 5;
+BA_ "SPN" SG_ 2565865728 TrctrMntdTrailerABSWarningSignal 1792;
+BA_ "SigType" SG_ 2565865728 TrailerABSStatus 5;
+BA_ "SPN" SG_ 2565865728 TrailerABSStatus 1836;
+BA_ "SigType" SG_ 2565865728 HaltBrakeSwitch 4;
+BA_ "SPN" SG_ 2565865728 HaltBrakeSwitch 2911;
+BA_ "SigType" SG_ 2565865728 SrcAddrssOfCntrllngDvcFrBrkeCtrl 0;
+BA_ "SPN" SG_ 2565865728 SrcAddrssOfCntrllngDvcFrBrkeCtrl 1481;
+BA_ "SigType" SG_ 2565865728 ATC_ASRInformationSignal 5;
+BA_ "SPN" SG_ 2565865728 ATC_ASRInformationSignal 1793;
+BA_ "SigType" SG_ 2565865728 ABS_EBSAmberWarningSignal 5;
+BA_ "SPN" SG_ 2565865728 ABS_EBSAmberWarningSignal 1438;
+BA_ "SigType" SG_ 2565865728 EBSRedWarningSignal 5;
+BA_ "SPN" SG_ 2565865728 EBSRedWarningSignal 1439;
+BA_ "SigType" SG_ 2565865728 ABSFullyOperational 5;
+BA_ "SPN" SG_ 2565865728 ABSFullyOperational 1243;
+BA_ "SigType" SG_ 2565865728 EngRetarderSelection 1;
+BA_ "SPN" SG_ 2565865728 EngRetarderSelection 973;
+BA_ "SigType" SG_ 2565865728 RemoteAccelEnableSwitch 4;
+BA_ "SPN" SG_ 2565865728 RemoteAccelEnableSwitch 969;
+BA_ "SigType" SG_ 2565865728 EngAuxShutdownSwitch 4;
+BA_ "SPN" SG_ 2565865728 EngAuxShutdownSwitch 970;
+BA_ "SigType" SG_ 2565865728 EngDerateSwitch 4;
+BA_ "SPN" SG_ 2565865728 EngDerateSwitch 971;
+BA_ "SigType" SG_ 2565865728 AccelInterlockSwitch 4;
+BA_ "SPN" SG_ 2565865728 AccelInterlockSwitch 972;
+BA_ "SigType" SG_ 2565865728 TractionCtrlOverrideSwitch 4;
+BA_ "SPN" SG_ 2565865728 TractionCtrlOverrideSwitch 1238;
+BA_ "SigType" SG_ 2565865728 ASRHillHolderSwitch 4;
+BA_ "SPN" SG_ 2565865728 ASRHillHolderSwitch 577;
+BA_ "SigType" SG_ 2565865728 ASROffroadSwitch 4;
+BA_ "SPN" SG_ 2565865728 ASROffroadSwitch 576;
+BA_ "SigType" SG_ 2565865728 ABSOffroadSwitch 4;
+BA_ "SPN" SG_ 2565865728 ABSOffroadSwitch 575;
+BA_ "SigType" SG_ 2565865728 BrakePedalPos 1;
+BA_ "SPN" SG_ 2565865728 BrakePedalPos 521;
+BA_ "SigType" SG_ 2565865728 EBSBrakeSwitch 4;
+BA_ "SPN" SG_ 2565865728 EBSBrakeSwitch 1121;
+BA_ "SigType" SG_ 2565865728 AntiLockBrakingActive 5;
+BA_ "SPN" SG_ 2565865728 AntiLockBrakingActive 563;
+BA_ "SigType" SG_ 2565865728 ASRBrakeCtrlActive 5;
+BA_ "SPN" SG_ 2565865728 ASRBrakeCtrlActive 562;
+BA_ "SigType" SG_ 2565865728 ASREngCtrlActive 5;
+BA_ "SPN" SG_ 2565865728 ASREngCtrlActive 561;
+BA_ "SigType" SG_ 2566804992 HtrPreliminaryFMI 0;
+BA_ "SPN" SG_ 2566804992 HtrPreliminaryFMI 4366;
+BA_ "SigType" SG_ 2566804992 Htr 1;
+BA_ "SPN" SG_ 2566804992 Htr 3363;
+BA_ "SigType" SG_ 2566804992 SCROpIndSev 0;
+BA_ "SPN" SG_ 2566804992 SCROpIndSev 5246;
+BA_ "SigType" SG_ 2566804992 TempPreliminaryFMI 0;
+BA_ "SPN" SG_ 2566804992 TempPreliminaryFMI 4365;
+BA_ "SigType" SG_ 2566804992 DEFTankLowLvlInd 0;
+BA_ "SPN" SG_ 2566804992 DEFTankLowLvlInd 5245;
+BA_ "SigType" SG_ 2566804992 LvlVolPreliminaryFMI 0;
+BA_ "SPN" SG_ 2566804992 LvlVolPreliminaryFMI 3532;
+BA_ "SigType" SG_ 2566804992 Lvl 1;
+BA_ "SPN" SG_ 2566804992 Lvl 3517;
+BA_ "SigType" SG_ 2566804992 Temp1 1;
+BA_ "SPN" SG_ 2566804992 Temp1 3031;
+BA_ "SigType" SG_ 2566804992 Volume 1;
+BA_ "SPN" SG_ 2566804992 Volume 1761;
+BA_ "SigType" SG_ 2566748928 DPFSootLoadRegenThreshold 1;
+BA_ "SPN" SG_ 2566748928 DPFSootLoadRegenThreshold 5466;
+BA_ "SigType" SG_ 2566748928 DPFTimeSinceLastActiveRegen 1;
+BA_ "SPN" SG_ 2566748928 DPFTimeSinceLastActiveRegen 3721;
+BA_ "SigType" SG_ 2566748928 DPFAshLoadPercent 1;
+BA_ "SPN" SG_ 2566748928 DPFAshLoadPercent 3720;
+BA_ "SigType" SG_ 2566748928 DPFSootLoadPercent 1;
+BA_ "SPN" SG_ 2566748928 DPFSootLoadPercent 3719;
+BA_ "SigType" SG_ 2365428224 EngDesiredTorqueRq 1;
+BA_ "GenSigStartValue" SG_ 2365428224 EngDesiredTorqueRq 125;
+BA_ "SPN" SG_ 2365428224 EngDesiredTorqueRq 6807;
+BA_ "SigType" SG_ 2365428224 EngColdAmbientElevatedIdleStatus 5;
+BA_ "SPN" SG_ 2365428224 EngColdAmbientElevatedIdleStatus 6884;
+BA_ "SigType" SG_ 2365428224 EngStarterMotorRelayCtrl 5;
+BA_ "SPN" SG_ 2365428224 EngStarterMotorRelayCtrl 6385;
+BA_ "SigType" SG_ 2365428224 EngDerateRq 1;
+BA_ "SPN" SG_ 2365428224 EngDerateRq 3644;
+BA_ "SigType" SG_ 2365428224 EngEmergencyShutdownIndication 5;
+BA_ "SPN" SG_ 2365428224 EngEmergencyShutdownIndication 3607;
+BA_ "SigType" SG_ 2365428224 EngControlledShutdownRq 5;
+BA_ "SPN" SG_ 2365428224 EngControlledShutdownRq 3606;
+BA_ "SigType" SG_ 2365428224 EngCoolantCirculatingPumpCtrl 5;
+BA_ "SPN" SG_ 2365428224 EngCoolantCirculatingPumpCtrl 3605;
+BA_ "SigType" SG_ 2365428224 EngBlock_CoolantPreheaterCtrl 5;
+BA_ "SPN" SG_ 2365428224 EngBlock_CoolantPreheaterCtrl 3604;
+BA_ "SigType" SG_ 2365428224 EngElctrclSystmPwrCnsrvationCtrl 5;
+BA_ "SPN" SG_ 2365428224 EngElctrclSystmPwrCnsrvationCtrl 3603;
+BA_ "SigType" SG_ 2365428224 EngOilPreheaterCtrl 5;
+BA_ "SPN" SG_ 2365428224 EngOilPreheaterCtrl 3602;
+BA_ "SigType" SG_ 2365428224 EngOilPrimingPumpCtrl 5;
+BA_ "SPN" SG_ 2365428224 EngOilPrimingPumpCtrl 3589;
+BA_ "SigType" SG_ 2365428224 EngFuelShutoffValveLeakTestCtrl 5;
+BA_ "SPN" SG_ 2365428224 EngFuelShutoffValveLeakTestCtrl 3601;
+BA_ "SigType" SG_ 2365428224 EngFuelShutoff2Ctrl 5;
+BA_ "SPN" SG_ 2365428224 EngFuelShutoff2Ctrl 2807;
+BA_ "SigType" SG_ 2365428224 EngFuelShutoff1Ctrl 5;
+BA_ "SPN" SG_ 2365428224 EngFuelShutoff1Ctrl 632;
+BA_ "SigType" SG_ 2365428224 EngFuelShutoffVentCtrl 5;
+BA_ "SPN" SG_ 2365428224 EngFuelShutoffVentCtrl 3608;
+BA_ "SigType" SG_ 2365428224 TimeRemainingInEngOperatingState 1;
+BA_ "SPN" SG_ 2365428224 TimeRemainingInEngOperatingState 3544;
+BA_ "SigType" SG_ 2365428224 FuelPumpPrimerCtrl 5;
+BA_ "SPN" SG_ 2365428224 FuelPumpPrimerCtrl 4082;
+BA_ "SigType" SG_ 2365428224 EngOperatingState 0;
+BA_ "SPN" SG_ 2365428224 EngOperatingState 3543;
+BA_ "SigType" SG_ 2365492224 RelativeHumidity 1;
+BA_ "SPN" SG_ 2365492224 RelativeHumidity 354;
+BA_ "SigType" SG_ 2365492224 AuxLevel 1;
+BA_ "SPN" SG_ 2365492224 AuxLevel 3087;
+BA_ "SigType" SG_ 2365492224 AuxPress2 1;
+BA_ "SPN" SG_ 2365492224 AuxPress2 1388;
+BA_ "SigType" SG_ 2365492224 AuxPress1 1;
+BA_ "SPN" SG_ 2365492224 AuxPress1 1387;
+BA_ "SigType" SG_ 2365492224 AuxTemp2 1;
+BA_ "SPN" SG_ 2365492224 AuxTemp2 442;
+BA_ "SigType" SG_ 2365492224 AuxTemp1 1;
+BA_ "SPN" SG_ 2365492224 AuxTemp1 441;
+BA_ "SigType" SG_ 2365519616 KeyswitchBatteryPotential 1;
+BA_ "SPN" SG_ 2365519616 KeyswitchBatteryPotential 158;
+BA_ "SigType" SG_ 2365519616 BatteryPotential_PowerInput1 1;
+BA_ "SPN" SG_ 2365519616 BatteryPotential_PowerInput1 168;
+BA_ "SigType" SG_ 2365519616 ChargingSystemPotential 1;
+BA_ "SPN" SG_ 2365519616 ChargingSystemPotential 167;
+BA_ "SigType" SG_ 2365519616 AltCurrent 1;
+BA_ "SPN" SG_ 2365519616 AltCurrent 115;
+BA_ "SigType" SG_ 2365519616 NetBatteryCurrent 1;
+BA_ "SPN" SG_ 2365519616 NetBatteryCurrent 114;
+

--- a/decoder/D65/dbc/D65_CH3_RCS_Module.dbc
+++ b/decoder/D65/dbc/D65_CH3_RCS_Module.dbc
@@ -1,0 +1,83 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: VCU DEV0 DEV1 DEV2 DEV3 DEV4 DEV5 DEV6
+
+
+BO_ 544 RCS_DEV0_T3IO_OUT0_m: 8 VCU
+ SG_ RCS_DEV0_X14A_Y115 : 58|1@1+ (1,0) [0|1] ""  DEV0
+
+BO_ 546 RCS_DEV2_T3IO_OUT1_m: 8 VCU
+ SG_ RCS_DEV2_X7_Y193_byte_lo : 0|8@1+ (1,0) [0|255] ""  DEV2
+ SG_ RCS_DEV2_X7_Y193_byte_hi : 40|2@1+ (1,0) [0|3] ""  DEV2
+
+BO_ 674 RCS_DEV2_T3IO_ANALOG_IN_m: 8 DEV2
+ SG_ RCS_DEV2_mux M : 62|2@1+ (1,0) [0|3] ""  VCU
+ SG_ RCS_DEV2_X2B_B456_byte_lo m1 : 0|8@1+ (1,0) [0|255] ""  VCU
+ SG_ RCS_DEV2_X2B_B456_byte_hi m1 : 48|4@1+ (1,0) [0|15] ""  VCU
+
+BO_ 677 RCS_DEV5_T3IO_ANALOG_IN_m: 8 DEV5
+ SG_ RCS_DEV5_mux M : 62|2@1+ (1,0) [0|3] ""  VCU
+ SG_ RCS_DEV5_X2B_B188_byte_lo m1 : 0|8@1+ (1,0) [0|255] ""  VCU
+ SG_ RCS_DEV5_X2B_B188_byte_hi m1 : 48|4@1+ (1,0) [0|15] ""  VCU
+
+
+BA_DEF_  "BusType" STRING ;
+BA_DEF_ BO_  "CanDootDecode" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootDecodeBus" INT 0 6;
+BA_DEF_ BO_  "CanDootPaused" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulate" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulateBus" INT 0 6;
+BA_DEF_ BO_  "CanDootSimulateCycleTime" INT 0 50000;
+BA_DEF_ BO_  "CG_MessageInstName" STRING ;
+BA_DEF_ SG_  "CanDootGroup" ENUM  "None","g1","g2","g3","g4","g5","g6","g7","g8","g9","gA","gB","gC","gD","gE","gF";
+BA_DEF_ SG_  "CanDootHidden" ENUM  "No","Yes";
+BA_DEF_ SG_  "CanDootBroadcast" ENUM  "No","Yes";
+BA_DEF_ SG_  "CG_VarType" ENUM  "bool","uint8_t","int8_t","uint16_t","int16_t","uint32_t","int32_t","float","double";
+BA_DEF_ BO_  "GenMsgCycleTime" INT 0 65535;
+BA_DEF_DEF_  "BusType" "CAN";
+BA_DEF_DEF_  "CanDootDecode" "Yes";
+BA_DEF_DEF_  "CanDootDecodeBus" 1;
+BA_DEF_DEF_  "CanDootPaused" "No";
+BA_DEF_DEF_  "CanDootSimulate" "No";
+BA_DEF_DEF_  "CanDootSimulateBus" 1;
+BA_DEF_DEF_  "CanDootSimulateCycleTime" 100;
+BA_DEF_DEF_  "CG_MessageInstName" "";
+BA_DEF_DEF_  "CanDootGroup" "None";
+BA_DEF_DEF_  "CanDootHidden" "No";
+BA_DEF_DEF_  "CanDootBroadcast" "Yes";
+BA_DEF_DEF_  "CG_VarType" "uint8_t";
+BA_DEF_DEF_  "GenMsgCycleTime" 0;
+

--- a/decoder/D65/dbc/D65_CH4_Main.dbc
+++ b/decoder/D65/dbc/D65_CH4_Main.dbc
@@ -1,0 +1,1689 @@
+VERSION "created by canmatrix"
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: IMD_StandAlone Master IMD EVCU DCDC2 DCDC1 BCL25_700_8 ECU HMI RCS
+
+
+BO_ 2556487144 AC_Comp_238_A: 8 Vector__XXX
+ SG_ AC_compressor_power_limit : 40|8@1+ (0.1,0) [0|25.5] "kw" Vector__XXX
+ SG_ AC_compressor_immediate_shutdown : 32|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ AC_compressor_enable : 24|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ AC_speed_of_compressor : 0|16@1+ (1,0) [0|65534] "rpm" Vector__XXX
+
+BO_ 2555439333 AC_Comp_248_B: 8 Vector__XXX
+ SG_ Comp_Input_DC_Voltage : 56|8@1+ (4,0) [0|1016] "V" Vector__XXX
+ SG_ Comp_Input_DC_Current : 48|8@1+ (0.1,0) [0|25.4] "A" Vector__XXX
+ SG_ Comp_IPM_temperature : 40|8@1+ (1,-40) [-40|215] "C" Vector__XXX
+ SG_ Comp_compressor_error : 32|8@1+ (1,0) [0|254] "" Vector__XXX
+ SG_ Comp_compressor_status : 24|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ Comp_phase_Current : 16|8@1+ (0.5,0) [0|127.5] "A" Vector__XXX
+ SG_ Comp_speed_of_compressor : 0|16@1+ (1,0) [0|65534] "rpm" Vector__XXX
+
+BO_ 2566902224 BCL_Bdc_BuckBoost_Status: 8 BCL25_700_8
+ SG_ BCL_Bdc_BuckBoost_Shtdwn_Rsn : 40|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BCL_Bdc_BuckBoost_State : 32|8@1+ (1,0) [0|255] "" Vector__XXX
+
+BO_ 2566903504 BCL_Bdc_Current: 8 BCL25_700_8
+ SG_ BCL_Bdc_Curr_L3_RMS : 32|16@1+ (0.05,0) [0|100] "A" Vector__XXX
+ SG_ BCL_Bdc_Curr_L2_RMS : 16|16@1+ (0.05,0) [0|100] "A" Vector__XXX
+ SG_ BCL_Bdc_Curr_L1_RMS : 0|16@1+ (0.05,0) [0|100] "A" Vector__XXX
+
+BO_ 2566902736 BCL_Bdc_Error_Status: 6 BCL25_700_8
+ SG_ BCL_Bdc_Aux_bOtpRecoveryDis : 45|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Aux_bBtnStartEn : 44|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Aux_bExtCurrSensor : 43|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Aux_bTempDerating : 42|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Aux_b1Phase : 41|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Aux_bBalancing : 40|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Cannot_Start_Rsn : 32|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bTemperatureWarn : 31|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bExportOvrLoadWarn : 30|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bLockFail : 23|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bLVBatOv : 22|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bLVBatUv : 21|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bTemperatureFail : 19|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bCanCrcFail : 18|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bHvilFail : 17|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bFailStartsLim : 16|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bExtCanFail : 15|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bAuxFail : 14|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bEepromCrcFail : 13|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bInvFail : 12|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bBBFail : 11|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bSignalFail : 10|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bExportOvrload : 8|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bHVBattUV : 7|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bHVBattOV : 6|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bPhase3NotOk : 5|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bPhase2NotOk : 4|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bPhase1NotOk : 3|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bFreqNotOk : 2|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bACNotOk : 1|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Error_bLVBatUvCustom : 0|1@1+ (1,0) [0|1] "" Vector__XXX
+
+BO_ 2566903760 BCL_Bdc_Hv_Values: 8 BCL25_700_8
+ SG_ BCL_Chg_Ibat_max_available : 32|16@1+ (0.05,0) [0|80] "A" Vector__XXX
+ SG_ BCL_Bdc_Vbat : 16|16@1+ (0.05,0) [0|850] "V" Vector__XXX
+ SG_ BCL_Bdc_Ibat : 0|16@1- (0.05,0) [-70|70] "A" Vector__XXX
+
+BO_ 2566905040 BCL_Bdc_Hvil: 8 BCL25_700_8
+ SG_ BCL_Hvil_Vout : 32|16@1+ (0.05,0) [0|3276.75] "V" Vector__XXX
+ SG_ BCL_Hvil_Vin : 16|16@1+ (0.05,0) [0|3276.75] "V" Vector__XXX
+ SG_ BCL_Hvil_Current : 8|8@1- (1,0) [-128|127] "mA" Vector__XXX
+ SG_ BCL_Bdc_Hvil_bHvilCurrentUnderLi : 5|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Hvil_bHvilCurrentOverLim : 4|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Hvil_bHvilOutOk : 3|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Hvil_bHvillnOk : 2|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Hvil_bHvilCurrentOk : 1|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Hvil_bHvilOk : 0|1@1+ (1,0) [0|1] "" Vector__XXX
+
+BO_ 2566902480 BCL_Bdc_Inverter_Status: 8 BCL25_700_8
+ SG_ BCL_Bdc_Inverter_Shtdwn_Rsn : 40|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BCL_Bdc_Inverter_State : 32|8@1+ (1,0) [0|255] "" Vector__XXX
+
+BO_ 2566904016 BCL_Bdc_J1772: 8 BCL25_700_8
+ SG_ BCL_Chg_Lock_State : 40|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BCL_Chg_Proximity_State : 32|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BCL_Chg_Pilot_Freq : 16|16@1+ (1,0) [0|1500] "Hz" Vector__XXX
+ SG_ BCL_Chg_Pilot_Duty : 8|8@1+ (1,0) [0|100] "%" Vector__XXX
+ SG_ BCL_Chg_Evse_Type : 0|8@1+ (1,0) [0|255] "" Vector__XXX
+
+BO_ 2566904272 BCL_Bdc_Other_Values: 8 BCL25_700_8
+ SG_ BCL_Bdc_LV_Vbat : 16|16@1+ (0.001,0) [0|65.535] "V" Vector__XXX
+ SG_ BCL_Bdc_Freq : 0|16@1+ (0.05,0) [0|300] "Hz" Vector__XXX
+
+BO_ 2566906320 BCL_Bdc_ProprietaryDiag: 8 BCL25_700_8
+ SG_ BCL_Bdc_VbusDc : 16|16@1+ (0.05,0) [0|1000] "V" Vector__XXX
+ SG_ BCL_Bdc_VbusInv : 0|16@1+ (0.05,0) [0|1000] "V" Vector__XXX
+
+BO_ 2565853185 BCL_Bdc_Setpoint: 7 ECU
+ SG_ BCL_Index M : 0|8@1+ (1,0) [0|255] ""  BCL25_700_8
+ SG_ BCL_cmd_Otp_recovery_enable m18 : 8|8@1+ (1,0) [0|2] "" Vector__XXX
+ SG_ BCL_cmd_TempExt_Table_Idx m81 : 8|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BCL_cmd_Save_Settings m127 : 8|8@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_cmd_Button_A_Action m17 : 8|8@1+ (1,0) [0|10] "" Vector__XXX
+ SG_ BCL_cmd_CAN_address_new61 m97 : 8|8@1+ (1,0) [0|255] ""  BCL25_700_8
+ SG_ BCL_cmd_Ext_DC_CurrSens_En m8 : 8|8@1+ (1,0) [0|10] ""  BCL25_700_8
+ SG_ BCL_cmd_Hvil_enable m64 : 8|8@1+ (1,0) [0|1] ""  BCL25_700_8
+ SG_ BCL_cmd_CRC_Cntr m16 : 8|8@1+ (1,0) [0|3] ""  BCL25_700_8
+ SG_ BCL_cmd_CAN_address_new60 m96 : 8|8@1+ (1,0) [0|255] ""  BCL25_700_8
+ SG_ BCL_cmd_TempExt_Sensor_Type m80 : 8|8@1+ (1,0) [0|10] ""  BCL25_700_8
+ SG_ BCL_cmd_Motor_Rise_Time m7 : 8|8@1+ (1,0) [0|60] "s"  BCL25_700_8
+ SG_ BCL_cmd_LED_Index m6 : 8|8@1+ (1,0) [0|100] ""  BCL25_700_8
+ SG_ BCL_cmd_EVSE_type_set m11 : 8|8@1+ (1,0) [0|2] "0"  BCL25_700_8
+ SG_ BCL_cmd_LV_Battery_UV_Limit m10 : 8|16@1+ (0.001,0) [0|65] "V"  BCL25_700_8
+ SG_ BCL_cmd_Sleep_Mode m4 : 8|8@1+ (1,0) [0|2] ""  BCL25_700_8
+ SG_ BCL_cmd_Control_pilot_imp m5 : 8|8@1+ (1,0) [0|1] ""  BCL25_700_8
+ SG_ BCL_cmd_wake_out m3 : 8|8@1+ (1,0) [0|1] ""  BCL25_700_8
+ SG_ BCL_cmd_Inv_Vbat_UV_lim m2 : 8|16@1+ (0.05,0) [0|850] "V"  BCL25_700_8
+ SG_ BCL_cmd_Chg_Vbat_lim m1 : 8|16@1+ (0.05,0) [0|850] "V"  BCL25_700_8
+ SG_ BCL_cmd_Enable m0 : 8|8@1+ (1,0) [0|1] ""  BCL25_700_8
+ SG_ BCL_cmd_TempExt_Table_Temp m81 : 16|8@1+ (1,-50) [-50|205] "" Vector__XXX
+ SG_ BCL_cmd_TempExt_Otp_En m80 : 16|8@1+ (1,0) [0|10] "" Vector__XXX
+ SG_ BCL_cmd_Button_B_Action m17 : 16|8@1+ (1,0) [0|10] "" Vector__XXX
+ SG_ BCL_cmd_CAN_address_SN_Upper m97 : 16|32@1+ (1,0) [0|4294967295] ""  BCL25_700_8
+ SG_ BCL_cmd_Ext_DC_CurrSens_Val m8 : 16|16@1+ (0.05,0) [0|60] "A"  BCL25_700_8
+ SG_ BCL_cmd_CAN_address_SN_Lower m96 : 16|32@1+ (1,0) [0|4294967295] ""  BCL25_700_8
+ SG_ BCL_cmd_LED_mode m6 : 16|8@1+ (1,0) [0|2] ""  BCL25_700_8
+ SG_ BCL_cmd_Mode m0 : 16|8@1+ (1,0) [0|255] ""  BCL25_700_8
+ SG_ BCL_cmd_TempExt_Table_Resistance m81 : 24|24@1+ (1,0) [0|16777215] "" Vector__XXX
+ SG_ BCL_cmd_TempExt_Otp m80 : 24|8@1+ (1,-50) [-50|205] "" Vector__XXX
+ SG_ BCL_cmd_Balancing m0 : 24|8@1+ (1,0) [0|1] ""  BCL25_700_8
+ SG_ BCL_cmd_Inv_Freq m2 : 24|8@1+ (1,0) [0|60] "Hz"  BCL25_700_8
+ SG_ BCL_cmd_LED_bright m6 : 24|8@1+ (0.5,0) [0|100] "%"  BCL25_700_8
+ SG_ BCL_cmd_Chg_Ibat_lim m1 : 24|16@1+ (0.05,0) [0|80] "A"  BCL25_700_8
+ SG_ BCL_cmd_Inv_Volt m2 : 32|16@1+ (0.05,0) [0|480] "V"  BCL25_700_8
+ SG_ BCL_cmd_LED_on_time m6 : 32|8@1+ (50,0) [0|12750] "ms"  BCL25_700_8
+ SG_ BCL_cmd_Chg_Iac_Lim m1 : 40|8@1+ (1,0) [0|80] "A"  BCL25_700_8
+ SG_ BCL_cmd_LED_duty m6 : 40|8@1+ (1,0) [0|100] "%"  BCL25_700_8
+
+BO_ 2566904528 BCL_Bdc_Sig_Temperature: 8 BCL25_700_8
+ SG_ BCL_Bdc_Temp_bSigOtp : 0|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Temp_bChassisOtp : 1|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Temp_bBbOtp : 2|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Temp_bInvOtp : 3|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Temp_bSigWarning : 4|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Temp_bChassisWarning : 5|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Temp_bBbOtpWarning : 6|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Temp_bInvWarning : 7|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Temp_Amb : 8|8@1+ (1,-50) [-50|205] "degC" Vector__XXX
+ SG_ BCL_Bdc_Temp_Chassis : 16|8@1+ (1,-50) [-50|205] "degC" Vector__XXX
+ SG_ BCL_Bdc_Temp_Bb : 24|8@1+ (1,-50) [-50|205] "degC" Vector__XXX
+ SG_ BCL_Bdc_Temp_Inv : 32|8@1+ (1,-50) [-50|205] "degC" Vector__XXX
+
+BO_ 2566901968 BCL_Bdc_Signal_Status: 8 BCL25_700_8
+ SG_ BCL_Bdc_bUnitReady : 0|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bModeEnable : 1|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bChargMode : 2|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bCharging : 3|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bExportMode : 4|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bExporting : 5|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bMotor : 6|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bSigFault : 8|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bAuxDis : 9|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bInvNotReady : 10|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bInvSleep : 11|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bInvFault : 12|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bBBNotReady : 13|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bBBSleep : 14|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bBBFault : 15|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bNoEvseMode : 16|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bCtrlProxNotOk : 17|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bCtrlPilotNotOk : 18|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bActuatorUnlock : 19|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bActuatorUnlocked : 20|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bEvseConnectionNotOk : 21|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bCtrlPilotS2NotReq : 22|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bCtrlPilotS2Dis : 23|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bKeySwitch : 24|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bAddr0 : 25|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bAddr1 : 26|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bBtnAOn : 27|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bBtnBOn : 28|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bWakeOutputOn : 29|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_bHvilEn : 30|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_Signal_State : 32|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BCL_Bdc_ShtDwn_Rsn : 40|8@1+ (1,0) [0|255] "" Vector__XXX
+
+BO_ 2566904784 BCL_Bdc_Temperature_Ext: 8 BCL25_700_8
+ SG_ BCL_Bdc_TempExt_bOtpCtrlEn : 0|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_TempExt_bOtp : 1|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_TempExt_bOutOfRange : 4|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_TempExt_bSensorShort : 5|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_TempExt_bSensDisconn : 6|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BCL_Bdc_TempExt_Sensor_Type : 8|8@1+ (1,0) [0|127] "" Vector__XXX
+ SG_ BCL_Bdc_TempExt : 16|8@1+ (1,-50) [-50|205] "degC" Vector__XXX
+ SG_ BCL_Bdc_TempExt_Otp_Lim_Set : 24|8@1+ (1,-50) [-50|205] "degC" Vector__XXX
+
+BO_ 2566905808 BCL_Bdc_Voltage_Line: 8 Vector__XXX
+ SG_ BCL_Bdc_Volt_L12_RMS : 0|16@1+ (0.05,0) [0|600] "V" Vector__XXX
+ SG_ BCL_Bdc_Volt_L23_RMS : 16|16@1+ (0.05,0) [0|600] "V" Vector__XXX
+ SG_ BCL_Bdc_Volt_L31_RMS : 32|16@1+ (0.05,0) [0|600] "V" Vector__XXX
+
+BO_ 2566903248 BCL_Bdc_Voltage_Phase: 8 BCL25_700_8
+ SG_ BCL_Bdc_Volt_L1_RMS : 0|16@1+ (0.05,0) [0|350] "V" Vector__XXX
+ SG_ BCL_Bdc_Volt_L2_RMS : 16|16@1+ (0.05,0) [0|350] "V" Vector__XXX
+ SG_ BCL_Bdc_Volt_L3_RMS : 32|16@1+ (0.05,0) [0|350] "V" Vector__XXX
+
+BO_ 2683179194 C2S_Version: 3 EVCU
+ SG_ C2S_version_major : 0|8@1+ (1,0) [0|255] ""  HMI
+ SG_ C2S_version_minor : 8|8@1+ (1,0) [0|255] ""  HMI
+ SG_ C2S_version_patch : 16|8@1+ (1,0) [0|255] ""  HMI
+
+BO_ 2683177658 C2S_FeedbackParameters: 5 EVCU
+ SG_ C2S_fp_param_id M : 0|8@1+ (1,0) [0|80] ""  HMI
+ SG_ C2S_fp_meb_contactor_fail_timeou m0 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_meb_dcdc_output_voltage m1 : 8|32@1- (0.1,0) [0|0] ""  HMI
+ SG_ C2S_fp_meb_dcdc_output_current m2 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_meb_dcdc_max_bat_chg_curr m3 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_meb_ccs_max_chg_current m4 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cr_running_off_delay_s m5 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cr_turn_pulse_on_time_s m6 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cr_turn_pulse_off_time_s m7 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cr_slip_ring_temp_thresho m8 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cr_full_power_current m9 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cr_max_current_fully_woun m10 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cr_max_current_slip_ring_ m11 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cr_fully_wound_current_ma m12 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cr_fully_unwound_current_ m13 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_md_safe_rpm_disable m14 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_md_bus_discharged_v m15 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_md_hours m16 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_md_hydraulic_enable m17 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_md_hydraulic_torque_limit m18 : 8|32@1- (0.1,0) [0|0] ""  HMI
+ SG_ C2S_fp_md_compressor1_enable m19 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_md_compressor1_torque_lim m20 : 8|32@1- (0.1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_fan_enable m21 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_fan_torque_limit m22 : 8|32@1- (0.1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_fan_min_rpm m23 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_fan_max_rpm m24 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_fan_off_threshold_rpm m25 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_fan_purge_speed m26 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_temp_buffer_c m27 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_shutdown_timeout_s m28 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump1_address m29 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump1_enabled m30 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump1_timeout_s m31 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump1_full_flow_rpm m32 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump1_idle_rpm m33 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump2_address m34 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump2_enabled m35 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump2_timeout_s m36 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump2_full_flow_rpm m37 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump2_idle_rpm m38 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump3_address m39 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump3_enabled m40 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump3_timeout_s m41 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump3_full_flow_rpm m42 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump3_idle_rpm m43 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump4_address m44 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump4_enabled m45 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump4_timeout_s m46 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump4_full_flow_rpm m47 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_pump4_idle_rpm m48 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_l2_motor_start_cool_te m49 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_l2_motor_max_cool_temp m50 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_l2_inv_start_cool_temp m51 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_l2_inv_max_cool_temp m52 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_l2_oil_start_cool_temp m53 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_l2_oil_max_cool_temp m54 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_l1_dcdc_start_cool_tem m55 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_l1_dcdc_max_cool_temp m56 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_l1_reel_drv_start_cool m57 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_l1_reel_drv_max_cool_t m58 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_l1_fan_mtr_start_cool_ m59 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_l1_fan_mtr_max_cool_te m60 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_l3_dchvi_start_cool_te m61 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_l3_dchvi_max_cool_temp m62 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_l4_acuhv_start_cool_te m63 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_l4_acuhv_max_cool_temp m64 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_btms_stop_dev_timeout_s m65 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_btms_safe_off_temp_low m66 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_btms_safe_off_temp_high m67 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_btms_pump_speed_pct m68 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_btms_low_power_speed_pct m69 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_hvac_compressor_speed m70 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_hvac_compressor_power m71 : 8|32@1- (0.1,0) [0|0] ""  HMI
+ SG_ C2S_fp_hvac_heater_power_setpoin m72 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_hvac_heater_temp_setpoint m73 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_hvac_pump_duty_cycle m74 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_request_all_params m75 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_fan_pid_kp m76 : 8|32@1- (1,0) [0|0] ""  HMI
+ SG_ C2S_fp_cs_fan_pid_ki m77 : 8|32@1- (1,0) [-3.4E+38|3.4E+38] ""  HMI
+ SG_ C2S_fp_cs_fan_pid_kd m78 : 8|32@1- (1,0) [-3.4E+38|3.4E+38] ""  HMI
+ SG_ C2S_fp_md_hydraulic_runtime_s m79 : 8|32@1- (1,0) [-3.4E+38|3.4E+38] ""  HMI
+ SG_ C2S_fp_md_compressor_runtime_s m80 : 8|32@1- (1,0) [-3.4E+38|3.4E+38] ""  HMI
+
+BO_ 2683180730 C2S_ActiveInfo: 8 EVCU
+ SG_ C2S_failed_to_start_reason : 56|8@1+ (1,0) [0|255] ""  HMI
+ SG_ C2S_waiting_for_hv_reset : 21|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_slip_ring_too_hot : 20|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_must_reverse : 19|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_stopping_main_hydraulic_moto : 18|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_stopping_main_compressor_mot : 17|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_stopping_cabin_hvac_compress : 16|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_stopping_cabin_hvac_heater : 15|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_stopping_cooling_system_fan : 14|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_stopping_cable_reel : 13|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_stopping_btms : 12|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_B460_emulation_active : 11|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_DCHVI_devices_not_synced : 10|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_ACUHV_devices_not_synced : 9|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_AC_devices_offline : 8|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Screen_HV_reset : 7|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_IMD_iso_alarm_is_active : 6|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Not_all_ignitions_are_on : 5|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_HVIL_is_not_closed : 4|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_IMD_not_safe_to_start : 3|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_HVPDU_HV_failed_to_start : 2|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_HVPDU_is_not_off : 1|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_EM_relay_not_closed : 0|1@1+ (1,0) [0|1] ""  HMI
+
+BO_ 2683180986 C2S_CRAndCCSControl: 6 EVCU
+ SG_ C2S_ccs_max_soc : 40|8@1+ (0.5,0) [0|100] "%"  HMI
+ SG_ C2S_ccs_max_charging_voltage : 24|16@1+ (1,0) [0|1024] "V"  HMI
+ SG_ C2S_ccs_max_charging_current : 16|8@1+ (1,0) [0|255] "A"  HMI
+ SG_ C2S_ccs_mode : 10|2@1+ (1,0) [0|3] ""  HMI
+ SG_ C2S_sc3_mode : 8|2@1+ (1,0) [0|3] ""  HMI
+ SG_ C2S_sc2_mode : 6|2@1+ (1,0) [0|3] ""  HMI
+ SG_ C2S_sc1_mode : 4|2@1+ (1,0) [0|3] ""  HMI
+ SG_ C2S_kc2_mode : 2|2@1+ (1,0) [0|3] ""  HMI
+ SG_ C2S_kc1_mode : 0|2@1+ (1,0) [0|3] ""  HMI
+
+BO_ 2683175354 C2S_HVDCPDUControl: 4 EVCU
+ SG_ C2S_HVDC_Ctrl_C5 : 20|2@1+ (1,0) [0|3] ""  HMI
+ SG_ C2S_HVDC_Ctrl_C4 : 18|2@1+ (1,0) [0|3] ""  HMI
+ SG_ C2S_HVDC_Ctrl_C3C2 : 16|2@1+ (1,0) [0|3] ""  HMI
+ SG_ C2S_HVDC_Ctrl_C3C1 : 14|2@1+ (1,0) [0|3] ""  HMI
+ SG_ C2S_HVDC_Ctrl_C3B2 : 12|2@1+ (1,0) [0|3] ""  HMI
+ SG_ C2S_HVDC_Ctrl_C3B1 : 10|2@1+ (1,0) [0|3] ""  HMI
+ SG_ C2S_HVDC_Ctrl_C3A2 : 8|2@1+ (1,0) [0|3] ""  HMI
+ SG_ C2S_HVDC_Ctrl_C3A1 : 6|2@1+ (1,0) [0|3] ""  HMI
+ SG_ C2S_HVDC_Ctrl_C2B : 4|2@1+ (1,0) [0|3] ""  HMI
+ SG_ C2S_HVDC_Ctrl_C2A : 2|2@1+ (1,0) [0|3] ""  HMI
+ SG_ C2S_HVDC_Ctrl_C1 : 0|2@1+ (1,0) [0|3] ""  HMI
+
+BO_ 2683175098 C2S_OtherControl: 4 HMI
+ SG_ C2S_CableReelInterlockOverride : 29|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_PowerSelectionBattery : 28|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_PowerSelectionGrid : 27|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_PowerSelectionCcs : 26|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_ScreenCrHeater : 25|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_ScreenCrLed : 24|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_ScreenCrKc2ReelingOut : 23|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_ScreenCrKc1ReelerRun : 22|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_BoschPumpOn : 21|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_BoschPumpOff : 20|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_EnableCableReelCharge : 19|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_EnableCcsCharge : 18|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_HvOverrideBitPos : 17|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_HvResetBitPos : 16|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_ScreenPowerCycleBitPos : 15|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_CascadiaDcdcOnBitPos : 14|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_CascadiaDcdcOffBitPos : 13|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_CoolingManualOnBitPos : 12|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_CoolingManualOffBitPos : 11|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_CoolingAutoBitPos : 10|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_ResetCcsBitPos : 9|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_PilotRelayBitPos : 8|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_ScreenCrManualAutoBitPos : 7|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_ScreenCrManualResetBitPos : 6|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_ScreenCrManualOutBitPos : 5|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_ScreenCrManualInBitPos : 4|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_ScreenPurgeFanBitPos : 3|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_ClearErrorsBitPos : 2|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_UseLowPowerBitPos : 1|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ C2S_RestartBitPos : 0|1@1+ (1,0) [0|1] ""  EVCU
+
+BO_ 2683176378 C2S_SMStatuses: 3 EVCU
+ SG_ C2S_CCS_state : 16|8@1+ (1,0) [0|255] ""  HMI
+ SG_ C2S_HVPDU_state : 8|8@1+ (1,0) [0|255] ""  HMI
+ SG_ C2S_EVCU_state : 0|8@1+ (1,0) [0|255] ""  HMI
+
+BO_ 2683175610 C2S_TTCIO1: 8 EVCU
+ SG_ C2S_plug_is_present : 62|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_ccs_release_din : 61|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_estop_pwr_fb2 : 60|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_estop_pwr_fb1 : 59|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_dcdc_en : 58|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_lv_lid : 57|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_estop_monitor : 56|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_ign_vpc2_kl15 : 55|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_ign_vpc1_kl15 : 54|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_inverter_CAN_en : 53|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_inverter_power : 52|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_imd_24v_pwr : 51|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_evcc_power : 50|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_evcc_term15 : 49|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_screen_kl15 : 48|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_ttc_io_1_kl15 : 47|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_keb_kl15 : 46|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_heater_cmd : 45|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_led_cmd : 44|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_KC2_reeling_out_cmd : 43|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_KC1_reeler_run_cmd : 42|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_sc4_reset_pb_cmd : 41|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_sc3_reel_out_cmd : 40|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_sc2_reel_in_cmd : 39|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_sc1_auto_sel_cmd : 38|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_pilot_ctrl_cmd : 37|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_panel_manual_auto_momenta : 36|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_panel_manual_out : 35|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_panel_manual_in : 34|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_panel_manual_reset : 33|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_k51_drive_ready : 32|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_k52_drive_running : 31|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_k61_auto_selected : 30|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_k63_manual_out : 29|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_k62_manual_in : 28|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_k53_motor_overtemp : 27|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_k55_drum_empty : 26|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_k54_drum_full : 25|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_k56_brake_open_manually : 24|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_cr_arm_limit : 23|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_imd_okhs : 22|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c5_fbk : 21|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c5_cmd : 20|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c4_fbk : 19|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c4_cmd : 18|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c3c2_fbk : 17|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c3c2_cmd : 16|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c3c1_fbk : 15|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c3c1_cmd : 14|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c3b2_fbk : 13|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c3b2_cmd : 12|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c3b1_fbk : 11|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c3b1_cmd : 10|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c3a2_fbk : 9|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c3a2_cmd : 8|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c3a1_fbk : 7|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c3a1_cmd : 6|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c2b_fbk : 5|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c2b_cmd : 4|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c2a_fbk : 3|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c2a_cmd : 2|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c1_fbk : 1|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_c1_cmd : 0|1@1+ (1,0) [0|1] ""  HMI
+
+BO_ 2683175866 C2S_TTCIO2: 8 EVCU
+ SG_ C2S_y489_bypass : 54|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_y424a_cooldown : 53|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_meb_set_user_selection : 52|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_meb_on_grid : 51|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_meb_on_ccs : 50|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_meb_on_battery : 49|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_blv204_3_connected : 48|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_blv204_2_connected : 47|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_blv204_1_connected : 46|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_blv191_1_connected : 45|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_blv190_3_connected : 44|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_blv190_2_connected : 43|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_blv190_1_connected : 42|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_iso_device_shutdown : 41|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_acdc_has_power : 40|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_rcs_y165_hecl_pump_is_on : 33|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_evcc_is_connected : 32|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_glycol_ls_out : 31|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_pump4_connected : 30|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_pump3_connected : 29|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_pump2_connected : 28|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_pump1_connected : 27|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_expander_connected : 26|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_show_must_reverse_warning : 25|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_reverse_is_allowed : 24|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_forward_is_allowed : 23|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_machine_is_moving : 22|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_machine_is_turning : 21|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_rcs_j1939_connected : 20|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_rcs_modules_connected : 19|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_in_rev : 18|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_in_fwd : 17|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_mode_POSITION : 16|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_mode_DRILL : 15|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_mode_TRAM : 14|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_mode_RRC : 13|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_start_button : 12|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_ac_activation : 11|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_rcs_operator_in_chair : 10|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_rcs_em_relay_closed : 9|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_rcs_start_key : 8|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_err_DCHVI4 : 7|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_err_DCHVI3 : 6|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_err_DCHVI2 : 5|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_err_DCHVI1 : 4|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_err_ACUHV1 : 3|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_err_ACUHV2 : 2|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_err_ACUHV3 : 1|1@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_err_ACUHV4 : 0|1@1+ (1,0) [0|1] ""  HMI
+
+BO_ 2683176122 C2S_TTCIOAnalog: 5 EVCU
+ SG_ C2S_Hyd_Oil_Y424c_Current_In_mA m52 : 8|32@1+ (1,0) [0|65535] "mA"  HMI
+ SG_ C2S_Hyd_Oil_Cooling_Temp m51 : 8|32@1+ (0.0125,-100) [-100|150] "�C"  HMI
+ SG_ C2S_Hyd_Oil_Cooling_Pressure m50 : 8|32@1+ (0.0125,-6.25) [-6.25|50] "bar"  HMI
+ SG_ C2S_RCS_B456_VesselPressure m49 : 8|32@1+ (0.0153,-6.345) [-6.345|55.08] "bar"  HMI
+ SG_ C2S_BL_Max_PowerSharingBatteryV m48 : 8|32@1+ (1,0) [0|1000] "V"  HMI
+ SG_ C2S_Acdc_Total_Power_W m47 : 8|32@1+ (1,0) [0|600000] "W"  HMI
+ SG_ C2S_Water_Mist_Level_10b_Raw m46 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Rcs_Hydraulic_Oil_Temp m45 : 8|32@1+ (0.24,-99.822) [-99.822|160.274] ""  HMI
+ SG_ C2S_Rcs_Compressor_Low_Stage_Tem m44 : 8|32@1+ (0.24,-99.822) [-99.822|160.274] ""  HMI
+ SG_ C2S_Rcs_Compressor_High_Stage_Te m43 : 8|32@1+ (0.254,-99.822) [-99.822|160.274] ""  HMI
+ SG_ C2S_Rcs_Tram_Pressure m42 : 8|32@1+ (0.428,-43.656) [-43.656|394.616] ""  HMI
+ SG_ C2S_Rcs_Ambient_Temperature m41 : 8|32@1+ (0.254,-99.822) [-99.822|160.274] ""  HMI
+ SG_ C2S_Rcs_Heat_Request m40 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Pilot_Diode_Mv m39 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Heat_Valve_Proportion m38 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Sensor_Dhab_Source_Mv m37 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Sensor_Dhab_Low m36 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Sensor_Dhab_High m35 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Dvc1000_3 m34 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Dvc1000_2 m33 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Dvc1000_1 m32 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Bat_Cpu m31 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Bat_K15 m30 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Acdc1_Flow_Out m29 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Motor1_Flow_Out m28 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Aux_In_Pwm m27 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Pump_Bosch_Pwm m26 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_B460_Pwm m25 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_B460_Press_In m24 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Rad_Press_In m23 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Rad_Press_Out m22 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Acdc2_Press_In m21 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Acdc2_Press_Out m20 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Acdc1_Press_In m19 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Acdc1_Press_Out m18 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Dcdc1_Press_Out m17 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Motor1_Press_In m16 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Motor1_Press_Out m15 : 8|32@1+ (1,0) [0|1] ""  HMI
+ SG_ C2S_Cr_Torque m14 : 8|32@1+ (1,0) [0|1] "mA"  HMI
+ SG_ C2S_Cr_Rotary_Sensor_Raw_In_uA m13 : 8|32@1+ (1,0) [0|1] "uA"  HMI
+ SG_ C2S_Cr_Rotary_Sensor_Percent m12 : 8|32@1+ (1,0) [0|1] "%"  HMI
+ SG_ C2S_Cr_Slip_Ring_Temp_5v3 m11 : 8|32@1+ (1,0) [0|1] "mV"  HMI
+ SG_ C2S_Cr_Slip_Ring_Temp_5v2 m10 : 8|32@1+ (1,0) [0|1] "mV"  HMI
+ SG_ C2S_Cr_Slip_Ring_Temp_5v1 m9 : 8|32@1+ (1,0) [0|1] "mV"  HMI
+ SG_ C2S_Cr_Slip_Ring_Sensor_Supply_M m8 : 8|32@1+ (1,0) [0|1] "mV"  HMI
+ SG_ C2S_Acdc2_Temp_Out m7 : 8|32@1+ (1,0) [0|1] "uA"  HMI
+ SG_ C2S_Acdc1_Temp_Out m6 : 8|32@1+ (1,0) [0|1] "uA"  HMI
+ SG_ C2S_Rad_Temp_In m5 : 8|32@1+ (1,0) [0|1] "uA"  HMI
+ SG_ C2S_Rad_Temp_Out m4 : 8|32@1+ (1,0) [0|1] "uA"  HMI
+ SG_ C2S_Motor1_Temp_Out m3 : 8|32@1+ (1,0) [0|1] "uA"  HMI
+ SG_ C2S_Lv_Pdu_Temp m2 : 8|32@1+ (1,0) [0|1] "Ohm"  HMI
+ SG_ C2S_Acdc_Pdu_Temp m1 : 8|32@1+ (1,0) [0|1] "Ohm"  HMI
+ SG_ C2S_Hv_Pdu_Temp m0 : 8|32@1+ (1,0) [0|1] "Ohm"  HMI
+ SG_ C2S_mux M : 0|8@1+ (1,0) [0|255] ""  HMI
+
+BO_ 2566902963 DCDC1_F_W_S_Message: 8 DCDC1
+ SG_ DCDC1_b_flt_InputUV : 0|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_flt_InputOV : 1|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_flt_OutputUV : 2|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_flt_OutputOV : 3|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_flt_OutputOC : 4|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_flt_OTP : 5|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_flt_I2Cfault : 6|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_flt_CANfault : 7|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_flt_EEPROM_CRCfault : 8|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_flt_ShortCircuit : 9|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_flt_ThermistorFault : 10|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_flt_Overload : 11|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_flt_OutputOVlatch : 12|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_flt_ReversPolarity : 13|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_war_CoolantOTP : 24|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_war_CurrentLimiting : 25|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_sts_UnitEnabled : 48|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_sts_Wakeup : 49|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_sts_Fault : 50|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_sts_LatchedFault : 51|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_sts_RemoteShutdown : 52|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_sts_StartUpInitDone : 53|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_sts_InputOk : 54|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_sts_HVIL_OK : 55|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_sts_ReversPolarity : 56|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC1_b_sts_Hiccup : 57|1@1+ (1,0) [0|1] ""  EVCU
+
+BO_ 2566903475 DCDC1_Input_Output: 8 DCDC1
+ SG_ DCDC1_Output_voltage : 0|16@1+ (0.05,0) [0|3276.75] "V"  EVCU
+ SG_ DCDC1_Output_current : 16|16@1+ (0.05,0) [0|3276.75] "A"  EVCU
+ SG_ DCDC1_Input_voltage : 32|16@1+ (0.05,0) [0|3276.75] "V"  EVCU
+ SG_ DCDC1_Temperature_Coolant : 48|16@1- (0.1,0) [-200|200] "deg C"  EVCU
+
+BO_ 2565845761 DCDC1_Setpoints: 8 EVCU
+ SG_ DCDC1_Set_index_byte M : 0|8@1+ (1,0) [0|255] ""  DCDC1
+ SG_ DCDC1_Remote_shutdown_sp m41 : 8|8@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ DCDC1_Temperature_coolant_fault m2 : 8|16@1- (0.1,0) [50|110] "deg C"  DCDC1
+ SG_ DCDC1_Output_voltage_UV_fault m1 : 8|16@1+ (0.05,0) [20|31.95] "V"  DCDC1
+ SG_ DCDC1_Output_Voltage_setpoint m0 : 8|16@1+ (0.05,0) [22|32] "V"  DCDC1
+ SG_ DCDC1_SRS_Batch_no m41 : 16|32@1+ (1,0) [0|4294967295] "" Vector__XXX
+ SG_ DCDC1_Temp_coolant_warning m2 : 24|16@1- (0.1,0) [40|100] "deg C"  DCDC1
+ SG_ DCDC1_Output_voltage_OV_fault m1 : 24|16@1+ (0.05,0) [22.05|36] "V"  DCDC1
+ SG_ DCDC1_Output_current_limit m0 : 24|16@1+ (0.05,0) [100|149] "A"  DCDC1
+ SG_ DCDC1_b_sts_RemoteShutdown m0 : 40|1@1+ (1,0) [0|1] ""  DCDC1
+ SG_ DCDC1_SRS_Serial_no m41 : 48|16@1+ (1,0) [0|65535] "" Vector__XXX
+
+BO_ 2566902961 DCDC2_F_W_S_Message: 8 DCDC2
+ SG_ DCDC2_b_flt_InputUV : 0|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_flt_InputOV : 1|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_flt_OutputUV : 2|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_flt_OutputOV : 3|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_flt_OutputOC : 4|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_flt_OTP : 5|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_flt_I2Cfault : 6|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_flt_CANfault : 7|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_flt_EEPROM_CRCfault : 8|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_flt_ShortCircuit : 9|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_flt_ThermistorFault : 10|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_flt_Overload : 11|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_flt_OutputOVlatch : 12|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_flt_ReversPolarity : 13|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_war_CoolantOTP : 24|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_war_CurrentLimiting : 25|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_sts_UnitEnabled : 48|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_sts_Wakeup : 49|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_sts_Fault : 50|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_sts_LatchedFault : 51|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_sts_RemoteShutdown : 52|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_sts_StartUpInitDone : 53|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_sts_InputOk : 54|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_sts_HVIL_OK : 55|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_sts_ReversPolarity : 56|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ DCDC2_b_sts_Hiccup : 57|1@1+ (1,0) [0|1] ""  EVCU
+
+BO_ 2566903473 DCDC2_Input_Output: 8 DCDC2
+ SG_ DCDC2_Output_voltage : 0|16@1+ (0.05,0) [0|3276.75] "V"  EVCU
+ SG_ DCDC2_Output_current : 16|16@1+ (0.05,0) [0|3276.75] "A"  EVCU
+ SG_ DCDC2_Input_voltage : 32|16@1+ (0.05,0) [0|3276.75] "V"  EVCU
+ SG_ DCDC2_Temperature_Coolant : 48|16@1- (0.1,0) [-200|200] "deg C"  EVCU
+
+BO_ 2565845249 DCDC2_Setpoints: 8 EVCU
+ SG_ DCDC2_Set_index_byte M : 0|8@1+ (1,0) [0|255] ""  DCDC2
+ SG_ DCDC2_Remote_shutdown_sp m41 : 8|8@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ DCDC2_Temperature_coolant_fault m2 : 8|16@1- (0.1,0) [50|110] "deg C"  DCDC2
+ SG_ DCDC2_Output_voltage_UV_fault m1 : 8|16@1+ (0.05,0) [20|31.95] "V"  DCDC2
+ SG_ DCDC2_Output_Voltage_setpoint m0 : 8|16@1+ (0.05,0) [22|32] "V"  DCDC2
+ SG_ DCDC2_SRS_Batch_no m41 : 16|32@1+ (1,0) [0|4294967295] "" Vector__XXX
+ SG_ DCDC1_Temp_coolant_warning m2 : 24|16@1- (0.1,0) [40|100] "deg C"  DCDC2
+ SG_ DCDC2_Output_voltage_OV_fault m1 : 24|16@1+ (0.05,0) [22.05|36] "V"  DCDC2
+ SG_ DCDC2_Output_current_limit m0 : 24|16@1+ (0.05,0) [100|149] "A"  DCDC2
+ SG_ DCDC2_b_sts_RemoteShutdown m0 : 40|1@1+ (1,0) [0|1] ""  DCDC2
+ SG_ DCDC2_SRS_Serial_no m41 : 48|16@1+ (1,0) [0|65535] "" Vector__XXX
+
+BO_ 2566853076 IMD_InfoGeneral: 7 IMD
+ SG_ IMD_G_Isolation_R_iso_Corrected : 0|16@1+ (1,0) [0|37500] "kOhm" Vector__XXX
+ SG_ IMD_G_Isolation_R_iso_Status : 16|2@1+ (1,0) [0|2] "" Vector__XXX
+ SG_ IMD_G_Isolation_Counter : 24|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ IMD_G_Warning_Alarm_Status_Bit00 : 32|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_G_Warning_Alarm_Status_Bit01 : 33|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_G_Warning_Alarm_Status_Bit02 : 34|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_G_Warning_Alarm_Status_Bit03 : 35|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_G_Warning_Alarm_Status_Bit04 : 36|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_G_Warning_Alarm_Status_Bit05 : 37|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_G_Warning_Alarm_Status_Bit06 : 38|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_G_Warning_Alarm_Status_Bit07 : 39|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_G_Warning_Alarm_Status_Bit08 : 40|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_G_Warning_Alarm_Status_Bit09 : 41|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_G_Warning_Alarm_Status_Bit10 : 42|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_G_Warning_Alarm_Status_Bit11 : 43|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_G_Warning_Alarm_Status_Bit12 : 44|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_G_Warning_Alarm_Status_Bit13 : 45|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_G_Warning_Alarm_Status_Bit14 : 46|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_G_Warning_Alarm_Status_Bit15 : 47|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_G_Device_Activity : 48|8@1+ (1,0) [0|4] "" Vector__XXX
+
+BO_ 2566853332 IMD_InfoIsolationDetail: 8 IMD
+ SG_ IMD_G_Isolation_R_iso_neg : 0|16@1+ (1,0) [0|50000] "kOhm" Vector__XXX
+ SG_ IMD_G_Isolation_R_iso_pos : 16|16@1+ (1,0) [0|50000] "kOhm" Vector__XXX
+ SG_ IMD_G_Isolation_R_iso_Original : 32|16@1+ (1,0) [0|64255] "kOhm" Vector__XXX
+ SG_ IMD_G_Isolation_Counter_Detail : 48|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ IMD_G_Isolation_Quality : 56|8@1+ (1,0) [0|100] "%" Vector__XXX
+
+BO_ 2566853844 IMD_InfoItSystem: 7 IMD
+ SG_ IMD_G_Capacity : 0|16@1+ (0.1,0) [0.1|20] "uF" Vector__XXX
+ SG_ IMD_G_Capacity_Counter : 16|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ IMD_G_Unbalance : 24|8@1+ (1,0) [0|250] "%" Vector__XXX
+ SG_ IMD_G_Unbalance_Counter : 32|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ IMD_G_HV_Frequency : 40|16@1+ (0.0078125,0) [0|501.9921875] "Hz" Vector__XXX
+
+BO_ 2566853588 IMD_InfoVoltage: 7 IMD
+ SG_ IMD_G_Voltage_HV : 0|16@1+ (0.05,-1606) [-1150|1150] "V" Vector__XXX
+ SG_ IMD_G_Voltage_HVneg_Earth : 16|16@1+ (0.05,-1606) [-1150|1150] "V" Vector__XXX
+ SG_ IMD_G_Voltage_HVpos_Earth : 32|16@1+ (0.05,-1606) [-1150|1150] "V" Vector__XXX
+ SG_ IMD_G_Voltage_Counter : 48|8@1+ (1,0) [0|255] "" Vector__XXX
+
+BO_ 2565854231 IMD_Request: 5 Master
+ SG_ IMD_Req_Request_Index M : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Earthlift_Status m112 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Warning_Alarm_Status m108 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Status_Lock m106 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Device_Activity m104 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Voltage_Thrs m102 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Voltage_Mode m100 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Voltage_HVpos_Earth m98 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Voltage_HVneg_Earth m96 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Voltage_HV m94 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Voltage_Counter m92 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_HV_Frequency m90 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Selftest_Period m88 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Capacity_Counter m84 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Capacity m82 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Isolation_Time_elapsed m80 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Isolation_R_iso_Origin m78 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Isolation_R_iso_Correc m76 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Isolation_Thrs_Warning m74 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Isolation_Thrs_Timeout m72 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Isolation_Thrs_Error m70 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Isolation_R_iso_Status m68 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Isolation_R_iso_pos m66 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Isolation_R_iso_neg m64 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Isolation_Quality m62 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Isolation_Power_On_Pro m58 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Isolation_Active_Profi m56 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Isolation_Counter m54 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Device_Error m52 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Selfholding_Iso_Alarm m48 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Unbalance_Thrs m46 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Unbalance_Counter m44 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Unbalance m42 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Hardware_DeviceTypePar m38 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Hardware_DeviceTy_0000 m36 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Software_Version m34 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Software_D_Number m32 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Software_Build_Number m30 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Hardware_SerialNumberP m28 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Hardware_SerialNu_0000 m26 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Hardware_Item_NumberPa m24 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Hardware_Item_Num_0000 m22 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Hardware_AH_NumberPart m20 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Hardware_AH_Numbe_0000 m18 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Hardware_AH_History m16 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Bootloader_Version m14 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Bootloader_D_Number m12 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_G_Bootloader_BuildNumber m10 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Req_S_Earthlift_Status m113 : 8|2@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Req_S_Factory_Reset m111 : 8|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Req_S_Status_Lock m107 : 8|2@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Req_S_Voltage_Thrs m103 : 8|16@1+ (1,0) [0|1000] "V" Vector__XXX
+ SG_ IMD_Req_S_Voltage_Mode m101 : 8|2@1+ (1,0) [0|2] "" Vector__XXX
+ SG_ IMD_Req_S_Selftest_Period m89 : 8|16@1+ (10,0) [10|642550] "s" Vector__XXX
+ SG_ IMD_Req_S_Selftest_Trigger m87 : 8|8@1+ (1,0) [0|2] "" Vector__XXX
+ SG_ IMD_Req_S_Isolation_Thrs_Warning m75 : 8|16@1+ (1,0) [30|2000] "kOhm" Vector__XXX
+ SG_ IMD_Req_S_Isolation_Thrs_Timeout m73 : 8|16@1+ (1,0) [0|64225] "s" Vector__XXX
+ SG_ IMD_Req_S_Isolation_Thrs_Error m71 : 8|16@1+ (1,0) [30|2000] "kOhm" Vector__XXX
+ SG_ IMD_Req_S_Isolation_Power_On_Pro m59 : 8|8@1+ (1,0) [0|6] "" Vector__XXX
+ SG_ IMD_Req_S_Isolation_Active_Profi m57 : 8|8@1+ (1,0) [0|6] "" Vector__XXX
+ SG_ IMD_Req_S_Selfholding_IsoAlarm_R m51 : 8|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Req_S_Selfholding_Iso_Alarm m49 : 8|2@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Req_S_Unbalance_Thrs m47 : 8|8@1+ (1,0) [0|45] "%" Vector__XXX
+
+BO_ 2565806036 IMD_Response: 8 IMD_StandAlone
+ SG_ IMD_Rsp_Response_Index M : 0|8@1+ (1,0) [0|0] ""  Master
+ SG_ IMD_Rsp_G_Earthlift_Status m112 : 8|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ IMD_Rsp_G_Warning_Alarm_Status_B m108 : 8|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Status_Lock m106 : 8|2@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Activity m104 : 8|8@1+ (1,0) [0|4] "" Vector__XXX
+ SG_ IMD_Rsp_G_Voltage_Thrs m102 : 8|16@1+ (1,0) [0|1000] "V" Vector__XXX
+ SG_ IMD_Rsp_G_Voltage_Mode m100 : 8|2@1+ (1,0) [0|2] "" Vector__XXX
+ SG_ IMD_Rsp_G_Voltage_HVpos_Earth m98 : 8|16@1+ (0.05,-1606) [-1150|1150] "V" Vector__XXX
+ SG_ IMD_Rsp_G_Voltage_HVneg_Earth m96 : 8|16@1+ (0.05,-1606) [-1150|1150] "V" Vector__XXX
+ SG_ IMD_Rsp_G_Voltage_HV m94 : 8|16@1+ (0.05,-1606) [-1150|1150] "V" Vector__XXX
+ SG_ IMD_Rsp_G_Voltage_Counter m92 : 8|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ IMD_Rsp_G_HV_Frequency m90 : 8|16@1+ (0.0078125,0) [0|501.9921875] "Hz" Vector__XXX
+ SG_ IMD_Rsp_G_Selftest_Period m88 : 8|16@1+ (10,0) [10|642550] "s" Vector__XXX
+ SG_ IMD_Rsp_G_Capacity_Counter m84 : 8|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ IMD_Rsp_G_Capacity m82 : 8|16@1+ (0.1,0) [0.1|20] "uF" Vector__XXX
+ SG_ IMD_Rsp_G_Isolation_Time_elapsed m80 : 8|16@1+ (1,0) [0|64255] "s" Vector__XXX
+ SG_ IMD_Rsp_G_Isolation_R_iso_Origin m78 : 8|16@1+ (1,0) [0|64255] "kOhm" Vector__XXX
+ SG_ IMD_Rsp_G_Isolation_R_iso_Correc m76 : 8|16@1+ (1,0) [0|37500] "kOhm" Vector__XXX
+ SG_ IMD_Rsp_G_Isolation_Thrs_Warning m74 : 8|16@1+ (1,0) [30|2000] "kOhm" Vector__XXX
+ SG_ IMD_Rsp_G_Isolation_Thrs_Timeout m72 : 8|16@1+ (1,0) [0|64225] "s" Vector__XXX
+ SG_ IMD_Rsp_G_Isolation_Thrs_Error m70 : 8|16@1+ (1,0) [30|2000] "kOhm" Vector__XXX
+ SG_ IMD_Rsp_G_Isolation_R_iso_Status m68 : 8|2@1+ (1,0) [0|2] "" Vector__XXX
+ SG_ IMD_Rsp_G_Isolation_R_iso_pos m66 : 8|16@1+ (1,0) [0|50000] "kOhm" Vector__XXX
+ SG_ IMD_Rsp_G_Isolation_R_iso_neg m64 : 8|16@1+ (1,0) [0|50000] "kOhm" Vector__XXX
+ SG_ IMD_Rsp_G_Isolation_Quality m62 : 8|8@1+ (1,0) [0|100] "%" Vector__XXX
+ SG_ IMD_Rsp_G_Isolation_Power_On_Pro m58 : 8|8@1+ (1,0) [0|6] "" Vector__XXX
+ SG_ IMD_Rsp_G_Isolation_Active_Profi m56 : 8|8@1+ (1,0) [0|6] "" Vector__XXX
+ SG_ IMD_Rsp_G_Isolation_Counter m54 : 8|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit00 m52 : 8|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Selfholding_Iso_Alarm m48 : 8|2@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Unbalance_Thrs m46 : 8|8@1+ (1,0) [0|45] "%" Vector__XXX
+ SG_ IMD_Rsp_G_Unbalance_Counter m44 : 8|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ IMD_Rsp_G_Unbalance m42 : 8|8@1+ (1,0) [0|250] "%" Vector__XXX
+ SG_ IMD_Rsp_G_Hardware_DeviceTypePar m38 : 8|56@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Rsp_G_Hardware_DeviceTy_0000 m36 : 8|56@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Rsp_G_Software_Version m34 : 8|16@1+ (1,0) [0|64255] "" Vector__XXX
+ SG_ IMD_Rsp_G_Software_D_Number m32 : 8|16@1+ (1,0) [0|656] "" Vector__XXX
+ SG_ IMD_Rsp_G_Software_Build_Number m30 : 8|16@1+ (1,0) [0|64255] "" Vector__XXX
+ SG_ IMD_Rsp_G_Hardware_SerialNumberP m28 : 8|56@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Rsp_G_Hardware_SerialNu_0000 m26 : 8|56@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Rsp_G_Hardware_Item_NumberPa m24 : 8|56@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Rsp_G_Hardware_Item_Num_0000 m22 : 8|56@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Rsp_G_Hardware_AH_NumberPart m20 : 8|56@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Rsp_G_Hardware_AH_Numbe_0000 m18 : 8|56@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Rsp_G_Hardware_AH_History m16 : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Rsp_G_Bootloader_Version m14 : 8|16@1+ (1,0) [0|65534] "" Vector__XXX
+ SG_ IMD_Rsp_G_Bootloader_D_Number m12 : 8|16@1+ (1,0) [0|684] "" Vector__XXX
+ SG_ IMD_Rsp_G_Bootloader_BuildNumber m10 : 8|16@1+ (1,0) [0|65534] "" Vector__XXX
+ SG_ IMD_Rsp_G_Warning_Alarm_Sta_0000 m108 : 9|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit01 m52 : 9|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Earthlift_Status_Unuse m112 : 10|6@1+ (1,0) [63|63] "" Vector__XXX
+ SG_ IMD_Rsp_G_Warning_Alarm_Sta_0001 m108 : 10|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Status_Lock_Unused m106 : 10|6@1+ (1,0) [0|63] "" Vector__XXX
+ SG_ IMD_Rsp_G_Voltage_Mode_Unused m100 : 10|6@1+ (1,0) [0|63] "" Vector__XXX
+ SG_ IMD_Rsp_G_Isolation_R_iso_S_0000 m68 : 10|6@1+ (1,0) [63|63] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit02 m52 : 10|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Req_G_Selfholding_Iso_Alarm_ m48 : 10|6@1+ (1,0) [63|63] "" Vector__XXX
+ SG_ IMD_Rsp_G_Warning_Alarm_Sta_0002 m108 : 11|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit03 m52 : 11|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Warning_Alarm_Sta_0003 m108 : 12|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit04 m52 : 12|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Warning_Alarm_Sta_0004 m108 : 13|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit05 m52 : 13|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Warning_Alarm_Sta_0005 m108 : 14|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit06 m52 : 14|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Warning_Alarm_Sta_0006 m108 : 15|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit07 m52 : 15|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Warning_Alarm_Sta_0007 m108 : 16|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit08 m52 : 16|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Warning_Alarm_Sta_0008 m108 : 17|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit09 m52 : 17|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Warning_Alarm_Sta_0009 m108 : 18|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit10 m52 : 18|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Warning_Alarm_Sta_0010 m108 : 19|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit11 m52 : 19|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Warning_Alarm_Sta_0011 m108 : 20|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit12 m52 : 20|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Warning_Alarm_Sta_0012 m108 : 21|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit13 m52 : 21|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Warning_Alarm_Sta_0013 m108 : 22|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit14 m52 : 22|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Warning_Alarm_Sta_0014 m108 : 23|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit15 m52 : 23|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit16 m52 : 24|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit17 m52 : 25|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit18 m52 : 26|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit19 m52 : 27|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit20 m52 : 28|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit21 m52 : 29|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit22 m52 : 30|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit23 m52 : 31|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit24 m52 : 32|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit25 m52 : 33|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit26 m52 : 34|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit27 m52 : 35|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit28 m52 : 36|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit29 m52 : 37|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit30 m52 : 38|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ IMD_Rsp_G_Device_Error_Bit31 m52 : 39|1@1+ (1,0) [0|1] "" Vector__XXX
+
+BO_ 2683176894 S2C_CompressorControl: 8 HMI
+ SG_ S2C_CmpCtl_active_discharge : 35|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_CmpCtl_enable : 34|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_CmpCtl_mode : 32|2@1+ (1,0) [0|3] ""  EVCU
+ SG_ S2C_CmpCtl_torque : 16|16@1+ (1,0) [0|65535] "Nm"  EVCU
+ SG_ S2C_CmpCtl_speed : 0|16@1+ (1,0) [0|65535] "rpm"  EVCU
+
+BO_ 2683180990 S2C_CRAndCCS_Control: 6 EVCU
+ SG_ S2C_ccs_max_soc : 40|8@1+ (0.5,0) [0|100] "%"  HMI
+ SG_ S2C_ccs_max_charging_voltage : 24|16@1+ (1,0) [0|1024] "V"  HMI
+ SG_ S2C_ccs_max_charging_current : 16|8@1+ (1,0) [0|255] "A"  HMI
+ SG_ S2C_CR_calibration_req : 13|1@1+ (1,0) [0|1] ""  HMI
+ SG_ S2C_ccs_mode : 10|2@1+ (1,0) [0|3] ""  HMI
+ SG_ S2C_sc3_mode : 8|2@1+ (1,0) [0|3] ""  HMI
+ SG_ S2C_sc2_mode : 6|2@1+ (1,0) [0|3] ""  HMI
+ SG_ S2C_sc1_mode : 4|2@1+ (1,0) [0|3] ""  HMI
+ SG_ S2C_kc2_mode : 2|2@1+ (1,0) [0|3] ""  HMI
+ SG_ S2C_kc1_mode : 0|2@1+ (1,0) [0|3] ""  HMI
+
+BO_ 2683177406 S2C_DCDCControl: 5 HMI
+ SG_ S2C_control_override : 32|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_output_current : 16|16@1+ (0.1,0) [100|150] "A"  EVCU
+ SG_ S2C_output_voltage : 0|16@1+ (0.1,0) [22|32] "V"  EVCU
+
+BO_ 2683177150 S2C_FanControl: 5 HMI
+ SG_ S2C_FanCtl_active_discharge : 35|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_FanCtl_enable : 34|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_FanCtl_mode : 32|2@1+ (1,0) [0|3] ""  EVCU
+ SG_ S2C_FanCtl_torque : 16|16@1+ (1,0) [0|65535] "Nm"  EVCU
+ SG_ S2C_FanCtl_speed : 0|16@1+ (1,0) [0|65535] "rpm"  EVCU
+
+BO_ 2683175358 S2C_HVDCPDUControl: 4 HMI
+ SG_ S2C_HVDC_Ctrl_C5 : 20|2@1+ (1,0) [0|3] ""  EVCU
+ SG_ S2C_HVDC_Ctrl_C4 : 18|2@1+ (1,0) [0|3] ""  EVCU
+ SG_ S2C_HVDC_Ctrl_C3C2 : 16|2@1+ (1,0) [0|3] ""  EVCU
+ SG_ S2C_HVDC_Ctrl_C3C1 : 14|2@1+ (1,0) [0|3] ""  EVCU
+ SG_ S2C_HVDC_Ctrl_C3B2 : 12|2@1+ (1,0) [0|3] ""  EVCU
+ SG_ S2C_HVDC_Ctrl_C3B1 : 10|2@1+ (1,0) [0|3] ""  EVCU
+ SG_ S2C_HVDC_Ctrl_C3A2 : 8|2@1+ (1,0) [0|3] ""  EVCU
+ SG_ S2C_HVDC_Ctrl_C3A1 : 6|2@1+ (1,0) [0|3] ""  EVCU
+ SG_ S2C_HVDC_Ctrl_C2B : 4|2@1+ (1,0) [0|3] ""  EVCU
+ SG_ S2C_HVDC_Ctrl_C2A : 2|2@1+ (1,0) [0|3] ""  EVCU
+ SG_ S2C_HVDC_Ctrl_C1 : 0|2@1+ (1,0) [0|3] ""  EVCU
+
+BO_ 2683176638 S2C_HydraulicControl: 8 HMI
+ SG_ S2C_HydCtl_hyd_oil_y424c_pwm : 42|4@1+ (10,0) [0|100] "%"  EVCU
+ SG_ S2C_HydCtl_hyd_oil_y489_mode : 40|2@1+ (1,0) [0|3] ""  EVCU
+ SG_ S2C_HydCtl_hyd_oil_y424a_mode : 38|2@1+ (1,0) [0|3] ""  EVCU
+ SG_ S2C_HydCtl_hyd_oil_y424c_mode : 36|2@1+ (1,0) [0|3] ""  EVCU
+ SG_ S2C_HydCtl_active_discharge : 35|1@1+ (1,0) [0|1] ""  HMI
+ SG_ S2C_HydCtl_enable : 34|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_HydCtl_mode : 32|2@1+ (1,0) [0|3] ""  EVCU
+ SG_ S2C_HydCtl_torque : 16|16@1+ (1,0) [0|65535] "Nm"  EVCU
+ SG_ S2C_HydCtl_speed : 0|16@1+ (1,0) [0|65535] "rpm"  EVCU
+
+BO_ 2683175102 S2C_OtherControl: 4 HMI
+ SG_ S2C_PowerSelectionBattery : 28|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_PowerSelectionGrid : 27|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_PowerSelectionCcs : 26|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_ScreenCrHeater : 25|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_ScreenCrLed : 24|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_ScreenCrKc2ReelingOut : 23|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_ScreenCrKc1ReelerRun : 22|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_BoschPumpOn : 21|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_BoschPumpOff : 20|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_EnableCableReelCharge : 19|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_EnableCcsCharge : 18|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_HvOverrideBitPos : 17|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_HvResetBitPos : 16|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_ScreenPowerCycleBitPos : 15|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_CascadiaDcdcOnBitPos : 14|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_CascadiaDcdcOffBitPos : 13|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_CoolingManualOnBitPos : 12|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_CoolingManualOffBitPos : 11|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_CoolingAutoBitPos : 10|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_ResetCcsBitPos : 9|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_PilotRelayBitPos : 8|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_ScreenCrManualAutoBitPos : 7|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_ScreenCrManualResetBitPos : 6|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_ScreenCrManualOutBitPos : 5|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_ScreenCrManualInBitPos : 4|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_ScreenPurgeFanBitPos : 3|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_ClearErrorsBitPos : 2|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_UseLowPowerBitPos : 1|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ S2C_RestartBitPos : 0|1@1+ (1,0) [0|1] ""  EVCU
+
+BO_ 2683177662 S2C_SettingsParameterUpdate: 5 HMI
+ SG_ S2C_sp_param_id M : 0|8@1+ (1,0) [0|80] ""  EVCU
+ SG_ S2C_sp_meb_contactor_fail_timeou m0 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_meb_dcdc_output_voltage m1 : 8|32@1- (0.1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_meb_dcdc_output_current m2 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_meb_dcdc_max_bat_chg_curr m3 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_meb_ccs_max_chg_current m4 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cr_running_off_delay_s m5 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cr_turn_pulse_on_time_s m6 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cr_turn_pulse_off_time_s m7 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cr_slip_ring_temp_thresho m8 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cr_full_power_current m9 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cr_max_current_fully_woun m10 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cr_max_current_slip_ring_ m11 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cr_fully_wound_current_ma m12 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cr_fully_unwound_current_ m13 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_md_safe_rpm_disable m14 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_md_bus_discharged_v m15 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_md_hours m16 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_md_hydraulic_enable m17 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_md_hydraulic_torque_limit m18 : 8|32@1- (0.1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_md_compressor1_enable m19 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_md_compressor1_torque_lim m20 : 8|32@1- (0.1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_fan_enable m21 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_fan_torque_limit m22 : 8|32@1- (0.1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_fan_min_rpm m23 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_fan_max_rpm m24 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_fan_off_threshold_rpm m25 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_fan_purge_speed m26 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_temp_buffer_c m27 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_shutdown_timeout_s m28 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump1_address m29 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump1_enabled m30 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump1_timeout_s m31 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump1_full_flow_rpm m32 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump1_idle_rpm m33 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump2_address m34 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump2_enabled m35 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump2_timeout_s m36 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump2_full_flow_rpm m37 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump2_idle_rpm m38 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump3_address m39 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump3_enabled m40 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump3_timeout_s m41 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump3_full_flow_rpm m42 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump3_idle_rpm m43 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump4_address m44 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump4_enabled m45 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump4_timeout_s m46 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump4_full_flow_rpm m47 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_pump4_idle_rpm m48 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_l2_motor_start_cool_te m49 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_l2_motor_max_cool_temp m50 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_l2_inv_start_cool_temp m51 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_l2_inv_max_cool_temp m52 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_l2_oil_start_cool_temp m53 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_l2_oil_max_cool_temp m54 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_l1_dcdc_start_cool_tem m55 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_l1_dcdc_max_cool_temp m56 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_l1_reel_drv_start_cool m57 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_l1_reel_drv_max_cool_t m58 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_l1_fan_mtr_start_cool_ m59 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_l1_fan_mtr_max_cool_te m60 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_l3_dchvi_start_cool_te m61 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_l3_dchvi_max_cool_temp m62 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_l4_acuhv_start_cool_te m63 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_l4_acuhv_max_cool_temp m64 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_btms_stop_dev_timeout_s m65 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_btms_safe_off_temp_low m66 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_btms_safe_off_temp_high m67 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_btms_pump_speed_pct m68 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_btms_low_power_speed_pct m69 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_hvac_compressor_speed m70 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_hvac_compressor_power m71 : 8|32@1- (0.1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_hvac_heater_power_setpoin m72 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_hvac_heater_temp_setpoint m73 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_hvac_pump_duty_cycle m74 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_request_all_params m75 : 8|32@1- (1,0) [0|0] ""  EVCU
+ SG_ S2C_sp_cs_fan_pid_kp m76 : 8|32@1- (1,0) [-3.4E+38|3.4E+38] ""  EVCU
+ SG_ S2C_sp_cs_fan_pid_ki m77 : 8|32@1- (1,0) [-3.4E+38|3.4E+38] ""  EVCU
+ SG_ S2C_sp_cs_fan_pid_kd m78 : 8|32@1- (1,0) [-3.4E+38|3.4E+38] ""  EVCU
+ SG_ S2C_sp_md_hydraulic_runtime_s m79 : 8|32@1- (1,0) [-3.4E+38|3.4E+38] ""  EVCU
+ SG_ S2C_sp_md_compressor_runtime_s m80 : 8|32@1- (1,0) [-3.4E+38|3.4E+38] ""  EVCU
+
+BO_ 2565806336 TMS_Cmd1: 8 Vector__XXX
+ SG_ Cmd_Operating_Mode : 13|3@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ Ambient_temp : 48|8@1+ (1,-40) [-40|215] "*C" Vector__XXX
+ SG_ Cmd_Battery_inlet_temp : 32|8@1+ (1,-40) [-40|215] "*C" Vector__XXX
+ SG_ Cmd_Battery_outlet_temp : 40|8@1+ (1,-40) [-40|215] "*C" Vector__XXX
+ SG_ Cooling_Capacity : 24|8@1+ (1,0) [0|100] "Rpm" Vector__XXX
+ SG_ Cmd_Heater_power : 56|3@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ Cmd_Pump_Speed : 16|8@1+ (1,0) [0|0] "Rpm" Vector__XXX
+
+BO_ 2566906137 TMS_Rx1: 8 Vector__XXX
+ SG_ Coolant_Level : 0|2@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ Fb_Operating_Mode : 13|3@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ System_Status : 8|3@1+ (1,0) [0|7] "" Vector__XXX
+ SG_ Fb_Condensor_Fan_Speed : 16|8@1+ (1,0) [0|100] "%" Vector__XXX
+ SG_ Fb_Pump_Speed : 24|8@1+ (1,0) [0|100] "%" Vector__XXX
+ SG_ High_Pressure : 32|8@1+ (2,0) [0|510] "psi" Vector__XXX
+ SG_ Low_Pressure : 48|8@1+ (1,0) [0|255] "psi" Vector__XXX
+ SG_ Suction_temp : 56|8@1+ (1,-40) [-40|215] "*C" Vector__XXX
+
+BO_ 2566906393 TMS_Rx2: 8 Vector__XXX
+ SG_ Glycol_Heater_power : 0|8@1+ (1,0) [0|100] "%" Vector__XXX
+ SG_ Coolant_inlet_temp : 32|8@1+ (1,-40) [-40|215] "*C" Vector__XXX
+ SG_ Coolant_outlet_temp : 40|8@1+ (1,-40) [-40|215] "*C" Vector__XXX
+ SG_ Heat_Error : 56|2@1+ (1,0) [0|3] "b" Vector__XXX
+ SG_ HP_Transducer_Sensor_Error : 50|2@1+ (1,0) [0|3] "b" Vector__XXX
+ SG_ LP_Temp_Sensor_Error : 52|2@1+ (1,0) [0|3] "b" Vector__XXX
+ SG_ LP_Transducer_Sensor_Error : 48|2@1+ (1,0) [0|3] "b" Vector__XXX
+ SG_ Safe_to_turn_off : 60|2@1+ (1,0) [0|3] "b" Vector__XXX
+
+BO_ 2566906649 TMS_Rx3: 8 Vector__XXX
+ SG_ Compressor_HV_Current : 8|8@1+ (0.5,0) [0|127.5] "A" Vector__XXX
+ SG_ Compressor_HV_Voltage : 16|8@1+ (5,0) [0|1275] "V" Vector__XXX
+ SG_ Compressor_speed : 0|8@1+ (50,0) [0|8500] "Rpm" Vector__XXX
+ SG_ COMP_Bus_Off : 40|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ COMP_Communication_Fault : 42|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ COMP_Current_Fault : 44|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ COMP_HV_Fault : 45|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ COMP_Internal_Voltage_Fault : 41|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ COMP_Temperature_Fault : 43|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ Compressor_State : 46|2@1+ (1,0) [0|3] "" Vector__XXX
+
+BO_ 2565835264 WP120_AC_EMP__MotorCommand: 8 Vector__XXX
+ SG_ AC_OnOffDirection : 0|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ AC_PowerHold : 2|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ AC_MotorSpeed : 8|16@1+ (0.5,0) [0|6000] "RPM" Vector__XXX
+ SG_ AC_PercentRPMSpeed : 24|8@1+ (0.5,0) [0|125] "Pct" Vector__XXX
+
+BO_ 2566857610 WP120_AC_EMP__MotorStatus2: 8 Vector__XXX
+ SG_ AC_OnOffDirectionStatus : 0|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ AC_StatusReasonCode : 2|4@1+ (1,0) [0|15] "" Vector__XXX
+ SG_ AC_CommandStatus : 6|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ AC_MotorSpeed : 8|16@1+ (0.5,0) [0|6000] "RPM" Vector__XXX
+ SG_ AC_MediumTemperature : 24|16@1+ (0.03125,-273) [-273|300] "C" Vector__XXX
+ SG_ AC_MotorPower : 40|16@1+ (0.5,0) [0|5000] "W" Vector__XXX
+ SG_ AC_MotorServiceIndicator : 56|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ AC_MotorOperatingStatus : 58|2@1+ (1,0) [0|3] "" Vector__XXX
+
+BO_ 2565832960 WP120_BE_EMP__MotorCommand: 8 Vector__XXX
+ SG_ BE_OnOffDirection : 0|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ BE_PowerHold : 2|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ BE_MotorSpeed : 8|16@1+ (0.5,0) [0|6000] "RPM" Vector__XXX
+ SG_ BE_PercentRPMSpeed : 24|8@1+ (0.5,0) [0|125] "Pct" Vector__XXX
+
+BO_ 2566857601 WP120_BE_EMP__MotorStatus2: 8 Vector__XXX
+ SG_ BE_OnOffDirectionStatus : 0|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ BE_StatusReasonCode : 2|4@1+ (1,0) [0|15] "" Vector__XXX
+ SG_ BE_CommandStatus : 6|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ BE_MotorSpeed : 8|16@1+ (0.5,0) [0|6000] "RPM" Vector__XXX
+ SG_ BE_MediumTemperature : 24|16@1+ (0.03125,-273) [-273|300] "C" Vector__XXX
+ SG_ BE_MotorPower : 40|16@1+ (0.5,0) [0|5000] "W" Vector__XXX
+ SG_ BE_MotorServiceIndicator : 56|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ BE_MotorOperatingStatus : 58|2@1+ (1,0) [0|3] "" Vector__XXX
+
+BO_ 2565832704 WP120_DC_EMP__MotorCommand: 8 Vector__XXX
+ SG_ DC_OnOffDirection : 0|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DC_PowerHold : 2|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DC_MotorSpeed : 8|16@1+ (0.5,0) [0|6000] "RPM" Vector__XXX
+ SG_ DC_PercentRPMSpeed : 24|8@1+ (0.5,0) [0|125] "Pct" Vector__XXX
+
+BO_ 2566857600 WP120_DC_EMP__MotorStatus2: 8 Vector__XXX
+ SG_ DC_OnOffDirectionStatus : 0|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DC_StatusReasonCode : 2|4@1+ (1,0) [0|15] "" Vector__XXX
+ SG_ DC_CommandStatus : 6|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DC_MotorSpeed : 8|16@1+ (0.5,0) [0|6000] "RPM" Vector__XXX
+ SG_ DC_MediumTemperature : 24|16@1+ (0.03125,-273) [-273|300] "C" Vector__XXX
+ SG_ DC_MotorPower : 40|16@1+ (0.5,0) [0|5000] "W" Vector__XXX
+ SG_ DC_MotorServiceIndicator : 56|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ DC_MotorOperatingStatus : 58|2@1+ (1,0) [0|3] "" Vector__XXX
+
+BO_ 2565833216 WP120_IM_EMP__MotorCommand: 8 Vector__XXX
+ SG_ IM_OnOffDirection : 0|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ IM_PowerHold : 2|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ IM_MotorSpeed : 8|16@1+ (0.5,0) [0|6000] "RPM" Vector__XXX
+ SG_ IM_PercentRPMSpeed : 24|8@1+ (0.5,0) [0|125] "Pct" Vector__XXX
+
+BO_ 2566857602 WP120_IM_EMP__MotorStatus2: 8 Vector__XXX
+ SG_ IM_OnOffDirectionStatus : 0|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ IM_StatusReasonCode : 2|4@1+ (1,0) [0|15] "" Vector__XXX
+ SG_ IM_CommandStatus : 6|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ IM_MotorSpeed : 8|16@1+ (0.5,0) [0|6000] "RPM" Vector__XXX
+ SG_ IM_MediumTemperature : 24|16@1+ (0.03125,-273) [-273|300] "C" Vector__XXX
+ SG_ IM_MotorPower : 40|16@1+ (0.5,0) [0|5000] "W" Vector__XXX
+ SG_ IM_MotorServiceIndicator : 56|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ IM_MotorOperatingStatus : 58|2@1+ (1,0) [0|3] "" Vector__XXX
+
+BO_ 2683178942 S2C_DCACControl: 7 HMI
+ SG_ S2C_BCL_Vdc_OL_Setpoint : 0|16@1+ (0.05,0) [0|1000] "V"  EVCU
+ SG_ S2C_BCL_Vdc_UL_Setpoint : 16|16@1+ (0.05,0) [0|1000] "V"  EVCU
+ SG_ S2C_BCL_Iac_Setpoint : 32|16@1+ (1,0) [0|500] "A"  EVCU
+ SG_ S2C_BCL_Mode : 48|2@1+ (1,0) [0|3] ""  EVCU
+ SG_ S2C_BCL_Enable : 50|1@1+ (1,0) [0|1] ""  EVCU
+
+
+
+CM_ BO_ 2556487144 "command from vehicle/system to compressor";
+CM_ SG_ 2556487144 AC_compressor_power_limit "Compressor power limit setting";
+CM_ SG_ 2556487144 AC_compressor_immediate_shutdown "1=on 0=off";
+CM_ SG_ 2556487144 AC_compressor_enable "1=on 0=off";
+CM_ SG_ 2556487144 AC_speed_of_compressor "Compressor speed setting";
+CM_ BO_ 2555439333 "feedback from compressor";
+CM_ SG_ 2555439333 Comp_Input_DC_Voltage "DC Voltage sensor measured value";
+CM_ SG_ 2555439333 Comp_Input_DC_Current "DC Current sensor measured value";
+CM_ SG_ 2555439333 Comp_IPM_temperature "Temperature sensor measured value";
+CM_ SG_ 2555439333 Comp_compressor_error "0x00:No Error
+0x01:Over Current
+0x02:Over Voltage
+0x04:Under Voltage
+0x08:Over temperature
+0x10:Internal fault
+0x20:Communication Error
+0x40:Over Current Lock
+0x80:Over Power Lock";
+CM_ SG_ 2555439333 Comp_compressor_status "0=off��1=running��3=fault";
+CM_ SG_ 2555439333 Comp_phase_Current "Phase Current sensor measured value";
+CM_ SG_ 2555439333 Comp_speed_of_compressor "Actual speed feedback from compressor";
+CM_ SG_ 2565853185 BCL_cmd_EVSE_type_set "1 = EVSE type 1 ( J1772 )
+2 = EVSE type (VDE-AR-E 2623-2-2)";
+CM_ BO_ 2566902963 "Faults, Warnings and Status flags";
+CM_ SG_ 2565845761 DCDC1_Temperature_coolant_fault "the coolant temeperature value treshold. If this temperature is exceeded then coolant fault is generated";
+CM_ SG_ 2565845761 DCDC1_Output_voltage_UV_fault "set the voltage value for treshold of undervoltage error. If ouput voltage falls below this value then undervoltage fault is generated by power supply.";
+CM_ SG_ 2565845761 DCDC1_Output_Voltage_setpoint "set the desired value of power supply output Voltage";
+CM_ SG_ 2565845761 DCDC1_Temp_coolant_warning "the coolant temeperature value treshold. If this temperature is exceeded then coolant warning is generated";
+CM_ SG_ 2565845761 DCDC1_Output_voltage_OV_fault "set the voltage value for treshold of overvoltage error. If output voltage exceeds this value then overvoltage fault is generated by power supply.";
+CM_ SG_ 2565845761 DCDC1_Output_current_limit "set the desired value of power supply output Current limit. Above this value the unit will drop output Voltage according current limiting curve.";
+CM_ BO_ 2566902961 "Faults, Warnings and Status flags";
+CM_ SG_ 2565845249 DCDC2_Temperature_coolant_fault "the coolant temeperature value treshold. If this temperature is exceeded then coolant fault is generated";
+CM_ SG_ 2565845249 DCDC2_Output_voltage_UV_fault "set the voltage value for treshold of undervoltage error. If ouput voltage falls below this value then undervoltage fault is generated by power supply.";
+CM_ SG_ 2565845249 DCDC2_Output_Voltage_setpoint "set the desired value of power supply output Voltage";
+CM_ SG_ 2565845249 DCDC1_Temp_coolant_warning "the coolant temeperature value treshold. If this temperature is exceeded then coolant warning is generated";
+CM_ SG_ 2565845249 DCDC2_Output_voltage_OV_fault "set the voltage value for treshold of overvoltage error. If output voltage exceeds this value then overvoltage fault is generated by power supply.";
+CM_ SG_ 2565845249 DCDC2_Output_current_limit "set the desired value of power supply output Current limit. Above this value the unit will drop output Voltage according current limiting curve.";
+CM_ SG_ 2566853076 IMD_G_Isolation_R_iso_Corrected "ValueType: Identifier = 383, Name = SAErs02";
+CM_ SG_ 2566853076 IMD_G_Isolation_R_iso_Status "ValueType: Identifier = 87, Name = SAEbs02";
+CM_ SG_ 2566853076 IMD_G_Isolation_Counter "ValueType: Identifier = 133, Name = SAEct03";
+CM_ SG_ 2566853076 IMD_G_Warning_Alarm_Status_Bit00 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2566853076 IMD_G_Warning_Alarm_Status_Bit01 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2566853076 IMD_G_Warning_Alarm_Status_Bit02 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2566853076 IMD_G_Warning_Alarm_Status_Bit03 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2566853076 IMD_G_Warning_Alarm_Status_Bit04 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2566853076 IMD_G_Warning_Alarm_Status_Bit05 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2566853076 IMD_G_Warning_Alarm_Status_Bit06 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2566853076 IMD_G_Warning_Alarm_Status_Bit07 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2566853076 IMD_G_Warning_Alarm_Status_Bit08 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2566853076 IMD_G_Warning_Alarm_Status_Bit09 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2566853076 IMD_G_Warning_Alarm_Status_Bit10 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2566853076 IMD_G_Warning_Alarm_Status_Bit11 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2566853076 IMD_G_Warning_Alarm_Status_Bit12 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2566853076 IMD_G_Warning_Alarm_Status_Bit13 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2566853076 IMD_G_Warning_Alarm_Status_Bit14 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2566853076 IMD_G_Warning_Alarm_Status_Bit15 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2566853076 IMD_G_Device_Activity "ValueType: Identifier = 129, Name = SAEct02";
+CM_ SG_ 2566853332 IMD_G_Isolation_R_iso_neg "ValueType: Identifier = 383, Name = SAErs02";
+CM_ SG_ 2566853332 IMD_G_Isolation_R_iso_pos "ValueType: Identifier = 383, Name = SAErs02";
+CM_ SG_ 2566853332 IMD_G_Isolation_R_iso_Original "ValueType: Identifier = 383, Name = SAErs02";
+CM_ SG_ 2566853332 IMD_G_Isolation_Counter_Detail "ValueType: Identifier = 133, Name = SAEct03";
+CM_ SG_ 2566853332 IMD_G_Isolation_Quality "ValueType: Identifier = 46, Name = SAEpc06";
+CM_ SG_ 2566853844 IMD_G_Capacity "ValueType: Identifier = 283, Name = SAEmd01    ";
+CM_ SG_ 2566853844 IMD_G_Capacity_Counter "ValueType: Identifier = 133, Name = SAEct03";
+CM_ SG_ 2566853844 IMD_G_Unbalance "ValueType: Identifier = 46, Name = SAEpc06";
+CM_ SG_ 2566853844 IMD_G_Unbalance_Counter "ValueType: Identifier = 133, Name = SAEct03";
+CM_ SG_ 2566853844 IMD_G_HV_Frequency "ValueType: Identifier = 461, Name = SAEfq04";
+CM_ SG_ 2566853588 IMD_G_Voltage_HV "ValueType: Identifier = 461, Name = SAEfq04";
+CM_ SG_ 2566853588 IMD_G_Voltage_HVneg_Earth "ValueType: Identifier = 461, Name = SAEfq04";
+CM_ SG_ 2566853588 IMD_G_Voltage_HVpos_Earth "ValueType: Identifier = 461, Name = SAEfq04";
+CM_ SG_ 2566853588 IMD_G_Voltage_Counter "ValueType: Identifier = 133, Name = SAEct03";
+CM_ SG_ 2565854231 IMD_Req_S_Earthlift_Status "ValueType: Identifier = 87, Name = SAEbs02";
+CM_ SG_ 2565854231 IMD_Req_S_Factory_Reset "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565854231 IMD_Req_S_Status_Lock "ValueType: Identifier = 87, Name = SAEbs02";
+CM_ SG_ 2565854231 IMD_Req_S_Voltage_Thrs "ValueType: Identifier = 145, Name = SAEev02";
+CM_ SG_ 2565854231 IMD_Req_S_Voltage_Mode "ValueType: Identifier = 87, Name = SAEbs02";
+CM_ SG_ 2565854231 IMD_Req_S_Selftest_Period "ValueType: Identifier = 464, Name = SAEtm25";
+CM_ SG_ 2565854231 IMD_Req_S_Selftest_Trigger "ValueType: Identifier = 120, Name = SAEcb01";
+CM_ SG_ 2565854231 IMD_Req_S_Isolation_Thrs_Warning "ValueType: Identifier = 383, Name = SAErs02";
+CM_ SG_ 2565854231 IMD_Req_S_Isolation_Thrs_Timeout "ValueType: Identifier = 64, Name = SAEtm05";
+CM_ SG_ 2565854231 IMD_Req_S_Isolation_Thrs_Error "ValueType: Identifier = 383, Name = SAErs02";
+CM_ SG_ 2565854231 IMD_Req_S_Isolation_Power_On_Pro "ValueType: Identifier = 129, Name = SAEct02";
+CM_ SG_ 2565854231 IMD_Req_S_Isolation_Active_Profi "ValueType: Identifier = 129, Name = SAEct02";
+CM_ SG_ 2565854231 IMD_Req_S_Selfholding_IsoAlarm_R "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565854231 IMD_Req_S_Selfholding_Iso_Alarm "ValueType: Identifier = 87, Name = SAEbs02";
+CM_ SG_ 2565854231 IMD_Req_S_Unbalance_Thrs "ValueType: Identifier = 46, Name = SAEpc06";
+CM_ SG_ 2565806036 IMD_Rsp_G_Earthlift_Status "ValueType: Identifier = 87, Name = SAEbs02";
+CM_ SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Status_B "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Status_Lock "ValueType: Identifier = 87, Name = SAEbs02";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Activity "ValueType: Identifier = 129, Name = SAEct02";
+CM_ SG_ 2565806036 IMD_Rsp_G_Voltage_Thrs "ValueType: Identifier = 145, Name = SAEev02";
+CM_ SG_ 2565806036 IMD_Rsp_G_Voltage_Mode "ValueType: Identifier = 87, Name = SAEbs02";
+CM_ SG_ 2565806036 IMD_Rsp_G_Voltage_HVpos_Earth "ValueType: Identifier = 461, Name = SAEfq04";
+CM_ SG_ 2565806036 IMD_Rsp_G_Voltage_HVneg_Earth "ValueType: Identifier = 461, Name = SAEfq04";
+CM_ SG_ 2565806036 IMD_Rsp_G_Voltage_HV "ValueType: Identifier = 461, Name = SAEfq04";
+CM_ SG_ 2565806036 IMD_Rsp_G_Voltage_Counter "ValueType: Identifier = 133, Name = SAEct03";
+CM_ SG_ 2565806036 IMD_Rsp_G_HV_Frequency "ValueType: Identifier = 461, Name = SAEfq04";
+CM_ SG_ 2565806036 IMD_Rsp_G_Selftest_Period "ValueType: Identifier = 464, Name = SAEtm25";
+CM_ SG_ 2565806036 IMD_Rsp_G_Capacity_Counter "ValueType: Identifier = 133, Name = SAEct03";
+CM_ SG_ 2565806036 IMD_Rsp_G_Capacity "ValueType: Identifier = 283, Name = SAEmd01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Isolation_Time_elapsed "ValueType: Identifier = 64, Name = SAEtm05";
+CM_ SG_ 2565806036 IMD_Rsp_G_Isolation_R_iso_Origin "ValueType: Identifier = 383, Name = SAErs02";
+CM_ SG_ 2565806036 IMD_Rsp_G_Isolation_R_iso_Correc "ValueType: Identifier = 383, Name = SAErs02";
+CM_ SG_ 2565806036 IMD_Rsp_G_Isolation_Thrs_Warning "ValueType: Identifier = 383, Name = SAErs02";
+CM_ SG_ 2565806036 IMD_Rsp_G_Isolation_Thrs_Timeout "ValueType: Identifier = 64, Name = SAEtm05";
+CM_ SG_ 2565806036 IMD_Rsp_G_Isolation_Thrs_Error "ValueType: Identifier = 383, Name = SAErs02";
+CM_ SG_ 2565806036 IMD_Rsp_G_Isolation_R_iso_Status "ValueType: Identifier = 87, Name = SAEbs02";
+CM_ SG_ 2565806036 IMD_Rsp_G_Isolation_R_iso_pos "ValueType: Identifier = 383, Name = SAErs02";
+CM_ SG_ 2565806036 IMD_Rsp_G_Isolation_R_iso_neg "ValueType: Identifier = 383, Name = SAErs02";
+CM_ SG_ 2565806036 IMD_Rsp_G_Isolation_Quality "ValueType: Identifier = 46, Name = SAEpc06";
+CM_ SG_ 2565806036 IMD_Rsp_G_Isolation_Power_On_Pro "ValueType: Identifier = 129, Name = SAEct02";
+CM_ SG_ 2565806036 IMD_Rsp_G_Isolation_Active_Profi "ValueType: Identifier = 129, Name = SAEct02";
+CM_ SG_ 2565806036 IMD_Rsp_G_Isolation_Counter "ValueType: Identifier = 133, Name = SAEct03";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit00 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Selfholding_Iso_Alarm "ValueType: Identifier = 87, Name = SAEbs02";
+CM_ SG_ 2565806036 IMD_Rsp_G_Unbalance_Thrs "ValueType: Identifier = 46, Name = SAEpc06";
+CM_ SG_ 2565806036 IMD_Rsp_G_Unbalance_Counter "ValueType: Identifier = 133, Name = SAEct03";
+CM_ SG_ 2565806036 IMD_Rsp_G_Unbalance "ValueType: Identifier = 46, Name = SAEpc06";
+CM_ SG_ 2565806036 IMD_Rsp_G_Hardware_DeviceTypePar "ValueType: Identifier = 258, Name = SAEatnd0200";
+CM_ SG_ 2565806036 IMD_Rsp_G_Hardware_DeviceTy_0000 "ValueType: Identifier = 258, Name = SAEatnd0200";
+CM_ SG_ 2565806036 IMD_Rsp_G_Software_Version "ValueType: Identifier = 373, Name = SAEid03";
+CM_ SG_ 2565806036 IMD_Rsp_G_Software_D_Number "ValueType: Identifier = 373, Name = SAEid03";
+CM_ SG_ 2565806036 IMD_Rsp_G_Software_Build_Number "ValueType: Identifier = 373, Name = SAEid03";
+CM_ SG_ 2565806036 IMD_Rsp_G_Hardware_SerialNumberP "ValueType: Identifier = 258, Name = SAEatnd0200";
+CM_ SG_ 2565806036 IMD_Rsp_G_Hardware_SerialNu_0000 "ValueType: Identifier = 258, Name = SAEatnd0200";
+CM_ SG_ 2565806036 IMD_Rsp_G_Hardware_Item_NumberPa "ValueType: Identifier = 258, Name = SAEatnd0200";
+CM_ SG_ 2565806036 IMD_Rsp_G_Hardware_Item_Num_0000 "ValueType: Identifier = 258, Name = SAEatnd0200";
+CM_ SG_ 2565806036 IMD_Rsp_G_Hardware_AH_NumberPart "ValueType: Identifier = 258, Name = SAEatnd0200";
+CM_ SG_ 2565806036 IMD_Rsp_G_Hardware_AH_Numbe_0000 "ValueType: Identifier = 258, Name = SAEatnd0200";
+CM_ SG_ 2565806036 IMD_Rsp_G_Bootloader_Version "ValueType: Identifier = 373, Name = SAEid03";
+CM_ SG_ 2565806036 IMD_Rsp_G_Bootloader_D_Number "ValueType: Identifier = 373, Name = SAEid03";
+CM_ SG_ 2565806036 IMD_Rsp_G_Bootloader_BuildNumber "ValueType: Identifier = 373, Name = SAEid03";
+CM_ SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0000 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit01 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0001 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit02 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0002 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit03 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0003 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit04 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0004 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit05 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0005 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit06 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0006 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit07 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0007 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit08 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0008 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit09 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0009 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit10 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0010 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit11 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0011 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit12 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0012 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit13 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0013 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit14 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0014 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit15 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit16 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit17 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit18 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit19 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit20 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit21 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit22 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit23 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit24 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit25 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit26 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit27 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit28 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit29 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit30 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806036 IMD_Rsp_G_Device_Error_Bit31 "ValueType: Identifier = 86, Name = SAEbs01";
+CM_ SG_ 2565806336 Cooling_Capacity "0-100% scaling too 0-8500 rpm
+1-5% minimum 500rpm";
+CM_ SG_ 2565806336 Cmd_Pump_Speed "1-100% -> min->max rpm
+1-28% minimum operating speed";
+CM_ SG_ 2566906137 Fb_Condensor_Fan_Speed "1-100% -> min->max rpm
+1-28% minimum operating speed";
+CM_ SG_ 2566906137 Fb_Pump_Speed "1-100% -> min->max rpm
+1-28% minimum operating speed";
+BA_DEF_ BO_  "CG_MessageInstName" STRING ;
+BA_DEF_ BO_  "CG_RX_TX" ENUM  "RX","TX","NONE";
+BA_DEF_ BO_  "CanDootDecode" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootDecodeBus" INT 0 6;
+BA_DEF_ BO_  "CanDootPaused" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulate" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulateBus" INT 0 6;
+BA_DEF_ BO_  "CanDootSimulateCycleTime" INT 0 50000;
+BA_DEF_ BO_  "GenMsgCycleTime" INT 0 65535;
+BA_DEF_ BO_  "GenMsgCycleTimeFast" INT 0 3600000;
+BA_DEF_ BO_  "GenMsgDelayTime" INT 0 1000;
+BA_DEF_ BO_  "GenMsgFastOnStart" INT 0 100000;
+BA_DEF_ BO_  "GenMsgILSupport" ENUM  "Yes","No";
+BA_DEF_ BO_  "GenMsgNrOfRepetition" INT 0 1000000;
+BA_DEF_ BO_  "GenMsgRequestable" INT 0 1;
+BA_DEF_ BO_  "GenMsgSendType" ENUM  "cyclic","reserved","cyclicIfActive","reserved","reserved","reserved","reserved","reserved","noMsgSendType";
+BA_DEF_ BO_  "GenMsgStartDelayTime" INT 0 100000;
+BA_DEF_ BO_  "VFrameFormat" ENUM  "StandardCAN","ExtendedCAN","reserved","J1939PG","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","StandardCAN_FD","ExtendedCAN_FD";
+BA_DEF_ SG_  "CG_VarType" ENUM  "bool","uint8_t","int8_t","uint16_t","int16_t","uint32_t","int32_t","float","double";
+BA_DEF_ SG_  "CanDootBroadcast" ENUM  "No","Yes";
+BA_DEF_ SG_  "CanDootGroup" ENUM  "None","g1","g2","g3","g4","g5","g6","g7","g8","g9","gA","gB","gC","gD","gE","gF";
+BA_DEF_ SG_  "CanDootHidden" ENUM  "No","Yes";
+BA_DEF_ SG_  "GenSigEVName" STRING ;
+BA_DEF_ SG_  "GenSigILSupport" ENUM  "Yes","No";
+BA_DEF_ SG_  "GenSigInactiveValue" INT 0 0;
+BA_DEF_ SG_  "GenSigSendType" ENUM  "Cyclic","OnWrite","OnWriteWithRepetition","OnChange","OnChangeWithRepetition","IfActive","IfActiveWithRepetition","NoSigSendType","OnChangeAndIfActive","OnChangeAndIfActiveWithRepetition";
+BA_DEF_ SG_  "GenSigStartValue" FLOAT -3.4E+38 3.4E+38;
+BA_DEF_ SG_  "SPN" INT 0 524287;
+BA_DEF_ SG_  "SigType" ENUM  "Default","Range","RangeSigned","ASCII","Discrete","Control","ReferencePGN","DTC","StringDelimiter","StringLength","StringLengthControl";
+BA_DEF_ BU_  "ECU" STRING ;
+BA_DEF_ BU_  "NmJ1939AAC" INT 0 1;
+BA_DEF_ BU_  "NmJ1939ECUInstance" INT 0 3;
+BA_DEF_ BU_  "NmJ1939Function" INT 0 255;
+BA_DEF_ BU_  "NmJ1939FunctionInstance" INT 0 7;
+BA_DEF_ BU_  "NmJ1939IdentityNumber" INT 0 2097151;
+BA_DEF_ BU_  "NmJ1939IndustryGroup" INT 0 7;
+BA_DEF_ BU_  "NmJ1939ManufacturerCode" INT 0 2047;
+BA_DEF_ BU_  "NmJ1939System" INT 0 127;
+BA_DEF_ BU_  "NmJ1939SystemInstance" INT 0 15;
+BA_DEF_ BU_  "NmStationAddress" INT 0 255;
+BA_DEF_ BU_  "NodeLayerModules" STRING ;
+BA_DEF_  "BusType" STRING ;
+BA_DEF_  "ProtocolType" STRING ;
+BA_DEF_ SG_  "SystemSignalLongSymbol" STRING ;
+BA_DEF_DEF_  "CG_MessageInstName" "";
+BA_DEF_DEF_  "CG_RX_TX" "RX";
+BA_DEF_DEF_  "CanDootDecode" "No";
+BA_DEF_DEF_  "CanDootDecodeBus" 1;
+BA_DEF_DEF_  "CanDootPaused" "No";
+BA_DEF_DEF_  "CanDootSimulate" "No";
+BA_DEF_DEF_  "CanDootSimulateBus" 1;
+BA_DEF_DEF_  "CanDootSimulateCycleTime" 100;
+BA_DEF_DEF_  "GenMsgCycleTime" 0;
+BA_DEF_DEF_  "GenMsgCycleTimeFast" 0;
+BA_DEF_DEF_  "GenMsgDelayTime" 0;
+BA_DEF_DEF_  "GenMsgFastOnStart" 0;
+BA_DEF_DEF_  "GenMsgILSupport" "Yes";
+BA_DEF_DEF_  "GenMsgNrOfRepetition" 0;
+BA_DEF_DEF_  "GenMsgRequestable" 1;
+BA_DEF_DEF_  "GenMsgSendType" "noMsgSendType";
+BA_DEF_DEF_  "GenMsgStartDelayTime" 0;
+BA_DEF_DEF_  "VFrameFormat" "ExtendedCAN";
+BA_DEF_DEF_  "CG_VarType" "uint8_t";
+BA_DEF_DEF_  "CanDootBroadcast" "Yes";
+BA_DEF_DEF_  "CanDootGroup" "None";
+BA_DEF_DEF_  "CanDootHidden" "No";
+BA_DEF_DEF_  "GenSigEVName" "Env@Nodename_@Signame";
+BA_DEF_DEF_  "GenSigILSupport" "Yes";
+BA_DEF_DEF_  "GenSigInactiveValue" 0;
+BA_DEF_DEF_  "GenSigSendType" "Cyclic";
+BA_DEF_DEF_  "GenSigStartValue" 0;
+BA_DEF_DEF_  "SPN" 0;
+BA_DEF_DEF_  "SigType" "Default";
+BA_DEF_DEF_  "ECU" "";
+BA_DEF_DEF_  "NmJ1939AAC" 0;
+BA_DEF_DEF_  "NmJ1939ECUInstance" 0;
+BA_DEF_DEF_  "NmJ1939Function" 0;
+BA_DEF_DEF_  "NmJ1939FunctionInstance" 0;
+BA_DEF_DEF_  "NmJ1939IdentityNumber" 0;
+BA_DEF_DEF_  "NmJ1939IndustryGroup" 0;
+BA_DEF_DEF_  "NmJ1939ManufacturerCode" 0;
+BA_DEF_DEF_  "NmJ1939System" 0;
+BA_DEF_DEF_  "NmJ1939SystemInstance" 0;
+BA_DEF_DEF_  "NmStationAddress" 254;
+BA_DEF_DEF_  "NodeLayerModules" "";
+BA_DEF_DEF_  "BusType" "CAN";
+BA_DEF_DEF_  "ProtocolType" "";
+BA_DEF_DEF_  "SystemSignalLongSymbol" "";
+BA_ "BusType" "CAN";
+BA_ "NmStationAddress" BU_ EVCU 1;
+BA_ "NmStationAddress" BU_ DCDC2 177;
+BA_ "NmStationAddress" BU_ DCDC1 179;
+BA_ "NmStationAddress" BU_ BCL25_700_8 208;
+BA_ "NmStationAddress" BU_ ECU 254;
+BA_ "CanDootDecode" BO_ 2683180730 1;
+BA_ "CanDootDecode" BO_ 2683180986 1;
+BA_ "CanDootDecode" BO_ 2683175354 1;
+BA_ "CanDootDecode" BO_ 2683175098 1;
+BA_ "CanDootDecode" BO_ 2683176378 1;
+BA_ "CanDootDecode" BO_ 2683175610 1;
+BA_ "CanDootDecode" BO_ 2683175866 1;
+BA_ "CanDootDecode" BO_ 2683180990 1;
+BA_ "GenSigStartValue" SG_ 2565853185 BCL_cmd_EVSE_type_set 0;
+BA_ "SystemSignalLongSymbol" SG_ 2683177658 C2S_fp_meb_contactor_fail_timeou "C2S_fp_meb_contactor_fail_timeout_ms";
+BA_ "SystemSignalLongSymbol" SG_ 2683177658 C2S_fp_meb_dcdc_max_bat_chg_curr "C2S_fp_meb_dcdc_max_bat_chg_current";
+BA_ "SystemSignalLongSymbol" SG_ 2683177658 C2S_fp_cr_slip_ring_temp_thresho "C2S_fp_cr_slip_ring_temp_threshold";
+BA_ "SystemSignalLongSymbol" SG_ 2683177658 C2S_fp_cr_max_current_fully_woun "C2S_fp_cr_max_current_fully_wound";
+BA_ "SystemSignalLongSymbol" SG_ 2683177658 C2S_fp_cr_max_current_slip_ring_ "C2S_fp_cr_max_current_slip_ring_hot";
+BA_ "SystemSignalLongSymbol" SG_ 2683177658 C2S_fp_cr_fully_unwound_current_ "C2S_fp_cr_fully_unwound_current_ma";
+BA_ "SystemSignalLongSymbol" SG_ 2683177658 C2S_fp_md_compressor1_torque_lim "C2S_fp_md_compressor1_torque_limit";
+BA_ "SystemSignalLongSymbol" SG_ 2683177658 C2S_fp_cs_l2_motor_start_cool_te "C2S_fp_cs_l2_motor_start_cool_temp";
+BA_ "SystemSignalLongSymbol" SG_ 2683177658 C2S_fp_cs_l1_dcdc_start_cool_tem "C2S_fp_cs_l1_dcdc_start_cool_temp";
+BA_ "SystemSignalLongSymbol" SG_ 2683177658 C2S_fp_cs_l1_reel_drv_start_cool "C2S_fp_cs_l1_reel_drv_start_cool_temp";
+BA_ "SystemSignalLongSymbol" SG_ 2683177658 C2S_fp_cs_l1_reel_drv_max_cool_t "C2S_fp_cs_l1_reel_drv_max_cool_temp";
+BA_ "SystemSignalLongSymbol" SG_ 2683177658 C2S_fp_cs_l1_fan_mtr_start_cool_ "C2S_fp_cs_l1_fan_mtr_start_cool_temp";
+BA_ "SystemSignalLongSymbol" SG_ 2683177658 C2S_fp_cs_l1_fan_mtr_max_cool_te "C2S_fp_cs_l1_fan_mtr_max_cool_temp";
+BA_ "SystemSignalLongSymbol" SG_ 2683177658 C2S_fp_cs_l3_dchvi_start_cool_te "C2S_fp_cs_l3_dchvi_start_cool_temp";
+BA_ "SystemSignalLongSymbol" SG_ 2683177658 C2S_fp_cs_l4_acuhv_start_cool_te "C2S_fp_cs_l4_acuhv_start_cool_temp";
+BA_ "SystemSignalLongSymbol" SG_ 2683177658 C2S_fp_hvac_heater_power_setpoin "C2S_fp_hvac_heater_power_setpoint";
+BA_ "SystemSignalLongSymbol" SG_ 2683180730 C2S_stopping_main_hydraulic_moto "C2S_stopping_main_hydraulic_motor";
+BA_ "SystemSignalLongSymbol" SG_ 2683180730 C2S_stopping_main_compressor_mot "C2S_stopping_main_compressor_motors";
+BA_ "SystemSignalLongSymbol" SG_ 2683180730 C2S_stopping_cabin_hvac_compress "C2S_stopping_cabin_hvac_compressor";
+BA_ "SystemSignalLongSymbol" SG_ 2683175610 C2S_cr_panel_manual_auto_momenta "C2S_cr_panel_manual_auto_momentary";
+BA_ "GenSigStartValue" SG_ 2683176122 C2S_Hyd_Oil_Cooling_Temp 8000;
+BA_ "GenSigStartValue" SG_ 2683176122 C2S_Hyd_Oil_Cooling_Pressure 500;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Acdc_Total_Power_W 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Water_Mist_Level_10b_Raw 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Rcs_Hydraulic_Oil_Temp 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Rcs_Compressor_Low_Stage_Tem 1;
+BA_ "SystemSignalLongSymbol" SG_ 2683176122 C2S_Rcs_Compressor_Low_Stage_Tem "C2S_Rcs_Compressor_Low_Stage_Temp";
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Rcs_Compressor_High_Stage_Te 1;
+BA_ "SystemSignalLongSymbol" SG_ 2683176122 C2S_Rcs_Compressor_High_Stage_Te "C2S_Rcs_Compressor_High_Stage_Temp";
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Rcs_Tram_Pressure 1;
+BA_ "GenSigStartValue" SG_ 2683176122 C2S_Rcs_Tram_Pressure 102;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Rcs_Ambient_Temperature 1;
+BA_ "GenSigStartValue" SG_ 2683176122 C2S_Rcs_Ambient_Temperature 499.299212598425;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Rcs_Heat_Request 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Heat_Valve_Proportion 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Sensor_Dhab_Source_Mv 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Sensor_Dhab_Low 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Sensor_Dhab_High 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Dvc1000_3 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Dvc1000_2 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Dvc1000_1 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Bat_K15 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Acdc1_Flow_Out 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Motor1_Flow_Out 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Aux_In_Pwm 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Pump_Bosch_Pwm 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_B460_Pwm 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_B460_Press_In 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Rad_Press_In 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Rad_Press_Out 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Acdc2_Press_In 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Acdc2_Press_Out 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Acdc1_Press_In 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Acdc1_Press_Out 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Dcdc1_Press_Out 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Motor1_Press_In 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Motor1_Press_Out 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Cr_Torque 0;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Cr_Rotary_Sensor_Raw_In_uA 0;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Cr_Rotary_Sensor_Percent 0;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Cr_Slip_Ring_Temp_5v3 0;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Cr_Slip_Ring_Temp_5v2 0;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Cr_Slip_Ring_Temp_5v1 0;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Cr_Slip_Ring_Sensor_Supply_M 0;
+BA_ "SystemSignalLongSymbol" SG_ 2683176122 C2S_Cr_Slip_Ring_Sensor_Supply_M "C2S_Cr_Slip_Ring_Sensor_Supply_Mv";
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Acdc2_Temp_Out 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Acdc1_Temp_Out 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Rad_Temp_In 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Rad_Temp_Out 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Motor1_Temp_Out 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Lv_Pdu_Temp 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Acdc_Pdu_Temp 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_Hv_Pdu_Temp 1;
+BA_ "CanDootHidden" SG_ 2683176122 C2S_mux 1;
+BA_ "GenSigStartValue" SG_ 2565845761 DCDC1_Temperature_coolant_fault 500;
+BA_ "GenSigStartValue" SG_ 2565845761 DCDC1_Output_voltage_UV_fault 400;
+BA_ "GenSigStartValue" SG_ 2565845761 DCDC1_Output_Voltage_setpoint 440;
+BA_ "GenSigStartValue" SG_ 2565845761 DCDC1_SRS_Batch_no 0;
+BA_ "GenSigStartValue" SG_ 2565845761 DCDC1_Temp_coolant_warning 400;
+BA_ "GenSigStartValue" SG_ 2565845761 DCDC1_Output_voltage_OV_fault 441;
+BA_ "GenSigStartValue" SG_ 2565845761 DCDC1_Output_current_limit 2000;
+BA_ "GenSigStartValue" SG_ 2565845761 DCDC1_SRS_Serial_no 0;
+BA_ "GenSigStartValue" SG_ 2565845249 DCDC2_Temperature_coolant_fault 500;
+BA_ "GenSigStartValue" SG_ 2565845249 DCDC2_Output_voltage_UV_fault 400;
+BA_ "GenSigStartValue" SG_ 2565845249 DCDC2_Output_Voltage_setpoint 440;
+BA_ "GenSigStartValue" SG_ 2565845249 DCDC2_SRS_Batch_no 0;
+BA_ "GenSigStartValue" SG_ 2565845249 DCDC1_Temp_coolant_warning 400;
+BA_ "GenSigStartValue" SG_ 2565845249 DCDC2_Output_voltage_OV_fault 441;
+BA_ "GenSigStartValue" SG_ 2565845249 DCDC2_Output_current_limit 2000;
+BA_ "GenSigStartValue" SG_ 2565845249 DCDC2_SRS_Serial_no 0;
+BA_ "GenSigStartValue" SG_ 2566853844 IMD_G_Capacity 1;
+BA_ "GenSigStartValue" SG_ 2566853588 IMD_G_Voltage_HV 32120;
+BA_ "GenSigStartValue" SG_ 2566853588 IMD_G_Voltage_HVneg_Earth 32120;
+BA_ "GenSigStartValue" SG_ 2566853588 IMD_G_Voltage_HVpos_Earth 32120;
+BA_ "SystemSignalLongSymbol" SG_ 2565854231 IMD_Req_G_Isolation_R_iso_Origin "IMD_Req_G_Isolation_R_iso_Original";
+BA_ "SystemSignalLongSymbol" SG_ 2565854231 IMD_Req_G_Isolation_R_iso_Correc "IMD_Req_G_Isolation_R_iso_Corrected";
+BA_ "SystemSignalLongSymbol" SG_ 2565854231 IMD_Req_G_Isolation_Power_On_Pro "IMD_Req_G_Isolation_Power_On_Profile";
+BA_ "SystemSignalLongSymbol" SG_ 2565854231 IMD_Req_G_Isolation_Active_Profi "IMD_Req_G_Isolation_Active_Profile";
+BA_ "SystemSignalLongSymbol" SG_ 2565854231 IMD_Req_G_Hardware_DeviceTypePar "IMD_Req_G_Hardware_DeviceTypePartB";
+BA_ "SystemSignalLongSymbol" SG_ 2565854231 IMD_Req_G_Hardware_DeviceTy_0000 "IMD_Req_G_Hardware_DeviceTypePartA";
+BA_ "SystemSignalLongSymbol" SG_ 2565854231 IMD_Req_G_Hardware_SerialNumberP "IMD_Req_G_Hardware_SerialNumberPartB";
+BA_ "SystemSignalLongSymbol" SG_ 2565854231 IMD_Req_G_Hardware_SerialNu_0000 "IMD_Req_G_Hardware_SerialNumberPartA";
+BA_ "SystemSignalLongSymbol" SG_ 2565854231 IMD_Req_G_Hardware_Item_NumberPa "IMD_Req_G_Hardware_Item_NumberPartB";
+BA_ "SystemSignalLongSymbol" SG_ 2565854231 IMD_Req_G_Hardware_Item_Num_0000 "IMD_Req_G_Hardware_Item_NumberPartA";
+BA_ "SystemSignalLongSymbol" SG_ 2565854231 IMD_Req_G_Hardware_AH_NumberPart "IMD_Req_G_Hardware_AH_NumberPartB";
+BA_ "SystemSignalLongSymbol" SG_ 2565854231 IMD_Req_G_Hardware_AH_Numbe_0000 "IMD_Req_G_Hardware_AH_NumberPartA";
+BA_ "GenSigStartValue" SG_ 2565854231 IMD_Req_S_Selftest_Period 1;
+BA_ "GenSigStartValue" SG_ 2565854231 IMD_Req_S_Isolation_Thrs_Warning 30;
+BA_ "GenSigStartValue" SG_ 2565854231 IMD_Req_S_Isolation_Thrs_Error 30;
+BA_ "SystemSignalLongSymbol" SG_ 2565854231 IMD_Req_S_Isolation_Power_On_Pro "IMD_Req_S_Isolation_Power_On_Profile";
+BA_ "SystemSignalLongSymbol" SG_ 2565854231 IMD_Req_S_Isolation_Active_Profi "IMD_Req_S_Isolation_Active_Profile";
+BA_ "SystemSignalLongSymbol" SG_ 2565854231 IMD_Req_S_Selfholding_IsoAlarm_R "IMD_Req_S_Selfholding_IsoAlarm_Reset";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Status_B "IMD_Rsp_G_Warning_Alarm_Status_Bit00";
+BA_ "GenSigStartValue" SG_ 2565806036 IMD_Rsp_G_Voltage_HVpos_Earth 32120;
+BA_ "GenSigStartValue" SG_ 2565806036 IMD_Rsp_G_Voltage_HVneg_Earth 32120;
+BA_ "GenSigStartValue" SG_ 2565806036 IMD_Rsp_G_Voltage_HV 32120;
+BA_ "GenSigStartValue" SG_ 2565806036 IMD_Rsp_G_Selftest_Period 1;
+BA_ "GenSigStartValue" SG_ 2565806036 IMD_Rsp_G_Capacity 1;
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Isolation_R_iso_Origin "IMD_Rsp_G_Isolation_R_iso_Original";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Isolation_R_iso_Correc "IMD_Rsp_G_Isolation_R_iso_Corrected";
+BA_ "GenSigStartValue" SG_ 2565806036 IMD_Rsp_G_Isolation_Thrs_Warning 30;
+BA_ "GenSigStartValue" SG_ 2565806036 IMD_Rsp_G_Isolation_Thrs_Error 30;
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Isolation_R_iso_Status "IMD_Rsp_G_Isolation_R_iso_Status1";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Isolation_Power_On_Pro "IMD_Rsp_G_Isolation_Power_On_Profile";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Isolation_Active_Profi "IMD_Rsp_G_Isolation_Active_Profile";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Hardware_DeviceTypePar "IMD_Rsp_G_Hardware_DeviceTypePartB";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Hardware_DeviceTy_0000 "IMD_Rsp_G_Hardware_DeviceTypePartA";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Hardware_SerialNumberP "IMD_Rsp_G_Hardware_SerialNumberPartB";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Hardware_SerialNu_0000 "IMD_Rsp_G_Hardware_SerialNumberPartA";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Hardware_Item_NumberPa "IMD_Rsp_G_Hardware_Item_NumberPartB";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Hardware_Item_Num_0000 "IMD_Rsp_G_Hardware_Item_NumberPartA";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Hardware_AH_NumberPart "IMD_Rsp_G_Hardware_AH_NumberPartB";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Hardware_AH_Numbe_0000 "IMD_Rsp_G_Hardware_AH_NumberPartA";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0000 "IMD_Rsp_G_Warning_Alarm_Status_Bit01";
+BA_ "GenSigStartValue" SG_ 2565806036 IMD_Rsp_G_Earthlift_Status_Unuse 0;
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Earthlift_Status_Unuse "IMD_Rsp_G_Earthlift_Status_Unused";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0001 "IMD_Rsp_G_Warning_Alarm_Status_Bit02";
+BA_ "GenSigStartValue" SG_ 2565806036 IMD_Rsp_G_Status_Lock_Unused 0;
+BA_ "GenSigStartValue" SG_ 2565806036 IMD_Rsp_G_Voltage_Mode_Unused 0;
+BA_ "GenSigStartValue" SG_ 2565806036 IMD_Rsp_G_Isolation_R_iso_S_0000 0;
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Isolation_R_iso_S_0000 "IMD_Rsp_G_Isolation_R_iso_StatusUnused";
+BA_ "GenSigStartValue" SG_ 2565806036 IMD_Req_G_Selfholding_Iso_Alarm_ 0;
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Req_G_Selfholding_Iso_Alarm_ "IMD_Req_G_Selfholding_Iso_Alarm_Unused";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0002 "IMD_Rsp_G_Warning_Alarm_Status_Bit03";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0003 "IMD_Rsp_G_Warning_Alarm_Status_Bit04";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0004 "IMD_Rsp_G_Warning_Alarm_Status_Bit05";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0005 "IMD_Rsp_G_Warning_Alarm_Status_Bit06";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0006 "IMD_Rsp_G_Warning_Alarm_Status_Bit07";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0007 "IMD_Rsp_G_Warning_Alarm_Status_Bit08";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0008 "IMD_Rsp_G_Warning_Alarm_Status_Bit09";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0009 "IMD_Rsp_G_Warning_Alarm_Status_Bit10";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0010 "IMD_Rsp_G_Warning_Alarm_Status_Bit11";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0011 "IMD_Rsp_G_Warning_Alarm_Status_Bit12";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0012 "IMD_Rsp_G_Warning_Alarm_Status_Bit13";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0013 "IMD_Rsp_G_Warning_Alarm_Status_Bit14";
+BA_ "SystemSignalLongSymbol" SG_ 2565806036 IMD_Rsp_G_Warning_Alarm_Sta_0014 "IMD_Rsp_G_Warning_Alarm_Status_Bit15";
+BA_ "GenSigStartValue" SG_ 2683177406 S2C_output_current 1000;
+BA_ "GenSigStartValue" SG_ 2683177406 S2C_output_voltage 220;
+BA_ "SystemSignalLongSymbol" SG_ 2683177662 S2C_sp_meb_contactor_fail_timeou "S2C_sp_meb_contactor_fail_timeout_ms";
+BA_ "SystemSignalLongSymbol" SG_ 2683177662 S2C_sp_meb_dcdc_max_bat_chg_curr "S2C_sp_meb_dcdc_max_bat_chg_current";
+BA_ "SystemSignalLongSymbol" SG_ 2683177662 S2C_sp_cr_slip_ring_temp_thresho "S2C_sp_cr_slip_ring_temp_threshold";
+BA_ "SystemSignalLongSymbol" SG_ 2683177662 S2C_sp_cr_max_current_fully_woun "S2C_sp_cr_max_current_fully_wound";
+BA_ "SystemSignalLongSymbol" SG_ 2683177662 S2C_sp_cr_max_current_slip_ring_ "S2C_sp_cr_max_current_slip_ring_hot";
+BA_ "SystemSignalLongSymbol" SG_ 2683177662 S2C_sp_cr_fully_unwound_current_ "S2C_sp_cr_fully_unwound_current_ma";
+BA_ "SystemSignalLongSymbol" SG_ 2683177662 S2C_sp_md_compressor1_torque_lim "S2C_sp_md_compressor1_torque_limit";
+BA_ "SystemSignalLongSymbol" SG_ 2683177662 S2C_sp_cs_l2_motor_start_cool_te "S2C_sp_cs_l2_motor_start_cool_temp";
+BA_ "SystemSignalLongSymbol" SG_ 2683177662 S2C_sp_cs_l1_dcdc_start_cool_tem "S2C_sp_cs_l1_dcdc_start_cool_temp";
+BA_ "SystemSignalLongSymbol" SG_ 2683177662 S2C_sp_cs_l1_reel_drv_start_cool "S2C_sp_cs_l1_reel_drv_start_cool_temp";
+BA_ "SystemSignalLongSymbol" SG_ 2683177662 S2C_sp_cs_l1_reel_drv_max_cool_t "S2C_sp_cs_l1_reel_drv_max_cool_temp";
+BA_ "SystemSignalLongSymbol" SG_ 2683177662 S2C_sp_cs_l1_fan_mtr_start_cool_ "S2C_sp_cs_l1_fan_mtr_start_cool_temp";
+BA_ "SystemSignalLongSymbol" SG_ 2683177662 S2C_sp_cs_l1_fan_mtr_max_cool_te "S2C_sp_cs_l1_fan_mtr_max_cool_temp";
+BA_ "SystemSignalLongSymbol" SG_ 2683177662 S2C_sp_cs_l3_dchvi_start_cool_te "S2C_sp_cs_l3_dchvi_start_cool_temp";
+BA_ "SystemSignalLongSymbol" SG_ 2683177662 S2C_sp_cs_l4_acuhv_start_cool_te "S2C_sp_cs_l4_acuhv_start_cool_temp";
+BA_ "SystemSignalLongSymbol" SG_ 2683177662 S2C_sp_hvac_heater_power_setpoin "S2C_sp_hvac_heater_power_setpoint";
+BA_ "GenSigStartValue" SG_ 2565806336 Ambient_temp 40;
+BA_ "GenSigStartValue" SG_ 2565806336 Cmd_Battery_inlet_temp 40;
+BA_ "GenSigStartValue" SG_ 2565806336 Cmd_Battery_outlet_temp 40;
+BA_ "GenSigStartValue" SG_ 2566906137 Suction_temp 40;
+BA_ "GenSigStartValue" SG_ 2566906393 Coolant_inlet_temp 40;
+BA_ "GenSigStartValue" SG_ 2566906393 Coolant_outlet_temp 40;
+BA_ "GenSigStartValue" SG_ 2566906393 Heat_Error 0;
+BA_ "GenSigStartValue" SG_ 2566906393 HP_Transducer_Sensor_Error 0;
+BA_ "GenSigStartValue" SG_ 2566906393 LP_Temp_Sensor_Error 0;
+BA_ "GenSigStartValue" SG_ 2566906393 LP_Transducer_Sensor_Error 0;
+BA_ "GenSigStartValue" SG_ 2566906393 Safe_to_turn_off 0;
+BA_ "GenSigStartValue" SG_ 2566857610 AC_MediumTemperature 8736;
+BA_ "GenSigStartValue" SG_ 2566857601 BE_MediumTemperature 8736;
+BA_ "GenSigStartValue" SG_ 2566857600 DC_MediumTemperature 8736;
+BA_ "GenSigStartValue" SG_ 2566857602 IM_MediumTemperature 8736;
+SIG_GROUP_ 2565853185 Bdc_OnOff_Mode 1 : BCL_cmd_Enable BCL_cmd_Mode BCL_cmd_Balancing;
+SIG_GROUP_ 2565853185 Bdc_Chg_Setpoints 1 : BCL_cmd_Chg_Vbat_lim BCL_cmd_Chg_Ibat_lim BCL_cmd_Chg_Iac_Lim;
+SIG_GROUP_ 2565853185 Bdc_Inv_Setpoints 1 :;
+SIG_GROUP_ 2565853185 Bdc_Wake_Out 1 : BCL_cmd_wake_out;
+SIG_GROUP_ 2565853185 Bdc_Sleep_Mode 1 : BCL_cmd_Sleep_Mode;
+SIG_GROUP_ 2565853185 Bdc_Pilot_Impedance 1 : BCL_cmd_Control_pilot_imp;
+SIG_GROUP_ 2565853185 Bdc_LED_Driver 1 : BCL_cmd_LED_Index BCL_cmd_LED_mode BCL_cmd_LED_bright BCL_cmd_LED_on_time BCL_cmd_LED_duty;
+SIG_GROUP_ 2565853185 Bdc_Motor_Rise_Time 1 : BCL_cmd_Motor_Rise_Time;
+SIG_GROUP_ 2565853185 Bdc_Ext_DC_Current_Sensor 1 : BCL_cmd_Ext_DC_CurrSens_En BCL_cmd_Ext_DC_CurrSens_Val;
+SIG_GROUP_ 2565853185 Bdc_LV_Battery_UV_Limit 1 : BCL_cmd_LV_Battery_UV_Limit;
+SIG_GROUP_ 2565853185 Bdc_EVSE_type 1 : BCL_cmd_EVSE_type_set;
+SIG_GROUP_ 2565853185 Bdc_CRC_counter_selection 1 : BCL_cmd_CRC_Cntr;
+SIG_GROUP_ 2565853185 Bdc_Button_Action_Selection 1 : BCL_cmd_Button_A_Action BCL_cmd_Button_B_Action;
+SIG_GROUP_ 2565853185 Bdc_Otp_Recovery_En 1 : BCL_cmd_Otp_recovery_enable;
+SIG_GROUP_ 2565853185 Bdc_Hvil_En 1 : BCL_cmd_Hvil_enable;
+SIG_GROUP_ 2565853185 Bdc_Ext_Temp_Sensor_Type 1 : BCL_cmd_TempExt_Sensor_Type BCL_cmd_TempExt_Otp_En BCL_cmd_TempExt_Otp;
+SIG_GROUP_ 2565853185 Bdc_Ext_Temp_Sensor_Custom_Table 1 : BCL_cmd_TempExt_Table_Idx BCL_cmd_TempExt_Table_Temp BCL_cmd_TempExt_Table_Resistance;
+SIG_GROUP_ 2565853185 Bdc_Ext_Set_Can_Addr 1 : BCL_cmd_CAN_address_new60 BCL_cmd_CAN_address_SN_Lower;
+SIG_GROUP_ 2565853185 Bdc_Ext_Set_Can_Addr_SN 1 : BCL_cmd_CAN_address_new61 BCL_cmd_CAN_address_SN_Upper;
+SIG_GROUP_ 2565853185 Bdc_Save_Setpoints 1 : BCL_cmd_Save_Settings;
+SIG_GROUP_ 2565845761 DCDC1_Output_volt_curr_setpoint 1 : DCDC1_Output_Voltage_setpoint DCDC1_Output_current_limit DCDC1_b_sts_RemoteShutdown;
+SIG_GROUP_ 2565845761 DCDC1_Output_uv_ov_setpoint 1 : DCDC1_Output_voltage_UV_fault DCDC1_Output_voltage_OV_fault;
+SIG_GROUP_ 2565845761 DCDC1_Temp_warning_limit 1 : DCDC1_Temperature_coolant_fault DCDC1_Temp_coolant_warning;
+SIG_GROUP_ 2565845761 DCDC1_Set_Remote_Shutdown 1 : DCDC1_Remote_shutdown_sp DCDC1_SRS_Batch_no DCDC1_SRS_Serial_no;
+SIG_GROUP_ 2565845249 DCDC2_Output_volt_curr_setpoint 1 : DCDC2_b_sts_RemoteShutdown DCDC2_Output_current_limit DCDC2_Output_Voltage_setpoint;
+SIG_GROUP_ 2565845249 DCDC2_Output_uv_ov_setpoint 1 : DCDC2_Output_voltage_OV_fault DCDC2_Output_voltage_UV_fault;
+SIG_GROUP_ 2565845249 DCDC2_Temp_warning_limit 1 : DCDC1_Temp_coolant_warning DCDC2_Temperature_coolant_fault;
+SIG_GROUP_ 2565845249 DCDC2_Set_Remote_Shutdown 1 : DCDC2_Remote_shutdown_sp DCDC2_SRS_Batch_no DCDC2_SRS_Serial_no;
+SIG_VALTYPE_ 2683177658 C2S_fp_cs_fan_pid_kp : 1;
+SIG_VALTYPE_ 2683177658 C2S_fp_cs_fan_pid_ki : 1;
+SIG_VALTYPE_ 2683177658 C2S_fp_cs_fan_pid_kd : 1;
+SIG_VALTYPE_ 2683177658 C2S_fp_md_hydraulic_runtime_s : 1;
+SIG_VALTYPE_ 2683177658 C2S_fp_md_compressor_runtime_s : 1;
+SIG_VALTYPE_ 2683177662 S2C_sp_cs_fan_pid_kp : 1;
+SIG_VALTYPE_ 2683177662 S2C_sp_cs_fan_pid_ki : 1;
+SIG_VALTYPE_ 2683177662 S2C_sp_cs_fan_pid_kd : 1;
+SIG_VALTYPE_ 2683177662 S2C_sp_md_hydraulic_runtime_s : 1;
+SIG_VALTYPE_ 2683177662 S2C_sp_md_compressor_runtime_s : 1;
+

--- a/decoder/D65/dbc/D65_CH5_CM.dbc
+++ b/decoder/D65/dbc/D65_CH5_CM.dbc
@@ -1,0 +1,1597 @@
+VERSION "created by canmatrix"
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: HYD COMP1 COMP2 FAN EVCU RCS
+
+
+BO_ 2147485197 FAN_Modulation_And_Flux_Info: 8 FAN
+ SG_ FAN_Iq_Command : 48|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ FAN_Id_Command : 32|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ FAN_Flux_Weakening_Output : 16|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ FAN_Modulation_Index : 0|16@1- (0.0001,0) [-3.2768|3.2767] ""  EVCU
+
+BO_ 2147485196 FAN_Torque_And_Timer_Info: 8 FAN
+ SG_ FAN_Power_On_Timer : 32|32@1+ (0.003,0) [0|12884800] "time:second"  EVCU
+ SG_ FAN_Torque_Feedback : 16|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  EVCU
+ SG_ FAN_Commanded_Torque : 0|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  EVCU
+
+BO_ 2147485218 FAN_Read_Write_Param_Response: 8 FAN
+ SG_ FAN_Parameter_Response_Write_OK : 16|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Parameter_Response_Data : 32|16@1- (1,0) [-32768|32767] ""  EVCU
+ SG_ FAN_Parameter_Response_Addr : 0|16@1+ (1,0) [0|65535] ""  EVCU
+
+BO_ 2147485217 FAN_Read_Write_Param_Command: 8 EVCU
+ SG_ VCU_FAN_Parameter_Data : 32|16@1- (1,0) [-32768|32767] ""  EVCU
+ SG_ VCU_FAN_Parameter_RW_Command : 16|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ VCU_FAN_Parameter_Address : 0|16@1+ (1,0) [0|65535] ""  EVCU
+
+BO_ 2147485216 FAN_Command_Message: 8 EVCU
+ SG_ VCU_FAN_Inverter_Enable : 40|1@1+ (1,0) [0|1] ""  FAN
+ SG_ VCU_FAN_Direction_Command : 32|1@1+ (1,0) [0|1] ""  FAN
+ SG_ VCU_FAN_Speed_Command : 16|16@1- (1,0) [-32768|32767] "angular_speed:rpm"  FAN
+ SG_ VCU_FAN_Torque_Command : 0|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  FAN
+ SG_ VCU_FAN_Inverter_Discharge : 41|1@1+ (1,0) [0|1] ""  FAN
+ SG_ VCU_FAN_Torque_Limit_Command : 48|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  FAN
+ SG_ VCU_FAN_Speed_Mode_Enable : 42|1@1+ (1,0) [0|1] ""  FAN
+
+BO_ 2147485195 FAN_Fault_Codes: 8 FAN
+ SG_ FAN_Run_Fault_Hi : 48|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ FAN_Post_Fault_Hi : 16|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ FAN_Run_Fault_Lo : 32|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ FAN_Post_Fault_Lo : 0|16@1+ (1,0) [0|65535] ""  EVCU
+
+BO_ 2147485194 FAN_Internal_States: 8 FAN
+ SG_ FAN_Direction_Command : 56|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Inverter_Enable_State : 48|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Relay_3_Status : 26|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Relay_4_Status : 27|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Relay_2_Status : 25|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Inverter_Run_Mode : 32|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Inverter_Command_Mode : 40|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Relay_1_Status : 24|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Inverter_State : 16|8@1+ (1,0) [0|255] ""  EVCU
+ SG_ FAN_VSM_State : 0|8@1+ (1,0) [0|15] ""  EVCU
+ SG_ FAN_Inverter_Enable_Lockout : 55|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Inverter_Discharge_State : 37|3@1+ (1,0) [0|7] ""  EVCU
+ SG_ FAN_Relay_5_Status : 28|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Relay_6_Status : 29|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_BMS_Active : 57|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_BMS_Torque_Limiting : 58|1@1+ (1,0) [0|0] ""  EVCU
+ SG_ FAN_PWM_Frequency : 8|8@1+ (1,0) [0|255] ""  EVCU
+ SG_ FAN_Limit_Max_Speed : 59|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Limit_Hot_Spot : 60|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Low_Speed_Limiting : 61|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Rolling_Counter : 44|4@1+ (1,0) [0|15] ""  EVCU
+ SG_ FAN_Limit_Coolant_Derating : 62|1@1+ (1,0) [0|1] ""  EVCU
+
+BO_ 2147485193 FAN_Internal_Voltages: 8 FAN
+ SG_ FAN_Ref_Voltage_12_0 : 48|16@1- (0.01,0) [-327.68|327.67] "voltage:V"  EVCU
+ SG_ FAN_Ref_Voltage_5_0 : 32|16@1- (0.01,0) [-327.68|327.67] "voltage:V"  EVCU
+ SG_ FAN_Ref_Voltage_2_5 : 16|16@1- (0.01,0) [-327.68|327.67] "voltage:V"  EVCU
+ SG_ FAN_Ref_Voltage_1_5 : 0|16@1- (0.01,0) [-327.68|327.67] "voltage:V"  EVCU
+
+BO_ 2147485192 FAN_Flux_ID_IQ_Info: 8 FAN
+ SG_ FAN_Iq : 48|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ FAN_Id : 32|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ FAN_Flux_Feedback : 16|16@1- (0.001,0) [-32.768|32.767] "flux:Wb"  EVCU
+ SG_ FAN_Flux_Command : 0|16@1- (0.001,0) [-32.768|32.767] "flux:Wb"  EVCU
+
+BO_ 2147485191 FAN_Voltage_Info: 8 FAN
+ SG_ FAN_VBC_Vq_Voltage : 48|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+ SG_ FAN_VAB_Vd_Voltage : 32|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+ SG_ FAN_Output_Voltage : 16|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+ SG_ FAN_DC_Bus_Voltage : 0|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+
+BO_ 2147485190 FAN_Current_Info: 8 FAN
+ SG_ FAN_DC_Bus_Current : 48|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ FAN_Phase_C_Current : 32|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ FAN_Phase_B_Current : 16|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ FAN_Phase_A_Current : 0|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+
+BO_ 2147485189 FAN_Motor_Position_Info: 8 FAN
+ SG_ FAN_Delta_Resolver_Filtered : 48|16@1- (0.1,0) [-3276.8|3276.7] "angle:deg"  EVCU
+ SG_ FAN_Electrical_Output_Frequency : 32|16@1- (0.1,0) [-3276.8|3276.7] "frequency:Hz"  EVCU
+ SG_ FAN_Motor_Speed : 16|16@1- (1,0) [-32768|32767] "angular_speed:rpm"  EVCU
+ SG_ FAN_Motor_Angle_Electrical : 0|16@1+ (0.1,0) [0|6553.5] "angle:deg"  EVCU
+
+BO_ 2147485188 FAN_Digital_Input_Status: 8 FAN
+ SG_ FAN_Digital_Input_5 : 32|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Digital_Input_4 : 24|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Digital_Input_3 : 16|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Digital_Input_2 : 8|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Digital_Input_1 : 0|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Digital_Input_6 : 40|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Digital_Input_7 : 48|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ FAN_Digital_Input_8 : 56|1@1+ (1,0) [0|1] ""  EVCU
+
+BO_ 2147485187 FAN_Analog_Input_Voltages: 8 FAN
+ SG_ FAN_Analog_Input_4 : 32|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ FAN_Analog_Input_1 : 0|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ FAN_Analog_Input_2 : 10|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ FAN_Analog_Input_5 : 42|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ FAN_Analog_Input_6 : 52|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ FAN_Analog_Input_3 : 20|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+
+BO_ 2147485186 FAN_Temperature_Set_3: 8 FAN
+ SG_ FAN_Torque_Shudder : 48|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  EVCU
+ SG_ FAN_Motor_Temp : 32|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ FAN_Hot_Spot_Temp : 16|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ FAN_Coolant_Temp : 0|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+
+BO_ 2147485185 FAN_Temperature_Set_2: 8 FAN
+ SG_ FAN_RTD2_Temperature : 32|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ FAN_RTD1_Temperature : 16|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ FAN_Control_Board_Temp : 0|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+
+BO_ 2147485184 FAN_Temperature_Set_1: 8 FAN
+ SG_ FAN_Gate_Driver_Board_Temp : 48|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ FAN_Module_C_Temp : 32|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ FAN_Module_B_Temp : 16|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ FAN_Module_A_Temp : 0|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+
+BO_ 2147485198 FAN_Firmware_Info: 8 FAN
+ SG_ FAN_Project_Code_EEP_Ver : 0|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ FAN_SW_Version : 16|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ FAN_DateCode_MMDD : 32|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ FAN_DateCode_YYYY : 48|16@1+ (1,0) [0|65535] ""  EVCU
+
+BO_ 2147485199 FAN_Diag_Data: 8 FAN
+ SG_ FAN_Diag_Buffer_Record : 0|8@1+ (1,0) [0|255] ""  EVCU
+ SG_ FAN_Diag_Buffer_Segment : 8|8@1+ (1,0) [0|5] ""  EVCU
+ SG_ FAN_Diag_Data_1 : 16|16@1- (1,0) [-32768|32767] ""  EVCU
+ SG_ FAN_Diag_Data_2 : 32|16@1- (1,0) [-32768|32767] ""  EVCU
+ SG_ FAN_Diag_Data_3 : 48|16@1- (1,0) [-32768|32767] ""  EVCU
+
+BO_ 2147485200 FAN_Fast_Info: 8 FAN
+ SG_ FAN_Fast_Torque_Command : 0|16@1- (0.1,0) [-3276.8|32767.7] "torque:N.m"  EVCU
+ SG_ FAN_Fast_Torque_Feedback : 16|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  EVCU
+ SG_ FAN_Fast_Motor_Speed : 32|16@1- (1,0) [-32768|32767] "angular_speed:rpm"  EVCU
+ SG_ FAN_Fast_DC_Bus_Voltage : 48|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+
+BO_ 2147483915 CP2_Voltage_Info: 8 COMP2
+ SG_ CP2_VBC_Vq_Voltage : 48|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+ SG_ CP2_VAB_Vd_Voltage : 32|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+ SG_ CP2_Output_Voltage : 16|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+ SG_ CP2_DC_Bus_Voltage : 0|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+
+BO_ 2147483920 CP2_Torque_And_Timer_Info: 8 COMP2
+ SG_ CP2_Power_On_Timer : 32|32@1+ (0.003,0) [0|12884800] "time:second"  EVCU
+ SG_ CP2_Torque_Feedback : 16|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  EVCU
+ SG_ CP2_Commanded_Torque : 0|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  EVCU
+
+BO_ 2147483910 CP2_Temperature_Set_3: 8 COMP2
+ SG_ CP2_Torque_Shudder : 48|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  EVCU
+ SG_ CP2_Motor_Temp : 32|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ CP2_Hot_Spot_Temp : 16|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ CP2_Coolant_Temp : 0|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+
+BO_ 2147483909 CP2_Temperature_Set_2: 8 COMP2
+ SG_ CP2_RTD2_Temperature : 32|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ CP2_RTD1_Temperature : 16|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ CP2_Control_Board_Temp : 0|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+
+BO_ 2147483908 CP2_Temperature_Set_1: 8 COMP2
+ SG_ CP2_Gate_Driver_Board_Temp : 48|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ CP2_Module_C_Temp : 32|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ CP2_Module_B_Temp : 16|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ CP2_Module_A_Temp : 0|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+
+BO_ 2147483942 CP2_Read_Write_Param_Response: 8 COMP2
+ SG_ CP2_Parameter_Response_Write_OK : 16|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Parameter_Response_Data : 32|16@1- (1,0) [-32768|32767] ""  EVCU
+ SG_ CP2_Parameter_Response_Addr : 0|16@1+ (1,0) [0|65535] ""  EVCU
+
+BO_ 2147483941 CP2_Read_Write_Param_Command: 8 EVCU
+ SG_ VCU_CP2_Parameter_Data : 32|16@1- (1,0) [-32768|32767] ""  COMP2
+ SG_ VCU_CP2_Parameter_RW_Command : 16|1@1+ (1,0) [0|1] ""  COMP2
+ SG_ VCU_CP2_Parameter_Address : 0|16@1+ (1,0) [0|65535] ""  COMP2
+
+BO_ 2147483913 CP2_Motor_Position_Info: 8 COMP2
+ SG_ CP2_Delta_Resolver_Filtered : 48|16@1- (0.1,0) [-3276.8|3276.7] "angle:deg"  EVCU
+ SG_ CP2_Electrical_Output_Frequency : 32|16@1- (0.1,0) [-3276.8|3276.7] "frequency:Hz"  EVCU
+ SG_ CP2_Motor_Speed : 16|16@1- (1,0) [-32768|32767] "angular_speed:rpm"  EVCU
+ SG_ CP2_Motor_Angle_Electrical : 0|16@1+ (0.1,0) [0|6553.5] "angle:deg"  EVCU
+
+BO_ 2147483921 CP2_Modulation_And_Flux_Info: 8 COMP2
+ SG_ CP2_Iq_Command : 48|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ CP2_Id_Command : 32|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ CP2_Flux_Weakening_Output : 16|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ CP2_Modulation_Index : 0|16@1- (0.0001,0) [-3.2768|3.2767] ""  EVCU
+
+BO_ 2147483917 CP2_Internal_Voltages: 8 COMP2
+ SG_ CP2_Ref_Voltage_12_0 : 48|16@1- (0.01,0) [-327.68|327.67] "voltage:V"  EVCU
+ SG_ CP2_Ref_Voltage_5_0 : 32|16@1- (0.01,0) [-327.68|327.67] "voltage:V"  EVCU
+ SG_ CP2_Ref_Voltage_2_5 : 16|16@1- (0.01,0) [-327.68|327.67] "voltage:V"  EVCU
+ SG_ CP2_Ref_Voltage_1_5 : 0|16@1- (0.01,0) [-327.68|327.67] "voltage:V"  EVCU
+
+BO_ 2147483918 CP2_Internal_States: 8 COMP2
+ SG_ CP2_Direction_Command : 56|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Inverter_Enable_State : 48|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Relay_3_Status : 26|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Relay_4_Status : 27|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Relay_2_Status : 25|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Inverter_Run_Mode : 32|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Inverter_Command_Mode : 40|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Relay_1_Status : 24|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Inverter_State : 16|8@1+ (1,0) [0|255] ""  EVCU
+ SG_ CP2_VSM_State : 0|8@1+ (1,0) [0|15] ""  EVCU
+ SG_ CP2_Inverter_Enable_Lockout : 55|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Inverter_Discharge_State : 37|3@1+ (1,0) [0|7] ""  EVCU
+ SG_ CP2_Relay_5_Status : 28|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Relay_6_Status : 29|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_BMS_Active : 57|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_BMS_Torque_Limiting : 58|1@1+ (1,0) [0|0] ""  EVCU
+ SG_ CP2_PWM_Frequency : 8|8@1+ (1,0) [0|255] ""  EVCU
+ SG_ CP2_Limit_Max_Speed : 59|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Limit_Hot_Spot : 60|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Low_Speed_Limiting : 61|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Rolling_Counter : 44|4@1+ (1,0) [0|15] ""  EVCU
+ SG_ CP2_Limit_Coolant_Derating : 62|1@1+ (1,0) [0|1] ""  EVCU
+
+BO_ 2147483916 CP2_Flux_ID_IQ_Info: 8 COMP2
+ SG_ CP2_Iq : 48|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ CP2_Id : 32|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ CP2_Flux_Feedback : 16|16@1- (0.001,0) [-32.768|32.767] "flux:Wb"  EVCU
+ SG_ CP2_Flux_Command : 0|16@1- (0.001,0) [-32.768|32.767] "flux:Wb"  EVCU
+
+BO_ 2147483922 CP2_Firmware_Info: 8 COMP2
+ SG_ CP2_Project_Code_EEP_Ver : 0|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ CP2_SW_Version : 16|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ CP2_DateCode_MMDD : 32|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ CP2_DateCode_YYYY : 48|16@1+ (1,0) [0|65535] ""  EVCU
+
+BO_ 2147483919 CP2_Fault_Codes: 8 COMP2
+ SG_ CP2_Run_Fault_Hi : 48|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ CP2_Post_Fault_Hi : 16|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ CP2_Run_Fault_Lo : 32|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ CP2_Post_Fault_Lo : 0|16@1+ (1,0) [0|65535] ""  EVCU
+
+BO_ 2147483924 CP2_Fast_Info: 8 COMP2
+ SG_ CP2_Fast_Torque_Command : 0|16@1- (0.1,0) [-3276.8|32767.7] "torque:N.m"  EVCU
+ SG_ CP2_Fast_Torque_Feedback : 16|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  EVCU
+ SG_ CP2_Fast_Motor_Speed : 32|16@1- (1,0) [-32768|32767] "angular_speed:rpm"  EVCU
+ SG_ CP2_Fast_DC_Bus_Voltage : 48|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+
+BO_ 2147483912 CP2_Digital_Input_Status: 8 COMP2
+ SG_ CP2_Digital_Input_5 : 32|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Digital_Input_4 : 24|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Digital_Input_3 : 16|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Digital_Input_2 : 8|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Digital_Input_1 : 0|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Digital_Input_6 : 40|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Digital_Input_7 : 48|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP2_Digital_Input_8 : 56|1@1+ (1,0) [0|1] ""  EVCU
+
+BO_ 2147483923 CP2_Diag_Data: 8 COMP2
+ SG_ CP2_Diag_Buffer_Record : 0|8@1+ (1,0) [0|255] ""  EVCU
+ SG_ CP2_Diag_Buffer_Segment : 8|8@1+ (1,0) [0|5] ""  EVCU
+ SG_ CP2_Diag_Data_1 : 16|16@1- (1,0) [-32768|32767] ""  EVCU
+ SG_ CP2_Diag_Data_2 : 32|16@1- (1,0) [-32768|32767] ""  EVCU
+ SG_ CP2_Diag_Data_3 : 48|16@1- (1,0) [-32768|32767] ""  EVCU
+
+BO_ 2147483914 CP2_Current_Info: 8 COMP2
+ SG_ CP2_DC_Bus_Current : 48|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ CP2_Phase_C_Current : 32|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ CP2_Phase_B_Current : 16|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ CP2_Phase_A_Current : 0|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+
+BO_ 2147483940 CP2_Command_Message: 8 COMP1
+ SG_ VCU_CP2_Inverter_Enable : 40|1@1+ (1,0) [0|1] ""  COMP2
+ SG_ VCU_CP2_Direction_Command : 32|1@1+ (1,0) [0|1] ""  COMP2
+ SG_ VCU_CP2_Speed_Command : 16|16@1- (1,0) [-32768|32767] "angular_speed:rpm"  COMP2
+ SG_ VCU_CP2_Torque_Command : 0|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  COMP2
+ SG_ VCU_CP2_Inverter_Discharge : 41|1@1+ (1,0) [0|1] ""  COMP2
+ SG_ VCU_CP2_Torque_Limit_Command : 48|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  COMP2
+ SG_ VCU_CP2_Speed_Mode_Enable : 42|1@1+ (1,0) [0|1] ""  COMP2
+
+BO_ 2147483911 CP2_Analog_Input_Voltages: 8 COMP2
+ SG_ CP2_Analog_Input_4 : 32|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ CP2_Analog_Input_1 : 0|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ CP2_Analog_Input_2 : 10|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ CP2_Analog_Input_5 : 42|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ CP2_Analog_Input_6 : 52|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ CP2_Analog_Input_3 : 20|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+
+BO_ 2147483892 CP1_Read_Write_Param_Response: 8 COMP1
+ SG_ CP1_Parameter_Response_Write_OK : 16|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Parameter_Response_Data : 32|16@1- (1,0) [-32768|32767] ""  EVCU
+ SG_ CP1_Parameter_Response_Addr : 0|16@1+ (1,0) [0|65535] ""  EVCU
+
+BO_ 2147483891 CP1_Read_Write_Param_Command: 8 EVCU
+ SG_ VCU_CP1_Parameter_Data : 32|16@1- (1,0) [-32768|32767] ""  COMP1
+ SG_ VCU_CP1_Parameter_RW_Command : 16|1@1+ (1,0) [0|1] ""  COMP1
+ SG_ VCU_CP1_Parameter_Address : 0|16@1+ (1,0) [0|65535] ""  COMP1
+
+BO_ 2147483890 CP1_Command_Message: 8 EVCU
+ SG_ VCU_CP1_Inverter_Enable : 40|1@1+ (1,0) [0|1] ""  COMP1
+ SG_ VCU_CP1_Direction_Command : 32|1@1+ (1,0) [0|1] ""  COMP1
+ SG_ VCU_CP1_Speed_Command : 16|16@1- (1,0) [-32768|32767] "angular_speed:rpm"  COMP1
+ SG_ VCU_CP1_Torque_Command : 0|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  COMP1
+ SG_ VCU_CP1_Inverter_Discharge : 41|1@1+ (1,0) [0|1] ""  COMP1
+ SG_ VCU_CP1_Torque_Limit_Command : 48|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  COMP1
+ SG_ VCU_CP1_Speed_Mode_Enable : 42|1@1+ (1,0) [0|1] ""  COMP1
+
+BO_ 2147483874 CP1_Fast_Info: 8 COMP1
+ SG_ CP1_Fast_Torque_Command : 0|16@1- (0.1,0) [-3276.8|32767.7] "torque:N.m"  EVCU
+ SG_ CP1_Fast_Torque_Feedback : 16|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  EVCU
+ SG_ CP1_Fast_Motor_Speed : 32|16@1- (1,0) [-32768|32767] "angular_speed:rpm"  EVCU
+ SG_ CP1_Fast_DC_Bus_Voltage : 48|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+
+BO_ 2147483873 CP1_Diag_Data: 8 COMP1
+ SG_ CP1_Diag_Buffer_Record : 0|8@1+ (1,0) [0|255] ""  EVCU
+ SG_ CP1_Diag_Buffer_Segment : 8|8@1+ (1,0) [0|5] ""  EVCU
+ SG_ CP1_Diag_Data_1 : 16|16@1- (1,0) [-32768|32767] ""  EVCU
+ SG_ CP1_Diag_Data_2 : 32|16@1- (1,0) [-32768|32767] ""  EVCU
+ SG_ CP1_Diag_Data_3 : 48|16@1- (1,0) [-32768|32767] ""  EVCU
+
+BO_ 2147483872 CP1_Firmware_Info: 8 COMP1
+ SG_ CP1_Project_Code_EEP_Ver : 0|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ CP1_SW_Version : 16|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ CP1_DateCode_MMDD : 32|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ CP1_DateCode_YYYY : 48|16@1+ (1,0) [0|65535] ""  EVCU
+
+BO_ 2147483871 CP1_Modulation_And_Flux_Info: 8 COMP1
+ SG_ CP1_Iq_Command : 48|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ CP1_Id_Command : 32|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ CP1_Flux_Weakening_Output : 16|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ CP1_Modulation_Index : 0|16@1- (0.0001,0) [-3.2768|3.2767] ""  EVCU
+
+BO_ 2147483870 CP1_Torque_And_Timer_Info: 8 COMP1
+ SG_ CP1_Power_On_Timer : 32|32@1+ (0.003,0) [0|12884800] "time:second"  EVCU
+ SG_ CP1_Torque_Feedback : 16|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  EVCU
+ SG_ CP1_Commanded_Torque : 0|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  EVCU
+
+BO_ 2147483869 CP1_Fault_Codes: 8 COMP1
+ SG_ CP1_Run_Fault_Hi : 48|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ CP1_Post_Fault_Hi : 16|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ CP1_Run_Fault_Lo : 32|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ CP1_Post_Fault_Lo : 0|16@1+ (1,0) [0|65535] ""  EVCU
+
+BO_ 2147483868 CP1_Internal_States: 8 COMP1
+ SG_ CP1_Direction_Command : 56|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Inverter_Enable_State : 48|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Relay_3_Status : 26|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Relay_4_Status : 27|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Relay_2_Status : 25|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Inverter_Run_Mode : 32|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Inverter_Command_Mode : 40|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Relay_1_Status : 24|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Inverter_State : 16|8@1+ (1,0) [0|255] ""  EVCU
+ SG_ CP1_VSM_State : 0|8@1+ (1,0) [0|15] ""  EVCU
+ SG_ CP1_Inverter_Enable_Lockout : 55|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Inverter_Discharge_State : 37|3@1+ (1,0) [0|7] ""  EVCU
+ SG_ CP1_Relay_5_Status : 28|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Relay_6_Status : 29|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_BMS_Active : 57|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_BMS_Torque_Limiting : 58|1@1+ (1,0) [0|0] ""  EVCU
+ SG_ CP1_PWM_Frequency : 8|8@1+ (1,0) [0|255] ""  EVCU
+ SG_ CP1_Limit_Max_Speed : 59|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Limit_Hot_Spot : 60|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Low_Speed_Limiting : 61|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Rolling_Counter : 44|4@1+ (1,0) [0|15] ""  EVCU
+ SG_ CP1_Limit_Coolant_Derating : 62|1@1+ (1,0) [0|1] ""  EVCU
+
+BO_ 2147483867 CP1_Internal_Voltages: 8 COMP1
+ SG_ CP1_Ref_Voltage_12_0 : 48|16@1- (0.01,0) [-327.68|327.67] "voltage:V"  EVCU
+ SG_ CP1_Ref_Voltage_5_0 : 32|16@1- (0.01,0) [-327.68|327.67] "voltage:V"  EVCU
+ SG_ CP1_Ref_Voltage_2_5 : 16|16@1- (0.01,0) [-327.68|327.67] "voltage:V"  EVCU
+ SG_ CP1_Ref_Voltage_1_5 : 0|16@1- (0.01,0) [-327.68|327.67] "voltage:V"  EVCU
+
+BO_ 2147483866 CP1_Flux_ID_IQ_Info: 8 COMP1
+ SG_ CP1_Iq : 48|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ CP1_Id : 32|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ CP1_Flux_Feedback : 16|16@1- (0.001,0) [-32.768|32.767] "flux:Wb"  EVCU
+ SG_ CP1_Flux_Command : 0|16@1- (0.001,0) [-32.768|32.767] "flux:Wb"  EVCU
+
+BO_ 2147483865 CP1_Voltage_Info: 8 COMP1
+ SG_ CP1_VBC_Vq_Voltage : 48|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+ SG_ CP1_VAB_Vd_Voltage : 32|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+ SG_ CP1_Output_Voltage : 16|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+ SG_ CP1_DC_Bus_Voltage : 0|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+
+BO_ 2147483864 CP1_Current_Info: 8 COMP1
+ SG_ CP1_DC_Bus_Current : 48|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ CP1_Phase_C_Current : 32|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ CP1_Phase_B_Current : 16|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ CP1_Phase_A_Current : 0|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+
+BO_ 2147483863 CP1_Motor_Position_Info: 8 COMP1
+ SG_ CP1_Delta_Resolver_Filtered : 48|16@1- (0.1,0) [-3276.8|3276.7] "angle:deg"  EVCU
+ SG_ CP1_Electrical_Output_Frequency : 32|16@1- (0.1,0) [-3276.8|3276.7] "frequency:Hz"  EVCU
+ SG_ CP1_Motor_Speed : 16|16@1- (1,0) [-32768|32767] "angular_speed:rpm"  EVCU
+ SG_ CP1_Motor_Angle_Electrical : 0|16@1+ (0.1,0) [0|6553.5] "angle:deg"  EVCU
+
+BO_ 2147483862 CP1_Digital_Input_Status: 8 COMP1
+ SG_ CP1_Digital_Input_5 : 32|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Digital_Input_4 : 24|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Digital_Input_3 : 16|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Digital_Input_2 : 8|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Digital_Input_1 : 0|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Digital_Input_6 : 40|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Digital_Input_7 : 48|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ CP1_Digital_Input_8 : 56|1@1+ (1,0) [0|1] ""  EVCU
+
+BO_ 2147483861 CP1_Analog_Input_Voltages: 8 COMP1
+ SG_ CP1_Analog_Input_4 : 32|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ CP1_Analog_Input_1 : 0|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ CP1_Analog_Input_2 : 10|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ CP1_Analog_Input_5 : 42|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ CP1_Analog_Input_6 : 52|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ CP1_Analog_Input_3 : 20|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+
+BO_ 2147483860 CP1_Temperature_Set_3: 8 COMP1
+ SG_ CP1_Torque_Shudder : 48|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  EVCU
+ SG_ CP1_Motor_Temp : 32|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ CP1_Hot_Spot_Temp : 16|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ CP1_Coolant_Temp : 0|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+
+BO_ 2147483859 CP1_Temperature_Set_2: 8 COMP1
+ SG_ CP1_RTD2_Temperature : 32|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ CP1_RTD1_Temperature : 16|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ CP1_Control_Board_Temp : 0|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+
+BO_ 2147483858 CP1_Temperature_Set_1: 8 COMP1
+ SG_ CP1_Gate_Driver_Board_Temp : 48|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ CP1_Module_C_Temp : 32|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ CP1_Module_B_Temp : 16|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ CP1_Module_A_Temp : 0|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+
+BO_ 2147483821 HYD_Modulation_And_Flux_Info: 8 HYD
+ SG_ HYD_Iq_Command : 48|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ HYD_Id_Command : 32|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ HYD_Flux_Weakening_Output : 16|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ HYD_Modulation_Index : 0|16@1- (0.0001,0) [-3.2768|3.2767] ""  EVCU
+
+BO_ 2147483820 HYD_Torque_And_Timer_Info: 8 HYD
+ SG_ HYD_Power_On_Timer : 32|32@1+ (0.003,0) [0|12884800] "time:second"  EVCU
+ SG_ HYD_Torque_Feedback : 16|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  EVCU
+ SG_ HYD_Commanded_Torque : 0|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  EVCU
+
+BO_ 2147483842 HYD_Read_Write_Param_Response: 8 HYD
+ SG_ HYD_Parameter_Response_Write_OK : 16|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Parameter_Response_Data : 32|16@1- (1,0) [-32768|32767] ""  EVCU
+ SG_ HYD_Parameter_Response_Addr : 0|16@1+ (1,0) [0|65535] ""  EVCU
+
+BO_ 2147483841 HYD_Read_Write_Param_Command: 8 EVCU
+ SG_ VCU_HYD_Parameter_Data : 32|16@1- (1,0) [-32768|32767] ""  EVCU
+ SG_ VCU_HYD_Parameter_RW_Command : 16|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ VCU_HYD_Parameter_Address : 0|16@1+ (1,0) [0|65535] ""  EVCU
+
+BO_ 2147483840 HYD_Command_Message: 8 EVCU
+ SG_ VCU_HYD_Inverter_Enable : 40|1@1+ (1,0) [0|1] ""  HYD
+ SG_ VCU_HYD_Direction_Command : 32|1@1+ (1,0) [0|1] ""  HYD
+ SG_ VCU_HYD_Speed_Command : 16|16@1- (1,0) [-32768|32767] "angular_speed:rpm"  HYD
+ SG_ VCU_HYD_Torque_Command : 0|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  HYD
+ SG_ VCU_HYD_Inverter_Discharge : 41|1@1+ (1,0) [0|1] ""  HYD
+ SG_ VCU_HYD_Torque_Limit_Command : 48|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  HYD
+ SG_ VCU_HYD_Speed_Mode_Enable : 42|1@1+ (1,0) [0|1] ""  HYD
+
+BO_ 2147483819 HYD_Fault_Codes: 8 HYD
+ SG_ HYD_Run_Fault_Hi : 48|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ HYD_Post_Fault_Hi : 16|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ HYD_Run_Fault_Lo : 32|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ HYD_Post_Fault_Lo : 0|16@1+ (1,0) [0|65535] ""  EVCU
+
+BO_ 2147483818 HYD_Internal_States: 8 HYD
+ SG_ HYD_Direction_Command : 56|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Inverter_Enable_State : 48|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Relay_3_Status : 26|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Relay_4_Status : 27|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Relay_2_Status : 25|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Inverter_Run_Mode : 32|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Inverter_Command_Mode : 40|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Relay_1_Status : 24|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Inverter_State : 16|8@1+ (1,0) [0|255] ""  EVCU
+ SG_ HYD_VSM_State : 0|8@1+ (1,0) [0|15] ""  EVCU
+ SG_ HYD_Inverter_Enable_Lockout : 55|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Inverter_Discharge_State : 37|3@1+ (1,0) [0|7] ""  EVCU
+ SG_ HYD_Relay_5_Status : 28|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Relay_6_Status : 29|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_BMS_Active : 57|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_BMS_Torque_Limiting : 58|1@1+ (1,0) [0|0] ""  EVCU
+ SG_ HYD_PWM_Frequency : 8|8@1+ (1,0) [0|255] ""  EVCU
+ SG_ HYD_Limit_Max_Speed : 59|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Limit_Hot_Spot : 60|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Low_Speed_Limiting : 61|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Rolling_Counter : 44|4@1+ (1,0) [0|15] ""  EVCU
+ SG_ HYD_Limit_Coolant_Derating : 62|1@1+ (1,0) [0|1] ""  EVCU
+
+BO_ 2147483817 HYD_Internal_Voltages: 8 HYD
+ SG_ HYD_Ref_Voltage_12_0 : 48|16@1- (0.01,0) [-327.68|327.67] "voltage:V"  EVCU
+ SG_ HYD_Ref_Voltage_5_0 : 32|16@1- (0.01,0) [-327.68|327.67] "voltage:V"  EVCU
+ SG_ HYD_Ref_Voltage_2_5 : 16|16@1- (0.01,0) [-327.68|327.67] "voltage:V"  EVCU
+ SG_ HYD_Ref_Voltage_1_5 : 0|16@1- (0.01,0) [-327.68|327.67] "voltage:V"  EVCU
+
+BO_ 2147483816 HYD_Flux_ID_IQ_Info: 8 HYD
+ SG_ HYD_Iq : 48|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ HYD_Id : 32|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ HYD_Flux_Feedback : 16|16@1- (0.001,0) [-32.768|32.767] "flux:Wb"  EVCU
+ SG_ HYD_Flux_Command : 0|16@1- (0.001,0) [-32.768|32.767] "flux:Wb"  EVCU
+
+BO_ 2147483815 HYD_Voltage_Info: 8 HYD
+ SG_ HYD_VBC_Vq_Voltage : 48|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+ SG_ HYD_VAB_Vd_Voltage : 32|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+ SG_ HYD_Output_Voltage : 16|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+ SG_ HYD_DC_Bus_Voltage : 0|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+
+BO_ 2147483814 HYD_Current_Info: 8 HYD
+ SG_ HYD_DC_Bus_Current : 48|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ HYD_Phase_C_Current : 32|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ HYD_Phase_B_Current : 16|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+ SG_ HYD_Phase_A_Current : 0|16@1- (0.1,0) [-3276.8|3276.7] "current:A"  EVCU
+
+BO_ 2147483813 HYD_Motor_Position_Info: 8 HYD
+ SG_ HYD_Delta_Resolver_Filtered : 48|16@1- (0.1,0) [-3276.8|3276.7] "angle:deg"  EVCU
+ SG_ HYD_Electrical_Output_Frequency : 32|16@1- (0.1,0) [-3276.8|3276.7] "frequency:Hz"  EVCU
+ SG_ HYD_Motor_Speed : 16|16@1- (1,0) [-32768|32767] "angular_speed:rpm"  EVCU
+ SG_ HYD_Motor_Angle_Electrical : 0|16@1+ (0.1,0) [0|6553.5] "angle:deg"  EVCU
+
+BO_ 2147483812 HYD_Digital_Input_Status: 8 HYD
+ SG_ HYD_Digital_Input_5 : 32|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Digital_Input_4 : 24|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Digital_Input_3 : 16|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Digital_Input_2 : 8|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Digital_Input_1 : 0|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Digital_Input_6 : 40|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Digital_Input_7 : 48|1@1+ (1,0) [0|1] ""  EVCU
+ SG_ HYD_Digital_Input_8 : 56|1@1+ (1,0) [0|1] ""  EVCU
+
+BO_ 2147483811 HYD_Analog_Input_Voltages: 8 HYD
+ SG_ HYD_Analog_Input_4 : 32|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ HYD_Analog_Input_1 : 0|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ HYD_Analog_Input_2 : 10|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ HYD_Analog_Input_5 : 42|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ HYD_Analog_Input_6 : 52|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+ SG_ HYD_Analog_Input_3 : 20|10@1+ (0.01,0) [0|10.23] "voltage:V"  EVCU
+
+BO_ 2147483810 HYD_Temperature_Set_3: 8 HYD
+ SG_ HYD_Torque_Shudder : 48|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  EVCU
+ SG_ HYD_Motor_Temp : 32|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ HYD_Hot_Spot_Temp : 16|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ HYD_Coolant_Temp : 0|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+
+BO_ 2147483809 HYD_Temperature_Set_2: 8 HYD
+ SG_ HYD_RTD2_Temperature : 32|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ HYD_RTD1_Temperature : 16|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ HYD_Control_Board_Temp : 0|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+
+BO_ 2147483808 HYD_Temperature_Set_1: 8 HYD
+ SG_ HYD_Gate_Driver_Board_Temp : 48|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ HYD_Module_C_Temp : 32|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ HYD_Module_B_Temp : 16|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+ SG_ HYD_Module_A_Temp : 0|16@1- (0.1,0) [-3276.8|3276.7] "temperature:C"  EVCU
+
+BO_ 2147483822 HYD_Firmware_Info: 8 HYD
+ SG_ HYD_Project_Code_EEP_Ver : 0|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ HYD_SW_Version : 16|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ HYD_DateCode_MMDD : 32|16@1+ (1,0) [0|65535] ""  EVCU
+ SG_ HYD_DateCode_YYYY : 48|16@1+ (1,0) [0|65535] ""  EVCU
+
+BO_ 2147483823 HYD_Diag_Data: 8 HYD
+ SG_ HYD_Diag_Buffer_Record : 0|8@1+ (1,0) [0|255] ""  EVCU
+ SG_ HYD_Diag_Buffer_Segment : 8|8@1+ (1,0) [0|5] ""  EVCU
+ SG_ HYD_Diag_Data_1 : 16|16@1- (1,0) [-32768|32767] ""  EVCU
+ SG_ HYD_Diag_Data_2 : 32|16@1- (1,0) [-32768|32767] ""  EVCU
+ SG_ HYD_Diag_Data_3 : 48|16@1- (1,0) [-32768|32767] ""  EVCU
+
+BO_ 2147483824 HYD_Fast_Info: 8 HYD
+ SG_ HYD_Fast_Torque_Command : 0|16@1- (0.1,0) [-3276.8|32767.7] "torque:N.m"  EVCU
+ SG_ HYD_Fast_Torque_Feedback : 16|16@1- (0.1,0) [-3276.8|3276.7] "torque:N.m"  EVCU
+ SG_ HYD_Fast_Motor_Speed : 32|16@1- (1,0) [-32768|32767] "angular_speed:rpm"  EVCU
+ SG_ HYD_Fast_DC_Bus_Voltage : 48|16@1- (0.1,0) [-3276.8|3276.7] "voltage:V"  EVCU
+
+BO_ 2348810288 C15_TSC1: 8 RCS
+ SG_ EngRequestedSpeed_SpeedLimit : 8|16@1+ (0.125,0) [0|8031.875] "rpm"  EVCU
+
+
+
+CM_ SG_ 2147485197 FAN_Iq_Command "The commanded Q-axis current";
+CM_ SG_ 2147485197 FAN_Id_Command "The commanded D-axis current";
+CM_ SG_ 2147485197 FAN_Flux_Weakening_Output "This is the current output of the flux regulator.";
+CM_ SG_ 2147485197 FAN_Modulation_Index "This is the modulation index. The scale factor is x100. To get the actual modulation index divide the value by 100.";
+CM_ SG_ 2147485196 FAN_Power_On_Timer "Updated every 3 msec. This will roll over in approximately 150 days!";
+CM_ SG_ 2147485196 FAN_Torque_Feedback "Estimated motor torque feedback";
+CM_ SG_ 2147485196 FAN_Commanded_Torque "The commanded Torque";
+CM_ BO_ 2147485218 "To write a parameter use message 0x0C1 with byte #2 set to 1 (write).
+To read a parameter use message 0x0C1 with byte #2 to set 0 (read). ";
+CM_ SG_ 2147485218 FAN_Parameter_Response_Write_OK "0=Write failure, 1=Success";
+CM_ SG_ 2147485218 FAN_Parameter_Response_Data "Data from parameter message.  All data is 16 bits and is contained in bytes 4 and 5. Bytes 6 and 7 should be ignored.";
+CM_ SG_ 2147485218 FAN_Parameter_Response_Addr "Address of parameter response message data.";
+CM_ BO_ 2147485217 "To write a parameter use message 0x0C1 with byte #2 set to 1 (write).
+To read a parameter use message 0x0C1 with byte #2 to set 0 (read). ";
+CM_ SG_ 2147485217 VCU_FAN_Parameter_Data "Data to be written.  All data is 16 bits and is contained in bytes 4 and 5.";
+CM_ SG_ 2147485217 VCU_FAN_Parameter_RW_Command "0=Read, 1=Write";
+CM_ SG_ 2147485217 VCU_FAN_Parameter_Address "Address of parameter to be written or read.";
+CM_ BO_ 2147485216 "The command message is used to transmit data to the controller. This message is sent from a user supplied external controller to the PMxxx controller.";
+CM_ SG_ 2147485216 VCU_FAN_Inverter_Enable "0=Inverter OFF, 1 = Inverter ON";
+CM_ SG_ 2147485216 VCU_FAN_Direction_Command "0=Reverse, 1=Forward.  Forward is positive motor speed.";
+CM_ SG_ 2147485216 VCU_FAN_Speed_Command "Speed command used when in speed mode";
+CM_ SG_ 2147485216 VCU_FAN_Torque_Command "Torque command when in torque mode";
+CM_ SG_ 2147485216 VCU_FAN_Inverter_Discharge "0=Discharge Disable,1=Discharge Enable";
+CM_ SG_ 2147485216 VCU_FAN_Torque_Limit_Command "Torque Limit, set to 0 to keep default";
+CM_ SG_ 2147485216 VCU_FAN_Speed_Mode_Enable "0 = No change to mode, 1 = change to speed mode from torque mode";
+CM_ SG_ 2147485195 FAN_Run_Fault_Hi "Each bit represents a fault. Please refer to PM100 Users Manual for details.";
+CM_ SG_ 2147485195 FAN_Post_Fault_Hi "Each bit represents a fault. Please refer to PM100 Users Manual for details.";
+CM_ SG_ 2147485195 FAN_Run_Fault_Lo "Each bit represents a fault. Please refer to PM100 Users Manual for details.";
+CM_ SG_ 2147485195 FAN_Post_Fault_Lo "Each bit represents a fault. Please refer to PM100 Users Manual for details.";
+CM_ SG_ 2147485194 FAN_Direction_Command "1 = Forward
+0 = 'Reverse' if inverter enabled  & 'Stopped' if inverter is disabled";
+CM_ SG_ 2147485194 FAN_Inverter_Enable_State "0=Inverter Disabled,
+1=Inverter Enabled";
+CM_ SG_ 2147485194 FAN_Relay_3_Status "0=OFF, 1=ON";
+CM_ SG_ 2147485194 FAN_Relay_4_Status "0=OFF, 1=ON";
+CM_ SG_ 2147485194 FAN_Relay_2_Status "0=OFF, 1=ON";
+CM_ SG_ 2147485194 FAN_Inverter_Run_Mode "0=Torque Mode, 1=Speed Mode";
+CM_ SG_ 2147485194 FAN_Inverter_Command_Mode "0=CAN mode, 1=VSM mode";
+CM_ SG_ 2147485194 FAN_Relay_1_Status "0=OFF, 1=ON";
+CM_ SG_ 2147485194 FAN_Inverter_State "Different states for the inverter state machine";
+CM_ SG_ 2147485194 FAN_VSM_State "Different states for the vehicle state machine";
+CM_ SG_ 2147485194 FAN_Inverter_Enable_Lockout "0=Lockout Disabled, 1=Lockout Enabled";
+CM_ SG_ 2147485194 FAN_Inverter_Discharge_State "0 = Disabled, 1 = Enabled, 2 = Speed Check, 3 = Active, 4 = Complete";
+CM_ SG_ 2147485194 FAN_Relay_5_Status "0=OFF, 1=ON";
+CM_ SG_ 2147485194 FAN_Relay_6_Status "0=OFF, 1=ON";
+CM_ SG_ 2147485194 FAN_BMS_Active "0 = BMS Not Active, 1 = BMS Active";
+CM_ SG_ 2147485194 FAN_BMS_Torque_Limiting "0 = Not Limiting, 1 = Limiting";
+CM_ SG_ 2147485194 FAN_PWM_Frequency "The current active PWM frequency";
+CM_ SG_ 2147485194 FAN_Limit_Max_Speed "Indicates that torque is being modified to limit the speed.";
+CM_ SG_ 2147485194 FAN_Limit_Hot_Spot "Indicates that torque is being limited to limit the hot spot temp";
+CM_ SG_ 2147485194 FAN_Low_Speed_Limiting "Indicates that motor current is being limited due to low motor electrical frequency.";
+CM_ SG_ 2147485194 FAN_Rolling_Counter "Rolling Counter value";
+CM_ SG_ 2147485194 FAN_Limit_Coolant_Derating "0 = Not limiting, 1 = Limiting";
+CM_ SG_ 2147485193 FAN_Ref_Voltage_12_0 "12V Input Voltage";
+CM_ SG_ 2147485193 FAN_Ref_Voltage_5_0 "Transducer voltage";
+CM_ SG_ 2147485193 FAN_Ref_Voltage_2_5 "Internal reference voltage";
+CM_ SG_ 2147485193 FAN_Ref_Voltage_1_5 "Internal reference voltage";
+CM_ SG_ 2147485192 FAN_Iq "The measured Iq current";
+CM_ SG_ 2147485192 FAN_Id "The measured Id current";
+CM_ SG_ 2147485192 FAN_Flux_Feedback "The estimated flux";
+CM_ SG_ 2147485192 FAN_Flux_Command "The commanded flux";
+CM_ SG_ 2147485191 FAN_VBC_Vq_Voltage "Measured value of the voltage between Phase B and Phase C";
+CM_ SG_ 2147485191 FAN_VAB_Vd_Voltage "Measured value of the voltage betwen phase A and Phase B";
+CM_ SG_ 2147485191 FAN_Output_Voltage "The calculated value of the output voltage, in peak line-neutral volts";
+CM_ SG_ 2147485191 FAN_DC_Bus_Voltage "The actual measured value of the DC bus voltage";
+CM_ SG_ 2147485190 FAN_DC_Bus_Current "The Calculated DC Bus Current";
+CM_ SG_ 2147485190 FAN_Phase_C_Current "The measured value of Phase C current";
+CM_ SG_ 2147485190 FAN_Phase_B_Current "The measured value of Phase B current";
+CM_ SG_ 2147485190 FAN_Phase_A_Current "The measured value of Phase A current";
+CM_ SG_ 2147485189 FAN_Delta_Resolver_Filtered "Used in calibration of resolver angle adjustment.";
+CM_ SG_ 2147485189 FAN_Electrical_Output_Frequency "The actual electrical frequency of the inverter";
+CM_ SG_ 2147485189 FAN_Motor_Speed "The measured speed of the motor";
+CM_ SG_ 2147485189 FAN_Motor_Angle_Electrical "The Electrical Angle of the motor as read by the encoder or resolver";
+CM_ SG_ 2147485188 FAN_Digital_Input_5 "Status of Digital Input #5";
+CM_ SG_ 2147485188 FAN_Digital_Input_4 "Status of Digital Input #4";
+CM_ SG_ 2147485188 FAN_Digital_Input_3 "Status of Digital Input #3";
+CM_ SG_ 2147485188 FAN_Digital_Input_2 "Status of Digital Input #2";
+CM_ SG_ 2147485188 FAN_Digital_Input_1 "Status of Digital Input #1";
+CM_ SG_ 2147485188 FAN_Digital_Input_6 "Status of Digital Input #6";
+CM_ SG_ 2147485188 FAN_Digital_Input_7 "Status of Digital Input #7";
+CM_ SG_ 2147485188 FAN_Digital_Input_8 "Status of Digital Input #8";
+CM_ SG_ 2147485187 FAN_Analog_Input_4 "Voltage on Analog Input #4";
+CM_ SG_ 2147485187 FAN_Analog_Input_1 "Voltage on Analog Input #1";
+CM_ SG_ 2147485187 FAN_Analog_Input_2 "Voltage on Analog Input #2";
+CM_ SG_ 2147485187 FAN_Analog_Input_5 "Voltage on Analog Input #5";
+CM_ SG_ 2147485187 FAN_Analog_Input_6 "Voltage on Analog Input #6";
+CM_ SG_ 2147485187 FAN_Analog_Input_3 "Voltage on Analog Input #3";
+CM_ SG_ 2147485186 FAN_Torque_Shudder "Shudder compensation value of torque";
+CM_ SG_ 2147485186 FAN_Motor_Temp "Motor Temperature Sensor";
+CM_ SG_ 2147485186 FAN_Hot_Spot_Temp "Estimated inverter hot spot temperature";
+CM_ SG_ 2147485186 FAN_Coolant_Temp "Estimated Coolant Temperature";
+CM_ SG_ 2147485185 FAN_RTD2_Temperature "RTD input 2 (PT1000) Temperature";
+CM_ SG_ 2147485185 FAN_RTD1_Temperature "RTD input 1 (PT1000) Temperature";
+CM_ SG_ 2147485185 FAN_Control_Board_Temp "Control Board Temperature";
+CM_ SG_ 2147485184 FAN_Gate_Driver_Board_Temp "Gate Driver Board Temperature";
+CM_ SG_ 2147485184 FAN_Module_C_Temp "IGBT Module C Temperature";
+CM_ SG_ 2147485184 FAN_Module_B_Temp "IGBT Module B Temperature";
+CM_ SG_ 2147485184 FAN_Module_A_Temp "IGBT Module A Temperature";
+CM_ SG_ 2147483915 CP2_VBC_Vq_Voltage "Measured value of the voltage between Phase B and Phase C";
+CM_ SG_ 2147483915 CP2_VAB_Vd_Voltage "Measured value of the voltage betwen phase A and Phase B";
+CM_ SG_ 2147483915 CP2_Output_Voltage "The calculated value of the output voltage, in peak line-neutral volts";
+CM_ SG_ 2147483915 CP2_DC_Bus_Voltage "The actual measured value of the DC bus voltage";
+CM_ SG_ 2147483920 CP2_Power_On_Timer "Updated every 3 msec. This will roll over in approximately 150 days!";
+CM_ SG_ 2147483920 CP2_Torque_Feedback "Estimated motor torque feedback";
+CM_ SG_ 2147483920 CP2_Commanded_Torque "The commanded Torque";
+CM_ SG_ 2147483910 CP2_Torque_Shudder "Shudder compensation value of torque";
+CM_ SG_ 2147483910 CP2_Motor_Temp "Motor Temperature Sensor";
+CM_ SG_ 2147483910 CP2_Hot_Spot_Temp "Estimated inverter hot spot temperature";
+CM_ SG_ 2147483910 CP2_Coolant_Temp "Estimated Coolant Temperature";
+CM_ SG_ 2147483909 CP2_RTD2_Temperature "RTD input 2 (PT1000) Temperature";
+CM_ SG_ 2147483909 CP2_RTD1_Temperature "RTD input 1 (PT1000) Temperature";
+CM_ SG_ 2147483909 CP2_Control_Board_Temp "Control Board Temperature";
+CM_ SG_ 2147483908 CP2_Gate_Driver_Board_Temp "Gate Driver Board Temperature";
+CM_ SG_ 2147483908 CP2_Module_C_Temp "IGBT Module C Temperature";
+CM_ SG_ 2147483908 CP2_Module_B_Temp "IGBT Module B Temperature";
+CM_ SG_ 2147483908 CP2_Module_A_Temp "IGBT Module A Temperature";
+CM_ BO_ 2147483942 "To write a parameter use message 0x0C1 with byte #2 set to 1 (write).
+To read a parameter use message 0x0C1 with byte #2 to set 0 (read). ";
+CM_ SG_ 2147483942 CP2_Parameter_Response_Write_OK "0=Write failure, 1=Success";
+CM_ SG_ 2147483942 CP2_Parameter_Response_Data "Data from parameter message.  All data is 16 bits and is contained in bytes 4 and 5. Bytes 6 and 7 should be ignored.";
+CM_ SG_ 2147483942 CP2_Parameter_Response_Addr "Address of parameter response message data.";
+CM_ BO_ 2147483941 "To write a parameter use message 0x0C1 with byte #2 set to 1 (write).
+To read a parameter use message 0x0C1 with byte #2 to set 0 (read). ";
+CM_ SG_ 2147483941 VCU_CP2_Parameter_Data "Data to be written.  All data is 16 bits and is contained in bytes 4 and 5.";
+CM_ SG_ 2147483941 VCU_CP2_Parameter_RW_Command "0=Read, 1=Write";
+CM_ SG_ 2147483941 VCU_CP2_Parameter_Address "Address of parameter to be written or read.";
+CM_ SG_ 2147483913 CP2_Delta_Resolver_Filtered "Used in calibration of resolver angle adjustment.";
+CM_ SG_ 2147483913 CP2_Electrical_Output_Frequency "The actual electrical frequency of the inverter";
+CM_ SG_ 2147483913 CP2_Motor_Speed "The measured speed of the motor";
+CM_ SG_ 2147483913 CP2_Motor_Angle_Electrical "The Electrical Angle of the motor as read by the encoder or resolver";
+CM_ SG_ 2147483921 CP2_Iq_Command "The commanded Q-axis current";
+CM_ SG_ 2147483921 CP2_Id_Command "The commanded D-axis current";
+CM_ SG_ 2147483921 CP2_Flux_Weakening_Output "This is the current output of the flux regulator.";
+CM_ SG_ 2147483921 CP2_Modulation_Index "This is the modulation index. The scale factor is x100. To get the actual modulation index divide the value by 100.";
+CM_ SG_ 2147483917 CP2_Ref_Voltage_12_0 "12V Input Voltage";
+CM_ SG_ 2147483917 CP2_Ref_Voltage_5_0 "Transducer voltage";
+CM_ SG_ 2147483917 CP2_Ref_Voltage_2_5 "Internal reference voltage";
+CM_ SG_ 2147483917 CP2_Ref_Voltage_1_5 "Internal reference voltage";
+CM_ SG_ 2147483918 CP2_Direction_Command "1 = Forward
+0 = 'Reverse' if inverter enabled  & 'Stopped' if inverter is disabled";
+CM_ SG_ 2147483918 CP2_Inverter_Enable_State "0=Inverter Disabled,
+1=Inverter Enabled";
+CM_ SG_ 2147483918 CP2_Relay_3_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483918 CP2_Relay_4_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483918 CP2_Relay_2_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483918 CP2_Inverter_Run_Mode "0=Torque Mode, 1=Speed Mode";
+CM_ SG_ 2147483918 CP2_Inverter_Command_Mode "0=CAN mode, 1=VSM mode";
+CM_ SG_ 2147483918 CP2_Relay_1_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483918 CP2_Inverter_State "Different states for the inverter state machine";
+CM_ SG_ 2147483918 CP2_VSM_State "Different states for the vehicle state machine";
+CM_ SG_ 2147483918 CP2_Inverter_Enable_Lockout "0=Lockout Disabled, 1=Lockout Enabled";
+CM_ SG_ 2147483918 CP2_Inverter_Discharge_State "0 = Disabled, 1 = Enabled, 2 = Speed Check, 3 = Active, 4 = Complete";
+CM_ SG_ 2147483918 CP2_Relay_5_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483918 CP2_Relay_6_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483918 CP2_BMS_Active "0 = BMS Not Active, 1 = BMS Active";
+CM_ SG_ 2147483918 CP2_BMS_Torque_Limiting "0 = Not Limiting, 1 = Limiting";
+CM_ SG_ 2147483918 CP2_PWM_Frequency "The current active PWM frequency";
+CM_ SG_ 2147483918 CP2_Limit_Max_Speed "Indicates that torque is being modified to limit the speed.";
+CM_ SG_ 2147483918 CP2_Limit_Hot_Spot "Indicates that torque is being limited to limit the hot spot temp";
+CM_ SG_ 2147483918 CP2_Low_Speed_Limiting "Indicates that motor current is being limited due to low motor electrical frequency.";
+CM_ SG_ 2147483918 CP2_Rolling_Counter "Rolling Counter value";
+CM_ SG_ 2147483918 CP2_Limit_Coolant_Derating "0 = Not limiting, 1 = Limiting";
+CM_ SG_ 2147483916 CP2_Iq "The measured Iq current";
+CM_ SG_ 2147483916 CP2_Id "The measured Id current";
+CM_ SG_ 2147483916 CP2_Flux_Feedback "The estimated flux";
+CM_ SG_ 2147483916 CP2_Flux_Command "The commanded flux";
+CM_ SG_ 2147483919 CP2_Run_Fault_Hi "Each bit represents a fault. Please refer to PM100 Users Manual for details.";
+CM_ SG_ 2147483919 CP2_Post_Fault_Hi "Each bit represents a fault. Please refer to PM100 Users Manual for details.";
+CM_ SG_ 2147483919 CP2_Run_Fault_Lo "Each bit represents a fault. Please refer to PM100 Users Manual for details.";
+CM_ SG_ 2147483919 CP2_Post_Fault_Lo "Each bit represents a fault. Please refer to PM100 Users Manual for details.";
+CM_ SG_ 2147483912 CP2_Digital_Input_5 "Status of Digital Input #5";
+CM_ SG_ 2147483912 CP2_Digital_Input_4 "Status of Digital Input #4";
+CM_ SG_ 2147483912 CP2_Digital_Input_3 "Status of Digital Input #3";
+CM_ SG_ 2147483912 CP2_Digital_Input_2 "Status of Digital Input #2";
+CM_ SG_ 2147483912 CP2_Digital_Input_1 "Status of Digital Input #1";
+CM_ SG_ 2147483912 CP2_Digital_Input_6 "Status of Digital Input #6";
+CM_ SG_ 2147483912 CP2_Digital_Input_7 "Status of Digital Input #7";
+CM_ SG_ 2147483912 CP2_Digital_Input_8 "Status of Digital Input #8";
+CM_ SG_ 2147483914 CP2_DC_Bus_Current "The Calculated DC Bus Current";
+CM_ SG_ 2147483914 CP2_Phase_C_Current "The measured value of Phase C current";
+CM_ SG_ 2147483914 CP2_Phase_B_Current "The measured value of Phase B current";
+CM_ SG_ 2147483914 CP2_Phase_A_Current "The measured value of Phase A current";
+CM_ BO_ 2147483940 "The command message is used to transmit data to the controller. This message is sent from a user supplied external controller to the PMxxx controller.";
+CM_ SG_ 2147483940 VCU_CP2_Inverter_Enable "0=Inverter OFF, 1 = Inverter ON";
+CM_ SG_ 2147483940 VCU_CP2_Direction_Command "0=Reverse, 1=Forward.  Forward is positive motor speed.";
+CM_ SG_ 2147483940 VCU_CP2_Speed_Command "Speed command used when in speed mode";
+CM_ SG_ 2147483940 VCU_CP2_Torque_Command "Torque command when in torque mode";
+CM_ SG_ 2147483940 VCU_CP2_Inverter_Discharge "0=Discharge Disable,1=Discharge Enable";
+CM_ SG_ 2147483940 VCU_CP2_Torque_Limit_Command "Torque Limit, set to 0 to keep default";
+CM_ SG_ 2147483940 VCU_CP2_Speed_Mode_Enable "0 = No change to mode, 1 = change to speed mode from torque mode";
+CM_ SG_ 2147483911 CP2_Analog_Input_4 "Voltage on Analog Input #4";
+CM_ SG_ 2147483911 CP2_Analog_Input_1 "Voltage on Analog Input #1";
+CM_ SG_ 2147483911 CP2_Analog_Input_2 "Voltage on Analog Input #2";
+CM_ SG_ 2147483911 CP2_Analog_Input_5 "Voltage on Analog Input #5";
+CM_ SG_ 2147483911 CP2_Analog_Input_6 "Voltage on Analog Input #6";
+CM_ SG_ 2147483911 CP2_Analog_Input_3 "Voltage on Analog Input #3";
+CM_ BO_ 2147483892 "To write a parameter use message 0x0C1 with byte #2 set to 1 (write).
+To read a parameter use message 0x0C1 with byte #2 to set 0 (read). ";
+CM_ SG_ 2147483892 CP1_Parameter_Response_Write_OK "0=Write failure, 1=Success";
+CM_ SG_ 2147483892 CP1_Parameter_Response_Data "Data from parameter message.  All data is 16 bits and is contained in bytes 4 and 5. Bytes 6 and 7 should be ignored.";
+CM_ SG_ 2147483892 CP1_Parameter_Response_Addr "Address of parameter response message data.";
+CM_ BO_ 2147483891 "To write a parameter use message 0x0C1 with byte #2 set to 1 (write).
+To read a parameter use message 0x0C1 with byte #2 to set 0 (read). ";
+CM_ SG_ 2147483891 VCU_CP1_Parameter_Data "Data to be written.  All data is 16 bits and is contained in bytes 4 and 5.";
+CM_ SG_ 2147483891 VCU_CP1_Parameter_RW_Command "0=Read, 1=Write";
+CM_ SG_ 2147483891 VCU_CP1_Parameter_Address "Address of parameter to be written or read.";
+CM_ BO_ 2147483890 "The command message is used to transmit data to the controller. This message is sent from a user supplied external controller to the PMxxx controller.";
+CM_ SG_ 2147483890 VCU_CP1_Inverter_Enable "0=Inverter OFF, 1 = Inverter ON";
+CM_ SG_ 2147483890 VCU_CP1_Direction_Command "0=Reverse, 1=Forward.  Forward is positive motor speed.";
+CM_ SG_ 2147483890 VCU_CP1_Speed_Command "Speed command used when in speed mode";
+CM_ SG_ 2147483890 VCU_CP1_Torque_Command "Torque command when in torque mode";
+CM_ SG_ 2147483890 VCU_CP1_Inverter_Discharge "0=Discharge Disable,1=Discharge Enable";
+CM_ SG_ 2147483890 VCU_CP1_Torque_Limit_Command "Torque Limit, set to 0 to keep default";
+CM_ SG_ 2147483890 VCU_CP1_Speed_Mode_Enable "0 = No change to mode, 1 = change to speed mode from torque mode";
+CM_ SG_ 2147483871 CP1_Iq_Command "The commanded Q-axis current";
+CM_ SG_ 2147483871 CP1_Id_Command "The commanded D-axis current";
+CM_ SG_ 2147483871 CP1_Flux_Weakening_Output "This is the current output of the flux regulator.";
+CM_ SG_ 2147483871 CP1_Modulation_Index "This is the modulation index. The scale factor is x100. To get the actual modulation index divide the value by 100.";
+CM_ SG_ 2147483870 CP1_Power_On_Timer "Updated every 3 msec. This will roll over in approximately 150 days!";
+CM_ SG_ 2147483870 CP1_Torque_Feedback "Estimated motor torque feedback";
+CM_ SG_ 2147483870 CP1_Commanded_Torque "The commanded Torque";
+CM_ SG_ 2147483869 CP1_Run_Fault_Hi "Each bit represents a fault. Please refer to PM100 Users Manual for details.";
+CM_ SG_ 2147483869 CP1_Post_Fault_Hi "Each bit represents a fault. Please refer to PM100 Users Manual for details.";
+CM_ SG_ 2147483869 CP1_Run_Fault_Lo "Each bit represents a fault. Please refer to PM100 Users Manual for details.";
+CM_ SG_ 2147483869 CP1_Post_Fault_Lo "Each bit represents a fault. Please refer to PM100 Users Manual for details.";
+CM_ SG_ 2147483868 CP1_Direction_Command "1 = Forward
+0 = 'Reverse' if inverter enabled  & 'Stopped' if inverter is disabled";
+CM_ SG_ 2147483868 CP1_Inverter_Enable_State "0=Inverter Disabled,
+1=Inverter Enabled";
+CM_ SG_ 2147483868 CP1_Relay_3_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483868 CP1_Relay_4_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483868 CP1_Relay_2_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483868 CP1_Inverter_Run_Mode "0=Torque Mode, 1=Speed Mode";
+CM_ SG_ 2147483868 CP1_Inverter_Command_Mode "0=CAN mode, 1=VSM mode";
+CM_ SG_ 2147483868 CP1_Relay_1_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483868 CP1_Inverter_State "Different states for the inverter state machine";
+CM_ SG_ 2147483868 CP1_VSM_State "Different states for the vehicle state machine";
+CM_ SG_ 2147483868 CP1_Inverter_Enable_Lockout "0=Lockout Disabled, 1=Lockout Enabled";
+CM_ SG_ 2147483868 CP1_Inverter_Discharge_State "0 = Disabled, 1 = Enabled, 2 = Speed Check, 3 = Active, 4 = Complete";
+CM_ SG_ 2147483868 CP1_Relay_5_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483868 CP1_Relay_6_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483868 CP1_BMS_Active "0 = BMS Not Active, 1 = BMS Active";
+CM_ SG_ 2147483868 CP1_BMS_Torque_Limiting "0 = Not Limiting, 1 = Limiting";
+CM_ SG_ 2147483868 CP1_PWM_Frequency "The current active PWM frequency";
+CM_ SG_ 2147483868 CP1_Limit_Max_Speed "Indicates that torque is being modified to limit the speed.";
+CM_ SG_ 2147483868 CP1_Limit_Hot_Spot "Indicates that torque is being limited to limit the hot spot temp";
+CM_ SG_ 2147483868 CP1_Low_Speed_Limiting "Indicates that motor current is being limited due to low motor electrical frequency.";
+CM_ SG_ 2147483868 CP1_Rolling_Counter "Rolling Counter value";
+CM_ SG_ 2147483868 CP1_Limit_Coolant_Derating "0 = Not limiting, 1 = Limiting";
+CM_ SG_ 2147483867 CP1_Ref_Voltage_12_0 "12V Input Voltage";
+CM_ SG_ 2147483867 CP1_Ref_Voltage_5_0 "Transducer voltage";
+CM_ SG_ 2147483867 CP1_Ref_Voltage_2_5 "Internal reference voltage";
+CM_ SG_ 2147483867 CP1_Ref_Voltage_1_5 "Internal reference voltage";
+CM_ SG_ 2147483866 CP1_Iq "The measured Iq current";
+CM_ SG_ 2147483866 CP1_Id "The measured Id current";
+CM_ SG_ 2147483866 CP1_Flux_Feedback "The estimated flux";
+CM_ SG_ 2147483866 CP1_Flux_Command "The commanded flux";
+CM_ SG_ 2147483865 CP1_VBC_Vq_Voltage "Measured value of the voltage between Phase B and Phase C";
+CM_ SG_ 2147483865 CP1_VAB_Vd_Voltage "Measured value of the voltage betwen phase A and Phase B";
+CM_ SG_ 2147483865 CP1_Output_Voltage "The calculated value of the output voltage, in peak line-neutral volts";
+CM_ SG_ 2147483865 CP1_DC_Bus_Voltage "The actual measured value of the DC bus voltage";
+CM_ SG_ 2147483864 CP1_DC_Bus_Current "The Calculated DC Bus Current";
+CM_ SG_ 2147483864 CP1_Phase_C_Current "The measured value of Phase C current";
+CM_ SG_ 2147483864 CP1_Phase_B_Current "The measured value of Phase B current";
+CM_ SG_ 2147483864 CP1_Phase_A_Current "The measured value of Phase A current";
+CM_ SG_ 2147483863 CP1_Delta_Resolver_Filtered "Used in calibration of resolver angle adjustment.";
+CM_ SG_ 2147483863 CP1_Electrical_Output_Frequency "The actual electrical frequency of the inverter";
+CM_ SG_ 2147483863 CP1_Motor_Speed "The measured speed of the motor";
+CM_ SG_ 2147483863 CP1_Motor_Angle_Electrical "The Electrical Angle of the motor as read by the encoder or resolver";
+CM_ SG_ 2147483862 CP1_Digital_Input_5 "Status of Digital Input #5";
+CM_ SG_ 2147483862 CP1_Digital_Input_4 "Status of Digital Input #4";
+CM_ SG_ 2147483862 CP1_Digital_Input_3 "Status of Digital Input #3";
+CM_ SG_ 2147483862 CP1_Digital_Input_2 "Status of Digital Input #2";
+CM_ SG_ 2147483862 CP1_Digital_Input_1 "Status of Digital Input #1";
+CM_ SG_ 2147483862 CP1_Digital_Input_6 "Status of Digital Input #6";
+CM_ SG_ 2147483862 CP1_Digital_Input_7 "Status of Digital Input #7";
+CM_ SG_ 2147483862 CP1_Digital_Input_8 "Status of Digital Input #8";
+CM_ SG_ 2147483861 CP1_Analog_Input_4 "Voltage on Analog Input #4";
+CM_ SG_ 2147483861 CP1_Analog_Input_1 "Voltage on Analog Input #1";
+CM_ SG_ 2147483861 CP1_Analog_Input_2 "Voltage on Analog Input #2";
+CM_ SG_ 2147483861 CP1_Analog_Input_5 "Voltage on Analog Input #5";
+CM_ SG_ 2147483861 CP1_Analog_Input_6 "Voltage on Analog Input #6";
+CM_ SG_ 2147483861 CP1_Analog_Input_3 "Voltage on Analog Input #3";
+CM_ SG_ 2147483860 CP1_Torque_Shudder "Shudder compensation value of torque";
+CM_ SG_ 2147483860 CP1_Motor_Temp "Motor Temperature Sensor";
+CM_ SG_ 2147483860 CP1_Hot_Spot_Temp "Estimated inverter hot spot temperature";
+CM_ SG_ 2147483860 CP1_Coolant_Temp "Estimated Coolant Temperature";
+CM_ SG_ 2147483859 CP1_RTD2_Temperature "RTD input 2 (PT1000) Temperature";
+CM_ SG_ 2147483859 CP1_RTD1_Temperature "RTD input 1 (PT1000) Temperature";
+CM_ SG_ 2147483859 CP1_Control_Board_Temp "Control Board Temperature";
+CM_ SG_ 2147483858 CP1_Gate_Driver_Board_Temp "Gate Driver Board Temperature";
+CM_ SG_ 2147483858 CP1_Module_C_Temp "IGBT Module C Temperature";
+CM_ SG_ 2147483858 CP1_Module_B_Temp "IGBT Module B Temperature";
+CM_ SG_ 2147483858 CP1_Module_A_Temp "IGBT Module A Temperature";
+CM_ SG_ 2147483821 HYD_Iq_Command "The commanded Q-axis current";
+CM_ SG_ 2147483821 HYD_Id_Command "The commanded D-axis current";
+CM_ SG_ 2147483821 HYD_Flux_Weakening_Output "This is the current output of the flux regulator.";
+CM_ SG_ 2147483821 HYD_Modulation_Index "This is the modulation index. The scale factor is x100. To get the actual modulation index divide the value by 100.";
+CM_ SG_ 2147483820 HYD_Power_On_Timer "Updated every 3 msec. This will roll over in approximately 150 days!";
+CM_ SG_ 2147483820 HYD_Torque_Feedback "Estimated motor torque feedback";
+CM_ SG_ 2147483820 HYD_Commanded_Torque "The commanded Torque";
+CM_ BO_ 2147483842 "To write a parameter use message 0x0C1 with byte #2 set to 1 (write).
+To read a parameter use message 0x0C1 with byte #2 to set 0 (read). ";
+CM_ SG_ 2147483842 HYD_Parameter_Response_Write_OK "0=Write failure, 1=Success";
+CM_ SG_ 2147483842 HYD_Parameter_Response_Data "Data from parameter message.  All data is 16 bits and is contained in bytes 4 and 5. Bytes 6 and 7 should be ignored.";
+CM_ SG_ 2147483842 HYD_Parameter_Response_Addr "Address of parameter response message data.";
+CM_ BO_ 2147483841 "To write a parameter use message 0x0C1 with byte #2 set to 1 (write).
+To read a parameter use message 0x0C1 with byte #2 to set 0 (read). ";
+CM_ SG_ 2147483841 VCU_HYD_Parameter_Data "Data to be written.  All data is 16 bits and is contained in bytes 4 and 5.";
+CM_ SG_ 2147483841 VCU_HYD_Parameter_RW_Command "0=Read, 1=Write";
+CM_ SG_ 2147483841 VCU_HYD_Parameter_Address "Address of parameter to be written or read.";
+CM_ BO_ 2147483840 "The command message is used to transmit data to the controller. This message is sent from a user supplied external controller to the PMxxx controller.";
+CM_ SG_ 2147483840 VCU_HYD_Inverter_Enable "0=Inverter OFF, 1 = Inverter ON";
+CM_ SG_ 2147483840 VCU_HYD_Direction_Command "0=Reverse, 1=Forward.  Forward is positive motor speed.";
+CM_ SG_ 2147483840 VCU_HYD_Speed_Command "Speed command used when in speed mode";
+CM_ SG_ 2147483840 VCU_HYD_Torque_Command "Torque command when in torque mode";
+CM_ SG_ 2147483840 VCU_HYD_Inverter_Discharge "0=Discharge Disable,1=Discharge Enable";
+CM_ SG_ 2147483840 VCU_HYD_Torque_Limit_Command "Torque Limit, set to 0 to keep default";
+CM_ SG_ 2147483840 VCU_HYD_Speed_Mode_Enable "0 = No change to mode, 1 = change to speed mode from torque mode";
+CM_ SG_ 2147483819 HYD_Run_Fault_Hi "Each bit represents a fault. Please refer to PM100 Users Manual for details.";
+CM_ SG_ 2147483819 HYD_Post_Fault_Hi "Each bit represents a fault. Please refer to PM100 Users Manual for details.";
+CM_ SG_ 2147483819 HYD_Run_Fault_Lo "Each bit represents a fault. Please refer to PM100 Users Manual for details.";
+CM_ SG_ 2147483819 HYD_Post_Fault_Lo "Each bit represents a fault. Please refer to PM100 Users Manual for details.";
+CM_ SG_ 2147483818 HYD_Direction_Command "1 = Forward
+0 = 'Reverse' if inverter enabled  & 'Stopped' if inverter is disabled";
+CM_ SG_ 2147483818 HYD_Inverter_Enable_State "0=Inverter Disabled,
+1=Inverter Enabled";
+CM_ SG_ 2147483818 HYD_Relay_3_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483818 HYD_Relay_4_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483818 HYD_Relay_2_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483818 HYD_Inverter_Run_Mode "0=Torque Mode, 1=Speed Mode";
+CM_ SG_ 2147483818 HYD_Inverter_Command_Mode "0=CAN mode, 1=VSM mode";
+CM_ SG_ 2147483818 HYD_Relay_1_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483818 HYD_Inverter_State "Different states for the inverter state machine";
+CM_ SG_ 2147483818 HYD_VSM_State "Different states for the vehicle state machine";
+CM_ SG_ 2147483818 HYD_Inverter_Enable_Lockout "0=Lockout Disabled, 1=Lockout Enabled";
+CM_ SG_ 2147483818 HYD_Inverter_Discharge_State "0 = Disabled, 1 = Enabled, 2 = Speed Check, 3 = Active, 4 = Complete";
+CM_ SG_ 2147483818 HYD_Relay_5_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483818 HYD_Relay_6_Status "0=OFF, 1=ON";
+CM_ SG_ 2147483818 HYD_BMS_Active "0 = BMS Not Active, 1 = BMS Active";
+CM_ SG_ 2147483818 HYD_BMS_Torque_Limiting "0 = Not Limiting, 1 = Limiting";
+CM_ SG_ 2147483818 HYD_PWM_Frequency "The current active PWM frequency";
+CM_ SG_ 2147483818 HYD_Limit_Max_Speed "Indicates that torque is being modified to limit the speed.";
+CM_ SG_ 2147483818 HYD_Limit_Hot_Spot "Indicates that torque is being limited to limit the hot spot temp";
+CM_ SG_ 2147483818 HYD_Low_Speed_Limiting "Indicates that motor current is being limited due to low motor electrical frequency.";
+CM_ SG_ 2147483818 HYD_Rolling_Counter "Rolling Counter value";
+CM_ SG_ 2147483818 HYD_Limit_Coolant_Derating "0 = Not limiting, 1 = Limiting";
+CM_ SG_ 2147483817 HYD_Ref_Voltage_12_0 "12V Input Voltage";
+CM_ SG_ 2147483817 HYD_Ref_Voltage_5_0 "Transducer voltage";
+CM_ SG_ 2147483817 HYD_Ref_Voltage_2_5 "Internal reference voltage";
+CM_ SG_ 2147483817 HYD_Ref_Voltage_1_5 "Internal reference voltage";
+CM_ SG_ 2147483816 HYD_Iq "The measured Iq current";
+CM_ SG_ 2147483816 HYD_Id "The measured Id current";
+CM_ SG_ 2147483816 HYD_Flux_Feedback "The estimated flux";
+CM_ SG_ 2147483816 HYD_Flux_Command "The commanded flux";
+CM_ SG_ 2147483815 HYD_VBC_Vq_Voltage "Measured value of the voltage between Phase B and Phase C";
+CM_ SG_ 2147483815 HYD_VAB_Vd_Voltage "Measured value of the voltage betwen phase A and Phase B";
+CM_ SG_ 2147483815 HYD_Output_Voltage "The calculated value of the output voltage, in peak line-neutral volts";
+CM_ SG_ 2147483815 HYD_DC_Bus_Voltage "The actual measured value of the DC bus voltage";
+CM_ SG_ 2147483814 HYD_DC_Bus_Current "The Calculated DC Bus Current";
+CM_ SG_ 2147483814 HYD_Phase_C_Current "The measured value of Phase C current";
+CM_ SG_ 2147483814 HYD_Phase_B_Current "The measured value of Phase B current";
+CM_ SG_ 2147483814 HYD_Phase_A_Current "The measured value of Phase A current";
+CM_ SG_ 2147483813 HYD_Delta_Resolver_Filtered "Used in calibration of resolver angle adjustment.";
+CM_ SG_ 2147483813 HYD_Electrical_Output_Frequency "The actual electrical frequency of the inverter";
+CM_ SG_ 2147483813 HYD_Motor_Speed "The measured speed of the motor";
+CM_ SG_ 2147483813 HYD_Motor_Angle_Electrical "The Electrical Angle of the motor as read by the encoder or resolver";
+CM_ SG_ 2147483812 HYD_Digital_Input_5 "Status of Digital Input #5";
+CM_ SG_ 2147483812 HYD_Digital_Input_4 "Status of Digital Input #4";
+CM_ SG_ 2147483812 HYD_Digital_Input_3 "Status of Digital Input #3";
+CM_ SG_ 2147483812 HYD_Digital_Input_2 "Status of Digital Input #2";
+CM_ SG_ 2147483812 HYD_Digital_Input_1 "Status of Digital Input #1";
+CM_ SG_ 2147483812 HYD_Digital_Input_6 "Status of Digital Input #6";
+CM_ SG_ 2147483812 HYD_Digital_Input_7 "Status of Digital Input #7";
+CM_ SG_ 2147483812 HYD_Digital_Input_8 "Status of Digital Input #8";
+CM_ SG_ 2147483811 HYD_Analog_Input_4 "Voltage on Analog Input #4";
+CM_ SG_ 2147483811 HYD_Analog_Input_1 "Voltage on Analog Input #1";
+CM_ SG_ 2147483811 HYD_Analog_Input_2 "Voltage on Analog Input #2";
+CM_ SG_ 2147483811 HYD_Analog_Input_5 "Voltage on Analog Input #5";
+CM_ SG_ 2147483811 HYD_Analog_Input_6 "Voltage on Analog Input #6";
+CM_ SG_ 2147483811 HYD_Analog_Input_3 "Voltage on Analog Input #3";
+CM_ SG_ 2147483810 HYD_Torque_Shudder "Shudder compensation value of torque";
+CM_ SG_ 2147483810 HYD_Motor_Temp "Motor Temperature Sensor";
+CM_ SG_ 2147483810 HYD_Hot_Spot_Temp "Estimated inverter hot spot temperature";
+CM_ SG_ 2147483810 HYD_Coolant_Temp "Estimated Coolant Temperature";
+CM_ SG_ 2147483809 HYD_RTD2_Temperature "RTD input 2 (PT1000) Temperature";
+CM_ SG_ 2147483809 HYD_RTD1_Temperature "RTD input 1 (PT1000) Temperature";
+CM_ SG_ 2147483809 HYD_Control_Board_Temp "Control Board Temperature";
+CM_ SG_ 2147483808 HYD_Gate_Driver_Board_Temp "Gate Driver Board Temperature";
+CM_ SG_ 2147483808 HYD_Module_C_Temp "IGBT Module C Temperature";
+CM_ SG_ 2147483808 HYD_Module_B_Temp "IGBT Module B Temperature";
+CM_ SG_ 2147483808 HYD_Module_A_Temp "IGBT Module A Temperature";
+BA_DEF_ BO_  "CANFD_BRS" ENUM  "0","1";
+BA_DEF_ BO_  "CanDootDecode" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootDecodeBus" INT 0 6;
+BA_DEF_ BO_  "CanDootHideAll" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootPaused" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulate" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulateBus" INT 0 6;
+BA_DEF_ BO_  "CanDootSimulateCycleTime" INT 0 50000;
+BA_DEF_ BO_  "GenMsgCycleTime" INT 0 100000;
+BA_DEF_ BO_  "VFrameFormat" ENUM  "StandardCAN","ExtendedCAN","reserved","J1939PG","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","StandardCAN_FD","ExtendedCAN_FD";
+BA_DEF_ SG_  "CanDootBroadcast" ENUM  "No","Yes";
+BA_DEF_ SG_  "CanDootGroup" ENUM  "None","g1","g2","g3","g4","g5","g6","g7","g8","g9","gA","gB","gC","gD","gE","gF";
+BA_DEF_ SG_  "CanDootHidden" ENUM  "No","Yes";
+BA_DEF_ SG_  "GenSigStartValue" INT 0 2147483647;
+BA_DEF_ BU_  "DeviceInfo" STRING ;
+BA_DEF_ BU_  "ECU" STRING ;
+BA_DEF_ BU_  "NmStationAddress" INT 0 255;
+BA_DEF_ BU_  "NodeLayerModules" STRING ;
+BA_DEF_  "BusType" STRING ;
+BA_DEF_  "DBName" STRING ;
+BA_DEF_DEF_  "CANFD_BRS" "1";
+BA_DEF_DEF_  "CanDootDecode" "No";
+BA_DEF_DEF_  "CanDootDecodeBus" 1;
+BA_DEF_DEF_  "CanDootHideAll" "No";
+BA_DEF_DEF_  "CanDootPaused" "Yes";
+BA_DEF_DEF_  "CanDootSimulate" "No";
+BA_DEF_DEF_  "CanDootSimulateBus" 1;
+BA_DEF_DEF_  "CanDootSimulateCycleTime" 1500;
+BA_DEF_DEF_  "GenMsgCycleTime" 0;
+BA_DEF_DEF_  "VFrameFormat" "ExtendedCAN";
+BA_DEF_DEF_  "CanDootBroadcast" "No";
+BA_DEF_DEF_  "CanDootGroup" "None";
+BA_DEF_DEF_  "CanDootHidden" "No";
+BA_DEF_DEF_  "GenSigStartValue" 0;
+BA_DEF_DEF_  "DeviceInfo" "";
+BA_DEF_DEF_  "ECU" "";
+BA_DEF_DEF_  "NmStationAddress" 254;
+BA_DEF_DEF_  "NodeLayerModules" "";
+BA_DEF_DEF_  "BusType" "CAN";
+BA_DEF_DEF_  "DBName" "";
+BA_ "DBName" "CAN_CM";
+BA_ "CanDootSimulateCycleTime" BO_ 2147485197 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485197 5;
+BA_ "CanDootSimulate" BO_ 2147485197 0;
+BA_ "CanDootPaused" BO_ 2147485197 1;
+BA_ "CanDootDecodeBus" BO_ 2147485197 5;
+BA_ "CanDootDecode" BO_ 2147485197 1;
+BA_ "GenMsgCycleTime" BO_ 2147485196 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485196 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485196 5;
+BA_ "CanDootSimulate" BO_ 2147485196 0;
+BA_ "CanDootPaused" BO_ 2147485196 0;
+BA_ "CanDootDecodeBus" BO_ 2147485196 5;
+BA_ "CanDootDecode" BO_ 2147485196 1;
+BA_ "GenMsgCycleTime" BO_ 2147485218 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485218 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485218 5;
+BA_ "CanDootSimulate" BO_ 2147485218 0;
+BA_ "CanDootPaused" BO_ 2147485218 1;
+BA_ "CanDootDecodeBus" BO_ 2147485218 5;
+BA_ "CanDootDecode" BO_ 2147485218 1;
+BA_ "GenMsgCycleTime" BO_ 2147485217 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485217 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485217 5;
+BA_ "CanDootSimulate" BO_ 2147485217 0;
+BA_ "CanDootPaused" BO_ 2147485217 1;
+BA_ "CanDootDecodeBus" BO_ 2147485217 5;
+BA_ "CanDootDecode" BO_ 2147485217 1;
+BA_ "CanDootDecode" BO_ 2147485216 1;
+BA_ "GenMsgCycleTime" BO_ 2147485216 5;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485216 250;
+BA_ "CanDootSimulateBus" BO_ 2147485216 5;
+BA_ "CanDootSimulate" BO_ 2147485216 0;
+BA_ "CanDootPaused" BO_ 2147485216 0;
+BA_ "CanDootDecodeBus" BO_ 2147485216 5;
+BA_ "GenMsgCycleTime" BO_ 2147485195 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485195 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485195 5;
+BA_ "CanDootSimulate" BO_ 2147485195 0;
+BA_ "CanDootPaused" BO_ 2147485195 0;
+BA_ "CanDootDecodeBus" BO_ 2147485195 5;
+BA_ "CanDootDecode" BO_ 2147485195 1;
+BA_ "GenMsgCycleTime" BO_ 2147485194 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485194 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485194 5;
+BA_ "CanDootSimulate" BO_ 2147485194 0;
+BA_ "CanDootPaused" BO_ 2147485194 0;
+BA_ "CanDootDecodeBus" BO_ 2147485194 5;
+BA_ "CanDootDecode" BO_ 2147485194 1;
+BA_ "GenMsgCycleTime" BO_ 2147485193 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485193 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485193 5;
+BA_ "CanDootSimulate" BO_ 2147485193 0;
+BA_ "CanDootPaused" BO_ 2147485193 1;
+BA_ "CanDootDecodeBus" BO_ 2147485193 5;
+BA_ "CanDootDecode" BO_ 2147485193 1;
+BA_ "GenMsgCycleTime" BO_ 2147485192 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485192 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485192 5;
+BA_ "CanDootSimulate" BO_ 2147485192 0;
+BA_ "CanDootPaused" BO_ 2147485192 1;
+BA_ "CanDootDecodeBus" BO_ 2147485192 5;
+BA_ "CanDootDecode" BO_ 2147485192 1;
+BA_ "GenMsgCycleTime" BO_ 2147485191 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485191 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485191 5;
+BA_ "CanDootSimulate" BO_ 2147485191 0;
+BA_ "CanDootPaused" BO_ 2147485191 0;
+BA_ "CanDootDecodeBus" BO_ 2147485191 5;
+BA_ "CanDootDecode" BO_ 2147485191 1;
+BA_ "GenMsgCycleTime" BO_ 2147485190 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485190 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485190 5;
+BA_ "CanDootSimulate" BO_ 2147485190 0;
+BA_ "CanDootPaused" BO_ 2147485190 0;
+BA_ "CanDootDecodeBus" BO_ 2147485190 5;
+BA_ "CanDootDecode" BO_ 2147485190 1;
+BA_ "GenMsgCycleTime" BO_ 2147485189 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485189 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485189 5;
+BA_ "CanDootSimulate" BO_ 2147485189 0;
+BA_ "CanDootPaused" BO_ 2147485189 0;
+BA_ "CanDootDecodeBus" BO_ 2147485189 5;
+BA_ "CanDootDecode" BO_ 2147485189 1;
+BA_ "GenMsgCycleTime" BO_ 2147485188 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485188 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485188 5;
+BA_ "CanDootSimulate" BO_ 2147485188 0;
+BA_ "CanDootPaused" BO_ 2147485188 1;
+BA_ "CanDootDecodeBus" BO_ 2147485188 5;
+BA_ "CanDootDecode" BO_ 2147485188 1;
+BA_ "GenMsgCycleTime" BO_ 2147485187 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485187 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485187 5;
+BA_ "CanDootSimulate" BO_ 2147485187 0;
+BA_ "CanDootPaused" BO_ 2147485187 1;
+BA_ "CanDootDecodeBus" BO_ 2147485187 5;
+BA_ "CanDootDecode" BO_ 2147485187 1;
+BA_ "GenMsgCycleTime" BO_ 2147485186 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485186 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485186 5;
+BA_ "CanDootSimulate" BO_ 2147485186 0;
+BA_ "CanDootPaused" BO_ 2147485186 0;
+BA_ "CanDootDecodeBus" BO_ 2147485186 5;
+BA_ "CanDootDecode" BO_ 2147485186 1;
+BA_ "GenMsgCycleTime" BO_ 2147485185 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485185 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485185 5;
+BA_ "CanDootSimulate" BO_ 2147485185 0;
+BA_ "CanDootPaused" BO_ 2147485185 1;
+BA_ "CanDootDecodeBus" BO_ 2147485185 5;
+BA_ "CanDootDecode" BO_ 2147485185 1;
+BA_ "GenMsgCycleTime" BO_ 2147485184 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485184 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485184 5;
+BA_ "CanDootSimulate" BO_ 2147485184 0;
+BA_ "CanDootPaused" BO_ 2147485184 1;
+BA_ "CanDootDecodeBus" BO_ 2147485184 5;
+BA_ "CanDootDecode" BO_ 2147485184 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485198 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485198 5;
+BA_ "CanDootSimulate" BO_ 2147485198 0;
+BA_ "CanDootPaused" BO_ 2147485198 1;
+BA_ "CanDootDecodeBus" BO_ 2147485198 5;
+BA_ "CanDootDecode" BO_ 2147485198 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485199 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485199 5;
+BA_ "CanDootSimulate" BO_ 2147485199 0;
+BA_ "CanDootPaused" BO_ 2147485199 1;
+BA_ "CanDootDecodeBus" BO_ 2147485199 5;
+BA_ "CanDootDecode" BO_ 2147485199 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2147485200 1000;
+BA_ "CanDootSimulateBus" BO_ 2147485200 5;
+BA_ "CanDootSimulate" BO_ 2147485200 0;
+BA_ "CanDootPaused" BO_ 2147485200 1;
+BA_ "CanDootDecodeBus" BO_ 2147485200 5;
+BA_ "CanDootDecode" BO_ 2147485200 1;
+BA_ "GenMsgCycleTime" BO_ 2147483915 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483915 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483915 5;
+BA_ "CanDootSimulate" BO_ 2147483915 0;
+BA_ "CanDootPaused" BO_ 2147483915 1;
+BA_ "CanDootDecodeBus" BO_ 2147483915 5;
+BA_ "CanDootDecode" BO_ 2147483915 1;
+BA_ "GenMsgCycleTime" BO_ 2147483920 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483920 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483920 5;
+BA_ "CanDootSimulate" BO_ 2147483920 0;
+BA_ "CanDootPaused" BO_ 2147483920 1;
+BA_ "CanDootDecodeBus" BO_ 2147483920 5;
+BA_ "CanDootDecode" BO_ 2147483920 1;
+BA_ "GenMsgCycleTime" BO_ 2147483910 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483910 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483910 5;
+BA_ "CanDootSimulate" BO_ 2147483910 0;
+BA_ "CanDootPaused" BO_ 2147483910 0;
+BA_ "CanDootDecodeBus" BO_ 2147483910 5;
+BA_ "CanDootDecode" BO_ 2147483910 1;
+BA_ "GenMsgCycleTime" BO_ 2147483909 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483909 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483909 5;
+BA_ "CanDootSimulate" BO_ 2147483909 0;
+BA_ "CanDootPaused" BO_ 2147483909 1;
+BA_ "CanDootDecodeBus" BO_ 2147483909 5;
+BA_ "CanDootDecode" BO_ 2147483909 1;
+BA_ "GenMsgCycleTime" BO_ 2147483908 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483908 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483908 5;
+BA_ "CanDootSimulate" BO_ 2147483908 0;
+BA_ "CanDootPaused" BO_ 2147483908 1;
+BA_ "CanDootDecodeBus" BO_ 2147483908 5;
+BA_ "CanDootDecode" BO_ 2147483908 1;
+BA_ "GenMsgCycleTime" BO_ 2147483942 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483942 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483942 5;
+BA_ "CanDootSimulate" BO_ 2147483942 0;
+BA_ "CanDootPaused" BO_ 2147483942 1;
+BA_ "CanDootDecodeBus" BO_ 2147483942 5;
+BA_ "CanDootDecode" BO_ 2147483942 1;
+BA_ "GenMsgCycleTime" BO_ 2147483941 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483941 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483941 5;
+BA_ "CanDootSimulate" BO_ 2147483941 0;
+BA_ "CanDootPaused" BO_ 2147483941 1;
+BA_ "CanDootDecodeBus" BO_ 2147483941 5;
+BA_ "CanDootDecode" BO_ 2147483941 1;
+BA_ "GenMsgCycleTime" BO_ 2147483913 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483913 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483913 5;
+BA_ "CanDootSimulate" BO_ 2147483913 0;
+BA_ "CanDootPaused" BO_ 2147483913 0;
+BA_ "CanDootDecodeBus" BO_ 2147483913 5;
+BA_ "CanDootDecode" BO_ 2147483913 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483921 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483921 5;
+BA_ "CanDootSimulate" BO_ 2147483921 0;
+BA_ "CanDootPaused" BO_ 2147483921 1;
+BA_ "CanDootDecodeBus" BO_ 2147483921 5;
+BA_ "CanDootDecode" BO_ 2147483921 1;
+BA_ "GenMsgCycleTime" BO_ 2147483917 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483917 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483917 5;
+BA_ "CanDootSimulate" BO_ 2147483917 0;
+BA_ "CanDootPaused" BO_ 2147483917 1;
+BA_ "CanDootDecodeBus" BO_ 2147483917 5;
+BA_ "CanDootDecode" BO_ 2147483917 1;
+BA_ "GenMsgCycleTime" BO_ 2147483918 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483918 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483918 5;
+BA_ "CanDootSimulate" BO_ 2147483918 0;
+BA_ "CanDootPaused" BO_ 2147483918 0;
+BA_ "CanDootDecodeBus" BO_ 2147483918 5;
+BA_ "CanDootDecode" BO_ 2147483918 1;
+BA_ "GenMsgCycleTime" BO_ 2147483916 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483916 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483916 5;
+BA_ "CanDootSimulate" BO_ 2147483916 0;
+BA_ "CanDootPaused" BO_ 2147483916 1;
+BA_ "CanDootDecodeBus" BO_ 2147483916 5;
+BA_ "CanDootDecode" BO_ 2147483916 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483922 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483922 5;
+BA_ "CanDootSimulate" BO_ 2147483922 0;
+BA_ "CanDootPaused" BO_ 2147483922 1;
+BA_ "CanDootDecodeBus" BO_ 2147483922 5;
+BA_ "CanDootDecode" BO_ 2147483922 1;
+BA_ "GenMsgCycleTime" BO_ 2147483919 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483919 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483919 5;
+BA_ "CanDootSimulate" BO_ 2147483919 0;
+BA_ "CanDootPaused" BO_ 2147483919 0;
+BA_ "CanDootDecodeBus" BO_ 2147483919 5;
+BA_ "CanDootDecode" BO_ 2147483919 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483924 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483924 5;
+BA_ "CanDootSimulate" BO_ 2147483924 0;
+BA_ "CanDootPaused" BO_ 2147483924 0;
+BA_ "CanDootDecodeBus" BO_ 2147483924 5;
+BA_ "CanDootDecode" BO_ 2147483924 1;
+BA_ "GenMsgCycleTime" BO_ 2147483912 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483912 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483912 5;
+BA_ "CanDootSimulate" BO_ 2147483912 0;
+BA_ "CanDootPaused" BO_ 2147483912 1;
+BA_ "CanDootDecodeBus" BO_ 2147483912 5;
+BA_ "CanDootDecode" BO_ 2147483912 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483923 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483923 5;
+BA_ "CanDootSimulate" BO_ 2147483923 0;
+BA_ "CanDootPaused" BO_ 2147483923 1;
+BA_ "CanDootDecodeBus" BO_ 2147483923 5;
+BA_ "CanDootDecode" BO_ 2147483923 1;
+BA_ "GenMsgCycleTime" BO_ 2147483914 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483914 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483914 5;
+BA_ "CanDootSimulate" BO_ 2147483914 0;
+BA_ "CanDootPaused" BO_ 2147483914 1;
+BA_ "CanDootDecodeBus" BO_ 2147483914 5;
+BA_ "CanDootDecode" BO_ 2147483914 1;
+BA_ "GenMsgCycleTime" BO_ 2147483940 5;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483940 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483940 5;
+BA_ "CanDootSimulate" BO_ 2147483940 0;
+BA_ "CanDootPaused" BO_ 2147483940 1;
+BA_ "CanDootDecodeBus" BO_ 2147483940 5;
+BA_ "CanDootDecode" BO_ 2147483940 1;
+BA_ "GenMsgCycleTime" BO_ 2147483911 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483911 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483911 5;
+BA_ "CanDootSimulate" BO_ 2147483911 0;
+BA_ "CanDootPaused" BO_ 2147483911 1;
+BA_ "CanDootDecodeBus" BO_ 2147483911 5;
+BA_ "CanDootDecode" BO_ 2147483911 1;
+BA_ "GenMsgCycleTime" BO_ 2147483892 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483892 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483892 5;
+BA_ "CanDootSimulate" BO_ 2147483892 0;
+BA_ "CanDootPaused" BO_ 2147483892 1;
+BA_ "CanDootDecodeBus" BO_ 2147483892 5;
+BA_ "CanDootDecode" BO_ 2147483892 1;
+BA_ "GenMsgCycleTime" BO_ 2147483891 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483891 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483891 5;
+BA_ "CanDootSimulate" BO_ 2147483891 0;
+BA_ "CanDootPaused" BO_ 2147483891 1;
+BA_ "CanDootDecodeBus" BO_ 2147483891 5;
+BA_ "CanDootDecode" BO_ 2147483891 1;
+BA_ "GenMsgCycleTime" BO_ 2147483890 5;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483890 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483890 5;
+BA_ "CanDootSimulate" BO_ 2147483890 0;
+BA_ "CanDootPaused" BO_ 2147483890 1;
+BA_ "CanDootDecodeBus" BO_ 2147483890 5;
+BA_ "CanDootDecode" BO_ 2147483890 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483874 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483874 5;
+BA_ "CanDootSimulate" BO_ 2147483874 0;
+BA_ "CanDootPaused" BO_ 2147483874 0;
+BA_ "CanDootDecodeBus" BO_ 2147483874 5;
+BA_ "CanDootDecode" BO_ 2147483874 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483873 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483873 5;
+BA_ "CanDootSimulate" BO_ 2147483873 0;
+BA_ "CanDootPaused" BO_ 2147483873 1;
+BA_ "CanDootDecodeBus" BO_ 2147483873 5;
+BA_ "CanDootDecode" BO_ 2147483873 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483872 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483872 5;
+BA_ "CanDootSimulate" BO_ 2147483872 0;
+BA_ "CanDootPaused" BO_ 2147483872 1;
+BA_ "CanDootDecodeBus" BO_ 2147483872 5;
+BA_ "CanDootDecode" BO_ 2147483872 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483871 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483871 5;
+BA_ "CanDootSimulate" BO_ 2147483871 0;
+BA_ "CanDootPaused" BO_ 2147483871 1;
+BA_ "CanDootDecodeBus" BO_ 2147483871 5;
+BA_ "CanDootDecode" BO_ 2147483871 1;
+BA_ "GenMsgCycleTime" BO_ 2147483870 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483870 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483870 5;
+BA_ "CanDootSimulate" BO_ 2147483870 0;
+BA_ "CanDootPaused" BO_ 2147483870 1;
+BA_ "CanDootDecodeBus" BO_ 2147483870 5;
+BA_ "CanDootDecode" BO_ 2147483870 1;
+BA_ "GenMsgCycleTime" BO_ 2147483869 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483869 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483869 5;
+BA_ "CanDootSimulate" BO_ 2147483869 0;
+BA_ "CanDootPaused" BO_ 2147483869 0;
+BA_ "CanDootDecodeBus" BO_ 2147483869 5;
+BA_ "CanDootDecode" BO_ 2147483869 1;
+BA_ "GenMsgCycleTime" BO_ 2147483868 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483868 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483868 5;
+BA_ "CanDootSimulate" BO_ 2147483868 0;
+BA_ "CanDootPaused" BO_ 2147483868 0;
+BA_ "CanDootDecodeBus" BO_ 2147483868 5;
+BA_ "CanDootDecode" BO_ 2147483868 1;
+BA_ "GenMsgCycleTime" BO_ 2147483867 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483867 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483867 5;
+BA_ "CanDootSimulate" BO_ 2147483867 0;
+BA_ "CanDootPaused" BO_ 2147483867 1;
+BA_ "CanDootDecodeBus" BO_ 2147483867 5;
+BA_ "CanDootDecode" BO_ 2147483867 1;
+BA_ "GenMsgCycleTime" BO_ 2147483866 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483866 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483866 5;
+BA_ "CanDootSimulate" BO_ 2147483866 0;
+BA_ "CanDootPaused" BO_ 2147483866 1;
+BA_ "CanDootDecodeBus" BO_ 2147483866 5;
+BA_ "CanDootDecode" BO_ 2147483866 1;
+BA_ "GenMsgCycleTime" BO_ 2147483865 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483865 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483865 5;
+BA_ "CanDootSimulate" BO_ 2147483865 0;
+BA_ "CanDootPaused" BO_ 2147483865 1;
+BA_ "CanDootDecodeBus" BO_ 2147483865 5;
+BA_ "CanDootDecode" BO_ 2147483865 1;
+BA_ "GenMsgCycleTime" BO_ 2147483864 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483864 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483864 5;
+BA_ "CanDootSimulate" BO_ 2147483864 0;
+BA_ "CanDootPaused" BO_ 2147483864 1;
+BA_ "CanDootDecodeBus" BO_ 2147483864 5;
+BA_ "CanDootDecode" BO_ 2147483864 1;
+BA_ "GenMsgCycleTime" BO_ 2147483863 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483863 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483863 5;
+BA_ "CanDootSimulate" BO_ 2147483863 0;
+BA_ "CanDootPaused" BO_ 2147483863 0;
+BA_ "CanDootDecodeBus" BO_ 2147483863 5;
+BA_ "CanDootDecode" BO_ 2147483863 1;
+BA_ "GenMsgCycleTime" BO_ 2147483862 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483862 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483862 5;
+BA_ "CanDootSimulate" BO_ 2147483862 0;
+BA_ "CanDootPaused" BO_ 2147483862 1;
+BA_ "CanDootDecodeBus" BO_ 2147483862 5;
+BA_ "CanDootDecode" BO_ 2147483862 1;
+BA_ "GenMsgCycleTime" BO_ 2147483861 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483861 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483861 5;
+BA_ "CanDootSimulate" BO_ 2147483861 0;
+BA_ "CanDootPaused" BO_ 2147483861 1;
+BA_ "CanDootDecodeBus" BO_ 2147483861 5;
+BA_ "CanDootDecode" BO_ 2147483861 1;
+BA_ "GenMsgCycleTime" BO_ 2147483860 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483860 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483860 5;
+BA_ "CanDootSimulate" BO_ 2147483860 0;
+BA_ "CanDootPaused" BO_ 2147483860 0;
+BA_ "CanDootDecodeBus" BO_ 2147483860 5;
+BA_ "CanDootDecode" BO_ 2147483860 1;
+BA_ "GenMsgCycleTime" BO_ 2147483859 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483859 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483859 5;
+BA_ "CanDootSimulate" BO_ 2147483859 0;
+BA_ "CanDootPaused" BO_ 2147483859 1;
+BA_ "CanDootDecodeBus" BO_ 2147483859 5;
+BA_ "CanDootDecode" BO_ 2147483859 1;
+BA_ "GenMsgCycleTime" BO_ 2147483858 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483858 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483858 5;
+BA_ "CanDootSimulate" BO_ 2147483858 0;
+BA_ "CanDootPaused" BO_ 2147483858 1;
+BA_ "CanDootDecodeBus" BO_ 2147483858 5;
+BA_ "CanDootDecode" BO_ 2147483858 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483821 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483821 5;
+BA_ "CanDootSimulate" BO_ 2147483821 0;
+BA_ "CanDootPaused" BO_ 2147483821 1;
+BA_ "CanDootDecodeBus" BO_ 2147483821 5;
+BA_ "CanDootDecode" BO_ 2147483821 1;
+BA_ "GenMsgCycleTime" BO_ 2147483820 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483820 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483820 5;
+BA_ "CanDootSimulate" BO_ 2147483820 0;
+BA_ "CanDootPaused" BO_ 2147483820 1;
+BA_ "CanDootDecodeBus" BO_ 2147483820 5;
+BA_ "CanDootDecode" BO_ 2147483820 1;
+BA_ "GenMsgCycleTime" BO_ 2147483842 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483842 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483842 5;
+BA_ "CanDootSimulate" BO_ 2147483842 0;
+BA_ "CanDootPaused" BO_ 2147483842 1;
+BA_ "CanDootDecodeBus" BO_ 2147483842 5;
+BA_ "CanDootDecode" BO_ 2147483842 1;
+BA_ "GenMsgCycleTime" BO_ 2147483841 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483841 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483841 5;
+BA_ "CanDootSimulate" BO_ 2147483841 0;
+BA_ "CanDootPaused" BO_ 2147483841 1;
+BA_ "CanDootDecodeBus" BO_ 2147483841 5;
+BA_ "CanDootDecode" BO_ 2147483841 1;
+BA_ "GenMsgCycleTime" BO_ 2147483840 5;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483840 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483840 5;
+BA_ "CanDootSimulate" BO_ 2147483840 0;
+BA_ "CanDootPaused" BO_ 2147483840 1;
+BA_ "CanDootDecodeBus" BO_ 2147483840 5;
+BA_ "CanDootDecode" BO_ 2147483840 1;
+BA_ "GenMsgCycleTime" BO_ 2147483819 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483819 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483819 5;
+BA_ "CanDootSimulate" BO_ 2147483819 0;
+BA_ "CanDootPaused" BO_ 2147483819 0;
+BA_ "CanDootDecodeBus" BO_ 2147483819 5;
+BA_ "CanDootDecode" BO_ 2147483819 1;
+BA_ "GenMsgCycleTime" BO_ 2147483818 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483818 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483818 5;
+BA_ "CanDootSimulate" BO_ 2147483818 0;
+BA_ "CanDootPaused" BO_ 2147483818 0;
+BA_ "CanDootDecodeBus" BO_ 2147483818 5;
+BA_ "CanDootDecode" BO_ 2147483818 1;
+BA_ "GenMsgCycleTime" BO_ 2147483817 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483817 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483817 5;
+BA_ "CanDootSimulate" BO_ 2147483817 0;
+BA_ "CanDootPaused" BO_ 2147483817 1;
+BA_ "CanDootDecodeBus" BO_ 2147483817 5;
+BA_ "CanDootDecode" BO_ 2147483817 1;
+BA_ "GenMsgCycleTime" BO_ 2147483816 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483816 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483816 5;
+BA_ "CanDootSimulate" BO_ 2147483816 0;
+BA_ "CanDootPaused" BO_ 2147483816 1;
+BA_ "CanDootDecodeBus" BO_ 2147483816 5;
+BA_ "CanDootDecode" BO_ 2147483816 1;
+BA_ "GenMsgCycleTime" BO_ 2147483815 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483815 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483815 5;
+BA_ "CanDootSimulate" BO_ 2147483815 0;
+BA_ "CanDootPaused" BO_ 2147483815 1;
+BA_ "CanDootDecodeBus" BO_ 2147483815 5;
+BA_ "CanDootDecode" BO_ 2147483815 1;
+BA_ "GenMsgCycleTime" BO_ 2147483814 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483814 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483814 5;
+BA_ "CanDootSimulate" BO_ 2147483814 0;
+BA_ "CanDootPaused" BO_ 2147483814 1;
+BA_ "CanDootDecodeBus" BO_ 2147483814 5;
+BA_ "CanDootDecode" BO_ 2147483814 1;
+BA_ "GenMsgCycleTime" BO_ 2147483813 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483813 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483813 5;
+BA_ "CanDootSimulate" BO_ 2147483813 0;
+BA_ "CanDootPaused" BO_ 2147483813 0;
+BA_ "CanDootDecodeBus" BO_ 2147483813 5;
+BA_ "CanDootDecode" BO_ 2147483813 1;
+BA_ "GenMsgCycleTime" BO_ 2147483812 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483812 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483812 5;
+BA_ "CanDootSimulate" BO_ 2147483812 0;
+BA_ "CanDootPaused" BO_ 2147483812 1;
+BA_ "CanDootDecodeBus" BO_ 2147483812 5;
+BA_ "CanDootDecode" BO_ 2147483812 1;
+BA_ "GenMsgCycleTime" BO_ 2147483811 10;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483811 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483811 5;
+BA_ "CanDootSimulate" BO_ 2147483811 0;
+BA_ "CanDootPaused" BO_ 2147483811 1;
+BA_ "CanDootDecodeBus" BO_ 2147483811 5;
+BA_ "CanDootDecode" BO_ 2147483811 1;
+BA_ "GenMsgCycleTime" BO_ 2147483810 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483810 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483810 5;
+BA_ "CanDootSimulate" BO_ 2147483810 0;
+BA_ "CanDootPaused" BO_ 2147483810 0;
+BA_ "CanDootDecodeBus" BO_ 2147483810 5;
+BA_ "CanDootDecode" BO_ 2147483810 1;
+BA_ "GenMsgCycleTime" BO_ 2147483809 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483809 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483809 5;
+BA_ "CanDootSimulate" BO_ 2147483809 0;
+BA_ "CanDootPaused" BO_ 2147483809 1;
+BA_ "CanDootDecodeBus" BO_ 2147483809 5;
+BA_ "CanDootDecode" BO_ 2147483809 1;
+BA_ "GenMsgCycleTime" BO_ 2147483808 100;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483808 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483808 5;
+BA_ "CanDootSimulate" BO_ 2147483808 0;
+BA_ "CanDootPaused" BO_ 2147483808 1;
+BA_ "CanDootDecodeBus" BO_ 2147483808 5;
+BA_ "CanDootDecode" BO_ 2147483808 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483822 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483822 5;
+BA_ "CanDootSimulate" BO_ 2147483822 0;
+BA_ "CanDootPaused" BO_ 2147483822 1;
+BA_ "CanDootDecodeBus" BO_ 2147483822 5;
+BA_ "CanDootDecode" BO_ 2147483822 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483823 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483823 5;
+BA_ "CanDootSimulate" BO_ 2147483823 0;
+BA_ "CanDootPaused" BO_ 2147483823 1;
+BA_ "CanDootDecodeBus" BO_ 2147483823 5;
+BA_ "CanDootDecode" BO_ 2147483823 1;
+BA_ "CanDootSimulateCycleTime" BO_ 2147483824 1000;
+BA_ "CanDootSimulateBus" BO_ 2147483824 5;
+BA_ "CanDootSimulate" BO_ 2147483824 0;
+BA_ "CanDootPaused" BO_ 2147483824 0;
+BA_ "CanDootDecodeBus" BO_ 2147483824 5;
+BA_ "CanDootDecode" BO_ 2147483824 1;
+

--- a/decoder/D65/dbc/D65_CH6_EVCC.dbc
+++ b/decoder/D65/dbc/D65_CH6_EVCC.dbc
@@ -1,0 +1,1879 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: EV EVCC
+
+
+BO_ 2566855296 EVCC_InletStatus2: 8 EVCC
+ SG_ protective_earth_offset : 32|16@1+ (1,-32000) [-32000|33533] "mV"  EV
+ SG_ control_pilot_min_voltage : 16|16@1+ (1,-32000) [-32000|33533] "mV"  EV
+ SG_ plug_present_voltage : 0|16@1+ (1,0) [0|65533] "mV"  EV
+
+BO_ 2566872448 EVCC_StateM: 5 EVCC
+ SG_ appl_scc_func_mode_req : 36|2@1+ (1,0) [0|3] ""  EV
+ SG_ appl_scc_charge_mode_req : 33|3@1+ (1,0) [0|6] ""  EV
+ SG_ statem_internet_available : 32|1@1+ (1,0) [0|0] ""  EV
+ SG_ statem_state_machine_status : 24|8@1+ (1,0) [0|0] ""  EV
+ SG_ statem_state_machine_message_sta : 16|8@1+ (1,0) [0|0] ""  EV
+ SG_ statem_state_machine_error : 8|8@1+ (1,0) [0|0] ""  EV
+ SG_ statem_energy_transfer_mode_flag : 0|8@1+ (1,0) [0|0] ""  EV
+
+BO_ 2566871680 EVCC_PresentVoltage: 5 EVCC
+ SG_ present_voltage_unit_flag : 32|8@1+ (1,0) [0|0] ""  EV
+ SG_ present_voltage_value : 16|16@1- (1,0) [0|0] ""  EV
+ SG_ present_voltage_multiplier : 8|8@1- (1,0) [0|0] ""  EV
+ SG_ present_voltage_unit : 0|4@1+ (1,0) [0|0] ""  EV
+
+BO_ 2566871424 EVCC_PresentCurrent: 5 EVCC
+ SG_ present_current_unit_flag : 32|8@1+ (1,0) [0|0] ""  EV
+ SG_ present_current_value : 16|16@1- (1,0) [0|0] ""  EV
+ SG_ present_current_multiplier : 8|8@1- (1,0) [0|0] ""  EV
+ SG_ present_current_unit : 0|4@1+ (1,0) [0|0] ""  EV
+
+BO_ 2566870912 EVCC_EvseMinimumVoltageLimit: 5 EVCC
+ SG_ minimum_voltage_limit_unit_flag : 32|8@1+ (1,0) [0|0] ""  EV
+ SG_ minimum_voltage_limit_value : 16|16@1- (1,0) [0|0] ""  EV
+ SG_ minimum_voltage_limit_multiplier : 8|8@1- (1,0) [0|0] ""  EV
+ SG_ minimum_voltage_limit_unit : 0|4@1+ (1,0) [0|0] ""  EV
+
+BO_ 2566870656 EVCC_EvseMinimumCurrentLimit: 5 EVCC
+ SG_ minimum_current_limit_unit_flag : 32|8@1+ (1,0) [0|0] ""  EV
+ SG_ minimum_current_limit_value : 16|16@1- (1,0) [0|0] ""  EV
+ SG_ minimum_current_limit_multiplier : 8|8@1- (1,0) [0|0] ""  EV
+ SG_ minimum_current_limit_unit : 0|4@1+ (1,0) [0|0] ""  EV
+
+BO_ 2566870400 EVCC_EvseMaximumVoltageLimit: 5 EVCC
+ SG_ maximum_voltage_limit_unit_flag : 32|8@1+ (1,0) [0|0] ""  EV
+ SG_ maximum_voltage_limit_value : 16|16@1- (1,0) [0|0] ""  EV
+ SG_ maximum_voltage_limit_multiplier : 8|8@1- (1,0) [0|0] ""  EV
+ SG_ maximum_voltage_limit_flag : 4|2@1+ (1,0) [0|0] ""  EV
+ SG_ maximum_voltage_limit_unit : 0|4@1+ (1,0) [0|0] ""  EV
+
+BO_ 2566870144 EVCC_EvseMaximumPowerLimit: 5 EVCC
+ SG_ maximum_powerL_lmit_unit_flag : 32|8@1+ (1,0) [0|0] ""  EV
+ SG_ maximum_power_limit_value : 16|16@1- (1,0) [0|0] ""  EV
+ SG_ maximum_power_limit_multiplier : 8|8@1- (1,0) [0|0] ""  EV
+ SG_ maximum_power_limit_flag : 4|2@1+ (1,0) [0|0] ""  EV
+ SG_ maximum_power_limit_unit : 0|4@1+ (1,0) [0|0] ""  EV
+
+BO_ 2566869888 EVCC_EvseMaximumCurrentLimit: 5 EVCC
+ SG_ maximum_current_limit_unit_flag : 32|8@1+ (1,0) [0|0] ""  EV
+ SG_ maximum_current_limit_value : 16|16@1- (1,0) [0|0] ""  EV
+ SG_ maximum_current_limit_multiplier : 8|8@1- (1,0) [0|0] ""  EV
+ SG_ maximum_current_limit_flag : 4|2@1+ (1,0) [0|0] ""  EV
+ SG_ maximum_current_limit_unit : 0|4@1+ (1,0) [0|0] ""  EV
+
+BO_ 2566863234 EVCC_EvMaximumVoltageLimit: 5 EV
+ SG_ maximum_voltage_limit_unit_flag : 32|8@1+ (1,0) [0|0] ""  EVCC
+ SG_ maximum_voltage_limit_value : 16|16@1- (1,0) [0|0] ""  EVCC
+ SG_ maximum_voltage_limit_multiplier : 8|8@1- (1,0) [0|0] ""  EVCC
+ SG_ maximum_voltage_limit_flag : 4|2@1+ (1,0) [0|0] ""  EVCC
+ SG_ maximum_voltage_limit_unit : 0|4@1+ (1,0) [0|0] ""  EVCC
+
+BO_ 2566862978 EVCC_EvMaximumPowerLimit: 5 EV
+ SG_ maximum_power_limit_unit_flag : 32|8@1+ (1,0) [0|0] ""  EVCC
+ SG_ maximum_power_limit_value : 16|16@1- (1,0) [0|0] ""  EVCC
+ SG_ maximum_power_limit_multiplier : 8|8@1- (1,0) [0|0] ""  EVCC
+ SG_ maximum_power_limit_flag : 4|2@1+ (1,0) [0|0] ""  EVCC
+ SG_ maximum_power_limit_unit : 0|4@1+ (1,0) [0|0] ""  EVCC
+
+BO_ 2566862722 EVCC_EvMaximumCurrentLimit: 5 EV
+ SG_ maximum_current_limit_unit_flag : 32|8@1+ (1,0) [0|0] ""  EVCC
+ SG_ maximum_current_limit_value : 16|16@1- (1,0) [0|0] ""  EVCC
+ SG_ maximum_current_limit_multiplier : 8|8@1- (1,0) [0|0] ""  EVCC
+ SG_ maximum_current_limit_flag : 4|2@1+ (1,0) [0|0] ""  EVCC
+ SG_ maximum_current_limit_unit : 0|4@1+ (1,0) [0|0] ""  EVCC
+
+BO_ 2566869120 EVCC_Status: 8 EVCC
+ SG_ notification_max_delay : 32|32@1+ (1,0) [0|0] ""  EV
+ SG_ response_code : 24|5@1+ (1,0) [0|0] ""  EV
+ SG_ date_time_now_flag : 20|2@1+ (1,0) [0|0] ""  EV
+ SG_ power_limit_achieved : 18|2@1+ (1,0) [0|0] ""  EV
+ SG_ voltage_limit_achieved : 16|2@1+ (1,0) [0|0] ""  EV
+ SG_ status_code : 12|4@1+ (1,0) [0|0] ""  EV
+ SG_ processing : 10|2@1+ (1,0) [0|0] ""  EV
+ SG_ notification : 8|2@1+ (1,0) [0|0] ""  EV
+ SG_ isolation_status_flag : 5|2@1+ (1,0) [0|0] ""  EV
+ SG_ isolation_status : 2|3@1+ (1,0) [0|0] ""  EV
+ SG_ current_limit_achieved : 0|2@1+ (1,0) [0|0] ""  EV
+
+BO_ 2566861954 EVCC_TargetCurrent: 5 EV
+ SG_ target_current_unit : 32|4@1+ (1,0) [0|0] ""  EVCC
+ SG_ target_current_unit_flag : 24|8@1+ (1,0) [0|0] ""  EVCC
+ SG_ target_current_multiplier : 16|8@1- (1,0) [0|0] ""  EVCC
+ SG_ target_current_value : 0|16@1- (1,0) [0|0] ""  EVCC
+
+BO_ 2566861698 EVCC_TargetVoltage: 5 EV
+ SG_ target_voltage_unit : 32|4@1+ (1,0) [0|0] ""  EVCC
+ SG_ target_voltage_unit_flag : 24|8@1+ (1,0) [0|0] ""  EVCC
+ SG_ target_voltage_multiplier : 16|8@1- (1,0) [0|0] ""  EVCC
+ SG_ target_voltage_value : 0|16@1- (1,0) [0|0] ""  EVCC
+
+BO_ 2566860930 EVCC_VehicleStatus: 7 EV
+ SG_ ress_soc : 48|8@1- (1,0) [0|0] ""  EVCC
+ SG_ full_soc : 40|8@1- (1,0) [0|0] ""  EVCC
+ SG_ bulk_soc : 32|8@1- (1,0) [0|0] ""  EVCC
+ SG_ statem_energy_transfer_mode : 26|4@1+ (1,0) [0|15] ""  EVCC
+ SG_ power_delivery_parameter_flag : 24|2@1+ (1,0) [0|0] ""  EVCC
+ SG_ ress_conditioning_flag : 22|2@1+ (1,0) [0|0] ""  EVCC
+ SG_ ress_conditioning : 20|2@1+ (1,0) [0|0] ""  EVCC
+ SG_ ready : 18|2@1+ (1,0) [0|0] ""  EVCC
+ SG_ cabin_conditioning_flag : 16|2@1+ (1,0) [0|0] ""  EVCC
+ SG_ cabin_conditioning : 14|2@1+ (1,0) [0|0] ""  EVCC
+ SG_ charging_complete : 12|2@1+ (1,0) [0|0] ""  EVCC
+ SG_ full_soc_flag : 10|2@1+ (1,0) [0|0] ""  EVCC
+ SG_ bulk_soc_flag : 8|2@1+ (1,0) [0|0] ""  EVCC
+ SG_ bulk_charging_complete_flag : 6|2@1+ (1,0) [0|3] "x"  EVCC
+ SG_ bulk_charging_complete : 4|2@1+ (1,0) [0|0] ""  EVCC
+ SG_ error_code : 0|4@1+ (1,0) [0|0] ""  EVCC
+
+BO_ 2566857090 EVCC_ChargeFromVehicle: 8 EV
+ SG_ pwm_charge_mode_request : 48|2@1+ (1,0) [0|3] ""  EVCC
+ SG_ renegotiate : 46|2@1+ (1,0) [0|3] ""  EVCC
+ SG_ charge_selection : 44|2@1+ (1,0) [0|3] ""  EVCC
+ SG_ stop_charge : 42|2@1+ (1,0) [0|3] ""  EVCC
+ SG_ contactor_status : 40|2@1+ (1,0) [0|3] ""  EVCC
+ SG_ charge_permission : 38|2@1+ (1,0) [0|3] ""  EVCC
+ SG_ plug_unlock_permission : 36|2@1+ (1,0) [0|3] ""  EVCC
+ SG_ plug_lock_permission : 34|2@1+ (1,0) [0|3] ""  EVCC
+ SG_ isolation_measurement_status : 32|2@1+ (1,0) [0|3] ""  EVCC
+ SG_ link_voltage : 16|16@1+ (1,0) [0|65533] "V"  EVCC
+ SG_ contactor_voltage : 0|16@1+ (1,0) [0|65533] "V"  EVCC
+
+BO_ 2566854528 EVCC_ChargeToVehicle: 8 EVCC
+ SG_ state_charge_from_vehicle : 44|8@1+ (1,0) [0|255] ""  EV
+ SG_ mobilization_status : 8|2@1+ (1,0) [0|3] ""  EV
+ SG_ charging_status : 6|2@1+ (1,0) [0|3] ""  EV
+ SG_ charge_selection_ack : 4|2@1+ (1,0) [0|3] ""  EV
+ SG_ contactor_request : 2|2@1+ (1,0) [0|0] ""  EV
+ SG_ isolation_measurement_request : 0|2@1+ (1,0) [0|3] ""  EV
+
+BO_ 2566856834 EVCC_Requests: 8 EV
+ SG_ Inlet_MotorRequest : 53|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ charge_unit_request : 51|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ control_pilot_charge_mode_reques : 48|3@1+ (1,0) [0|7] "" Vector__XXX
+ SG_ rtc_timer_value : 40|8@1+ (1,0) [0|254] "min"  EVCC
+ SG_ plug_lock_motor_request : 36|3@1+ (1,0) [0|7] "" Vector__XXX
+ SG_ rtc_timer_request : 34|2@1+ (1,0) [0|3] ""  EVCC
+ SG_ highside_out_4_request : 32|2@1+ (1,0) [0|3] ""  EVCC
+ SG_ highside_out_3_request : 30|2@1+ (1,0) [0|3] ""  EVCC
+ SG_ highside_out_2_request : 28|2@1+ (1,0) [0|3] ""  EVCC
+ SG_ highside_out_1_request : 26|2@1+ (1,0) [0|3] ""  EVCC
+ SG_ highside_out_0_request : 24|2@1+ (1,0) [0|3] ""  EVCC
+ SG_ led_2_request : 16|8@1+ (0.5,0) [0|100] "%"  EVCC
+ SG_ led_1_request : 8|8@1+ (0.5,0) [0|100] "%"  EVCC
+ SG_ led_0_request : 0|8@1+ (0.5,0) [0|100] "%"  EVCC
+
+BO_ 2566854016 EVCC_OutputStatus: 7 EVCC
+ SG_ highside_out_3_input_wakeup : 52|2@1+ (1,0) [0|3] ""  EV
+ SG_ highside_out_4_input_status : 50|2@1+ (1,0) [0|3] ""  EV
+ SG_ highside_out_4_input_debounced_s : 48|2@1+ (1,0) [0|3] ""  EV
+ SG_ highside_out_3_input_status : 46|2@1+ (1,0) [0|3] ""  EV
+ SG_ high_side_out_3_input_debounced_ : 44|2@1+ (1,0) [0|3] ""  EV
+ SG_ highside_out_2_input_status : 42|2@1+ (1,0) [0|3] ""  EV
+ SG_ highside_out_2_input_debounced_s : 40|2@1+ (1,0) [0|3] ""  EV
+ SG_ highside_out_1_input_status : 38|2@1+ (1,0) [0|3] ""  EV
+ SG_ highside_out_1_input_debounced_s : 36|2@1+ (1,0) [0|3] ""  EV
+ SG_ highside_out_0_input_status : 34|2@1+ (1,0) [0|3] ""  EV
+ SG_ highside_out_0_Input_debounced_s : 32|2@1+ (1,0) [0|3] ""  EV
+ SG_ led_2_self_diagnostic_status : 28|3@1+ (1,0) [0|7] ""  EV
+ SG_ led_1_self_diagnostic_status : 24|3@1+ (1,0) [0|7] ""  EV
+ SG_ led_0_self_diagnostic_status : 20|3@1+ (1,0) [0|7] ""  EV
+ SG_ highside_out_4_self_diagnostic_s : 16|3@1+ (1,0) [0|7] ""  EV
+ SG_ highside_out_3_self_diagnostic_s : 12|3@1+ (1,0) [0|7] ""  EV
+ SG_ highside_out_2_self_diagnostic_s : 8|3@1+ (1,0) [0|7] ""  EV
+ SG_ highside_out_1_self_diagnostic_s : 4|3@1+ (1,0) [0|7] ""  EV
+ SG_ highside_out_0_self_diagnostic_s : 0|3@1+ (1,0) [0|7] ""  EV
+
+BO_ 2566853760 EVCC_ControlPilotStatus: 7 EVCC
+ SG_ charge_unit_max_current : 48|8@1+ (1,0) [0|255] "A"  EV
+ SG_ charge_unit_state : 45|3@1+ (1,0) [0|7] ""  EV
+ SG_ charge_unit_mode : 42|3@1+ (1,0) [0|7] ""  EV
+ SG_ control_pilot_wakeup : 40|2@1+ (1,0) [0|3] ""  EV
+ SG_ control_pilot_voltage : 24|16@1+ (1,-32000) [-32000|33533] "mV"  EV
+ SG_ control_pilot_duty_cycle : 16|8@1+ (0.5,0) [0|100] "%"  EV
+ SG_ control_pilot_frequency : 0|16@1+ (1,0) [0|65533] "Hz"  EV
+
+BO_ 2566853504 EVCC_InletStatus: 8 EVCC
+ SG_ s3_switch_debounced_status : 62|2@1+ (1,0) [0|3] ""  EV
+ SG_ s3_switch_status : 60|2@1+ (1,0) [0|3] ""  EV
+ SG_ inlet_connection_status : 58|2@1+ (1,0) [0|0] ""  EV
+ SG_ digital_input_debounced_status : 56|2@1+ (1,0) [0|3] ""  EV
+ SG_ inlet_max_current : 48|8@1+ (1,0) [0|255] "A"  EV
+ SG_ inlet_motor_status : 44|3@1+ (1,0) [0|7] ""  EV
+ SG_ digital_input_wakeup : 42|2@1+ (1,0) [0|3] ""  EV
+ SG_ digital_input_status : 40|2@1+ (1,0) [0|3] ""  EV
+ SG_ inlet_hw_variant : 38|2@1+ (1,0) [0|3] ""  EV
+ SG_ plug_lock_output1_self_diagnosti : 35|3@1+ (1,0) [0|7] ""  EV
+ SG_ plug_lock_output0_self_diagnosti : 32|3@1+ (1,0) [0|7] ""  EV
+ SG_ plug_lock_motor_status : 29|3@1+ (1,0) [0|7] ""  EV
+ SG_ pos_feedback_self_diagnostic_sta : 26|3@1+ (1,0) [0|7] ""  EV
+ SG_ plug_present_wakeup : 24|2@1+ (1,0) [0|3] ""  EV
+ SG_ plug_present_status : 22|2@1+ (1,0) [0|0] ""  EV
+ SG_ plug_present_resistance : 19|3@1+ (1,0) [0|7] ""  EV
+ SG_ plug_present_self_diagnostic_sta : 16|3@1+ (1,0) [0|7] ""  EV
+ SG_ pos_feedback_voltage : 0|16@1+ (1,0) [0|65533] "mV"  EV
+
+BO_ 2566853248 EVCC_PTC2: 7 EVCC
+ SG_ ptc_2_self_diagnostic_status : 48|3@1+ (1,0) [0|7] ""  EV
+ SG_ ptc_2_temperature : 32|16@1+ (1,-150) [-150|65383] "�C"  EV
+ SG_ ptc_2_resistance : 16|16@1+ (1,0) [0|65533] "Ohm"  EV
+ SG_ ptc_2_raw : 0|16@1+ (1,0) [0|65533] ""  EV
+
+BO_ 2566852992 EVCC_PTC1: 7 EVCC
+ SG_ ptc_1_self_diagnostic_status : 48|3@1+ (1,0) [0|7] ""  EV
+ SG_ ptc_1_temperature : 32|16@1+ (1,-150) [-150|65383] "�C"  EV
+ SG_ ptc_1_resistance : 16|16@1+ (1,0) [0|65533] "Ohm"  EV
+ SG_ ptc_1_raw : 0|16@1+ (1,0) [0|65533] ""  EV
+
+BO_ 2566852736 EVCC_PTC0: 7 EVCC
+ SG_ ptc_0_self_diagnostic_status : 48|3@1+ (1,0) [0|7] ""  EV
+ SG_ ptc_0_temperature : 32|16@1+ (1,-150) [-150|65383] "�C"  EV
+ SG_ ptc_0_resistance : 16|16@1+ (1,0) [0|65533] "Ohm"  EV
+ SG_ ptc_0_raw : 0|16@1+ (1,0) [0|65533] ""  EV
+
+
+
+CM_ BU_ EVCC "The VCVCCU node";
+CM_ SG_ 2566855296 protective_earth_offset "Measured offset voltage of the protective earth signal";
+CM_ SG_ 2566855296 control_pilot_min_voltage "Measured min voltage value of control pilot signal";
+CM_ SG_ 2566855296 plug_present_voltage "Measured voltage value of proximity pin signal";
+CM_ SG_ 2566871680 present_voltage_value "Present voltage of ";
+CM_ SG_ 2566870912 minimum_voltage_limit_value "Minimum voltage the  can deliver with the expected accuracy";
+CM_ SG_ 2566870656 minimum_current_limit_value "Minimum current the  can deliver with the expected accuracy";
+CM_ SG_ 2566870400 maximum_voltage_limit_value "Maximum voltage the  can deliver";
+CM_ SG_ 2566870144 maximum_power_limit_value "Maximum power the  can deliver";
+CM_ SG_ 2566869888 maximum_current_limit_value "Maximum current the  can deliver";
+CM_ SG_ 2566863234 maximum_voltage_limit_value "Maximum voltage supported by the  ";
+CM_ SG_ 2566862978 maximum_power_limit_value "Maximum power supported by the  ";
+CM_ SG_ 2566862722 maximum_current_limit_value "Maximum current supported by the  ";
+CM_ SG_ 2566869120 notification_max_delay "The SECC uses the NotificationMaxDelay element in the Status to indicate the time until it expects the  CC to react on the action request indicated in Notification. To be performed immediately if time is in past.";
+CM_ SG_ 2566869120 response_code "Response Code indicating the acknowledgment status of any of the V2G messages received by the SECC.";
+CM_ SG_ 2566869120 power_limit_achieved "If set to TRUE, the  has reached its power limit";
+CM_ SG_ 2566869120 voltage_limit_achieved "If set to TRUE, the  has reached its voltage limit";
+CM_ SG_ 2566869120 status_code "Indicates if the internal state of the ";
+CM_ SG_ 2566869120 processing "Parameter  indicating  that  the  has finished the processing that  was  initiated  after  the ContractAuthenticationReq or that  the  is still processing at the time  the  response  message  was sent.";
+CM_ SG_ 2566869120 notification "This value is used by the SECC to influence the behaviour of the  CC. The Notification contains an action that the SECC wants the  CC to perform within time provided in NotificationMaxDelay. To be performed immediately if time is in past.";
+CM_ SG_ 2566869120 isolation_status "Indicates the isolation condition (result of the isolation test/monitoring). ";
+CM_ SG_ 2566869120 current_limit_achieved "If set to TRUE, the  has reached its current limit. ";
+CM_ SG_ 2566861954 target_current_value "Current demanded by  ";
+CM_ SG_ 2566861698 target_voltage_value "Target Voltage requested by  ";
+CM_ SG_ 2566860930 ress_soc "State of charge of the  ’s battery (RESS) ";
+CM_ SG_ 2566860930 full_soc "SOC at which the   considers the battery to be fully charged ";
+CM_ SG_ 2566860930 bulk_soc "SOC at which the   considers a fast charging process to end";
+CM_ SG_ 2566860930 statem_energy_transfer_mode "Selected energy transfer mode";
+CM_ SG_ 2566860930 ress_conditioning "Vehicle RESS Conditioning, The vehicle is using energyfrom the DC charger to condition the RESS to a target temperature.";
+CM_ SG_ 2566860930 ready "If set to TRUE, the   is ready to charge. ";
+CM_ SG_ 2566860930 cabin_conditioning "Vehicle Cabin Conditioning, The   is using energy from the DC supply to heat or cool the passenger compartment. ";
+CM_ SG_ 2566860930 charging_complete "If set to TRUE, the   indicates that full  charge  (100 %  SOC)  is complete.";
+CM_ SG_ 2566860930 bulk_charging_complete "If set to TRUE, the   indicates that bulk charge (approx. 80 % SOC) is complete.";
+CM_ SG_ 2566860930 error_code "Indicates the   internal status.";
+CM_ SG_ 2566857090 pwm_charge_mode_request "ChargeMode selected for Pwm charging";
+CM_ SG_ 2566857090 renegotiate "Triggers a renegotiation of V2G Charging Schedule with ";
+CM_ SG_ 2566857090 charge_selection "Vehicle charge selection signal";
+CM_ SG_ 2566857090 stop_charge "Stop charging button";
+CM_ SG_ 2566857090 contactor_status "Status of the Charging contactors";
+CM_ SG_ 2566857090 charge_permission "Permission from the vehicle to charge";
+CM_ SG_ 2566857090 plug_unlock_permission "Permission from the vehicle to unlock the plug";
+CM_ SG_ 2566857090 plug_lock_permission "Permission from the vehicle to lock the plug";
+CM_ SG_ 2566857090 isolation_measurement_status "Vehicle isolation measurement status";
+CM_ SG_ 2566857090 link_voltage "Measured voltage at the battery";
+CM_ SG_ 2566857090 contactor_voltage "Measured voltage at the contactor";
+CM_ SG_ 2566854528 charge_selection_ack "Charge selection acknowledge signal";
+CM_ SG_ 2566854528 contactor_request "Request for the Charging contactors";
+CM_ SG_ 2566854528 isolation_measurement_request "Vehicle isolation measurement request";
+CM_ SG_ 2566856834 Inlet_MotorRequest "Requests to control the inlet motor";
+CM_ SG_ 2566856834 charge_unit_request "Charging mode control of CP";
+CM_ SG_ 2566856834 control_pilot_charge_mode_reques "Value of the resistor connected to the Control Pilot which defines the mode used";
+CM_ SG_ 2566856834 rtc_timer_value "RTC timer value";
+CM_ SG_ 2566856834 plug_lock_motor_request "Request for the plug lock motor movement";
+CM_ SG_ 2566856834 rtc_timer_request "RTC timer request";
+CM_ SG_ 2566856834 highside_out_4_request "Request for high side output 4";
+CM_ SG_ 2566856834 highside_out_3_request "Request for high side output 3";
+CM_ SG_ 2566856834 highside_out_2_request "Request for high side output 2";
+CM_ SG_ 2566856834 highside_out_1_request "Request for high side output 1";
+CM_ SG_ 2566856834 highside_out_0_request "Request for high side output 0";
+CM_ SG_ 2566856834 led_2_request "Request for the duty cycle of the LED2";
+CM_ SG_ 2566856834 led_1_request "Request for the duty cycle of the LED1";
+CM_ SG_ 2566856834 led_0_request "Request for the duty cycle of the LED0";
+CM_ SG_ 2566854016 highside_out_3_input_wakeup "Wakeup detection of high side 3 input signal";
+CM_ SG_ 2566854016 highside_out_4_input_status "Status of the high side 4 input signal";
+CM_ SG_ 2566854016 highside_out_4_input_debounced_s "Debounced status of the high side 4 input signal";
+CM_ SG_ 2566854016 highside_out_3_input_status "Status of the high side 3 input signal";
+CM_ SG_ 2566854016 high_side_out_3_input_debounced_ "Debounced status of the high side 3 input signal";
+CM_ SG_ 2566854016 highside_out_2_input_status "Status of the high side 2 input signal";
+CM_ SG_ 2566854016 highside_out_2_input_debounced_s "Debounced status of the high side 2 input signal";
+CM_ SG_ 2566854016 highside_out_1_input_status "Status of the high side 1 input signal";
+CM_ SG_ 2566854016 highside_out_1_input_debounced_s "Debounced status of the high side 1 input signal";
+CM_ SG_ 2566854016 highside_out_0_input_status "Status of the high side 0 input signal";
+CM_ SG_ 2566854016 highside_out_0_Input_debounced_s "Debounced status of the high side 0 input signal";
+CM_ SG_ 2566854016 led_2_self_diagnostic_status "SelfDiagnosticStatus of LED output 2";
+CM_ SG_ 2566854016 led_1_self_diagnostic_status "SelfDiagnosticStatus of LED output 1";
+CM_ SG_ 2566854016 led_0_self_diagnostic_status "SelfDiagnosticStatus of LED output 0";
+CM_ SG_ 2566854016 highside_out_4_self_diagnostic_s "SelfDiagnosticStatus of high side output 4";
+CM_ SG_ 2566854016 highside_out_3_self_diagnostic_s "SelfDiagnosticStatus of high side output 3";
+CM_ SG_ 2566854016 highside_out_2_self_diagnostic_s "SelfDiagnosticStatus of high side output 2";
+CM_ SG_ 2566854016 highside_out_1_self_diagnostic_s "SelfDiagnosticStatus of high side output 1";
+CM_ SG_ 2566854016 highside_out_0_self_diagnostic_s "SelfDiagnosticStatus of high side output 0";
+CM_ SG_ 2566853760 charge_unit_max_current "Max current derived from CP duty cycle";
+CM_ SG_ 2566853760 charge_unit_state "Vehicle state derived from CP voltage and duty cycle";
+CM_ SG_ 2566853760 charge_unit_mode "Requested charging mode from the , derived from the CP duty cycle";
+CM_ SG_ 2566853760 control_pilot_wakeup "Wakeup detection of control pilot signal";
+CM_ SG_ 2566853760 control_pilot_voltage "Measured voltage value of control pilot signal";
+CM_ SG_ 2566853760 control_pilot_duty_cycle "Duty cycle of the Control Pilot signal";
+CM_ SG_ 2566853760 control_pilot_frequency "Measured frequency value of control pilot signal";
+CM_ SG_ 2566853504 s3_switch_debounced_status "Debounced status of the S3 switch signal";
+CM_ SG_ 2566853504 s3_switch_status "Status of the S3 switch signal";
+CM_ SG_ 2566853504 inlet_connection_status "Inlet connection state derived from PP and CP";
+CM_ SG_ 2566853504 digital_input_debounced_status "Debounced status of the digital input signal";
+CM_ SG_ 2566853504 inlet_max_current "Max current derived from PP resistance";
+CM_ SG_ 2566853504 inlet_motor_status "Inlet lock status";
+CM_ SG_ 2566853504 digital_input_wakeup "Wakeup detection of digital input signal";
+CM_ SG_ 2566853504 digital_input_status "Status of the digital input signal";
+CM_ SG_ 2566853504 inlet_hw_variant "Status of the digital input signal";
+CM_ SG_ 2566853504 plug_lock_output1_self_diagnosti "SelfDiagnosticStatus of full bridge output 0";
+CM_ SG_ 2566853504 plug_lock_output0_self_diagnosti "SelfDiagnosticStatus of full bridge output 0";
+CM_ SG_ 2566853504 plug_lock_motor_status "Status of the plug lock motor movement";
+CM_ SG_ 2566853504 pos_feedback_self_diagnostic_sta "SelfDiagnosticStatus of position feedback signal";
+CM_ SG_ 2566853504 plug_present_wakeup "Wakeup detection of proximity pin signal";
+CM_ SG_ 2566853504 plug_present_status "Proximity Pin detection";
+CM_ SG_ 2566853504 plug_present_resistance "Value of the resistor connected to the Proximity Pin which defines the diameter of the cable";
+CM_ SG_ 2566853504 plug_present_self_diagnostic_sta "SelfDiagnostic Status of proximity pin signal";
+CM_ SG_ 2566853504 pos_feedback_voltage "Measured voltage value of position feedback signal";
+CM_ SG_ 2566853248 ptc_2_self_diagnostic_status "SelfDiagnosticStatus of PTC2 signal";
+CM_ SG_ 2566853248 ptc_2_temperature "Temperature measurement inside the inlet";
+CM_ SG_ 2566853248 ptc_2_resistance "Measured resistance value of PTC2";
+CM_ SG_ 2566853248 ptc_2_raw "Measured raw value of PTC2";
+CM_ SG_ 2566852992 ptc_1_self_diagnostic_status "SelfDiagnosticStatus of PTC1 signal";
+CM_ SG_ 2566852992 ptc_1_temperature "Temperature measurement inside the inlet";
+CM_ SG_ 2566852992 ptc_1_resistance "Measured resistance value of PTC1";
+CM_ SG_ 2566852992 ptc_1_raw "Measured raw value of PTC1";
+CM_ SG_ 2566852736 ptc_0_self_diagnostic_status "SelfDiagnosticStatus of PTC0 signal";
+CM_ SG_ 2566852736 ptc_0_temperature "Temperature measurement inside the inlet";
+CM_ SG_ 2566852736 ptc_0_resistance "Measured resistance value of PTC0";
+CM_ SG_ 2566852736 ptc_0_raw "Measured raw value of PTC0";
+BA_DEF_  "E2EP01SyncCounterInit" INT 0 65535;
+BA_DEF_  "E2EP01DataIdNibbleOffset" INT 0 65535;
+BA_DEF_  "E2EP01DataIdMode" ENUM  "all16Bit","alternating8Bit","lower8Bit","lower12Bit";
+BA_DEF_  "E2EP01CounterOffset" INT 0 65535;
+BA_DEF_  "E2EP01CrcOffset" INT 0 65535;
+BA_DEF_  "E2EP01ProfileBehavior" ENUM  "PRE_R4_2","R4_2";
+BA_DEF_  "E2EP01Offset" INT 0 65535;
+BA_DEF_ BO_  "E2EProfile" STRING ;
+BA_DEF_ BO_  "E2EDataLength" INT 0 65535;
+BA_DEF_ BO_  "E2EDataId01" INT 0 65535;
+BA_DEF_  "E2EP01WindowSize" INT 0 65535;
+BA_DEF_  "E2EP01UpperHeaderBitsToShift" INT 0 65535;
+BA_DEF_  "E2EP01MinOkStateValid" INT 0 65535;
+BA_DEF_  "E2EP01MinOkStateInvalid" INT 0 65535;
+BA_DEF_  "E2EP01MinOkStateInit" INT 0 65535;
+BA_DEF_  "E2EP01MaxNoNewOrRepeatedData" INT 0 65535;
+BA_DEF_  "E2EP01MaxErrorStateValid" INT 0 65535;
+BA_DEF_  "E2EP01MaxErrorStateInvalid" INT 0 65535;
+BA_DEF_  "E2EP01MaxErrorStateInit" INT 0 65535;
+BA_DEF_  "E2EP01MaxDeltaCounter" INT 0 65535;
+BA_DEF_  "E2EP01ProfileName" STRING ;
+BA_DEF_ SG_  "SPN" INT 0 524287;
+BA_DEF_ SG_  "GenSigStartValue" INT 0 2147483647;
+BA_DEF_ SG_  "GenSigInactiveValue" INT 0 0;
+BA_DEF_ SG_  "GenSigSendType" ENUM  "Cyclic","OnWrite","OnWriteWithRepetition","OnChange","OnChangeWithRepetition","IfActive","IfActiveWithRepetition","NoSigSendType";
+BA_DEF_ SG_  "GenSigILSupport" ENUM  "No","Yes";
+BA_DEF_ SG_  "GenSigEVName" STRING ;
+BA_DEF_ SG_  "SigType" ENUM  "Default","Range","RangeSigned","ASCII","Discrete","Control","ReferencePGN","DTC","StringDelimiter","StringLength","StringLengthControl";
+BA_DEF_ BO_  "VFrameFormat" ENUM  "StandardCAN","ExtendedCAN","reserved","J1939PG";
+BA_DEF_ BO_  "GenMsgCycleTime" INT 0 3600000;
+BA_DEF_ BO_  "GenMsgRequestable" INT 0 1;
+BA_DEF_ BO_  "GenMsgSendType" ENUM  "cyclic","NotUsed","IfActive","NotUsed","NotUsed","NotUsed","NotUsed","NotUsed","noMsgSendType";
+BA_DEF_ BO_  "GenMsgStartDelayTime" INT 0 100000;
+BA_DEF_ BO_  "GenMsgILSupport" ENUM  "No","Yes";
+BA_DEF_ BO_  "GenMsgDelayTime" INT 0 1000;
+BA_DEF_ BO_  "GenMsgNrOfRepetition" INT 0 1000000;
+BA_DEF_ BO_  "GenMsgCycleTimeFast" INT 0 3600000;
+BA_DEF_ BO_  "GenMsgFastOnStart" INT 0 100000;
+BA_DEF_ BO_  "TpJ1939VarDlc" ENUM  "No","Yes";
+BA_DEF_ BO_  "NmAsrMessage" ENUM  "no","yes";
+BA_DEF_ BO_  "DiagRequest" ENUM  "No","Yes";
+BA_DEF_ BO_  "DiagResponse" ENUM  "No","Yes";
+BA_DEF_ BO_  "DiagState" ENUM  "No","Yes";
+BA_DEF_ BO_  "DiagConnection" INT 0 65535;
+BA_DEF_ BU_  "NmStationAddress" INT 0 255;
+BA_DEF_ BU_  "NmJ1939AAC" INT 0 1;
+BA_DEF_ BU_  "NmJ1939ECUInstance" INT 0 3;
+BA_DEF_ BU_  "NmJ1939Function" INT 0 255;
+BA_DEF_ BU_  "NmJ1939FunctionInstance" INT 0 7;
+BA_DEF_ BU_  "NmJ1939IdentityNumber" INT 0 2097151;
+BA_DEF_ BU_  "NmJ1939IndustryGroup" INT 0 7;
+BA_DEF_ BU_  "NmJ1939ManufacturerCode" INT 0 2047;
+BA_DEF_ BU_  "NmJ1939System" INT 0 127;
+BA_DEF_ BU_  "NmJ1939SystemInstance" INT 0 15;
+BA_DEF_ BU_  "ECU" STRING ;
+BA_DEF_ BU_  "NodeLayerModules" STRING ;
+BA_DEF_ BU_  "NmAsrCanMsgCycleOffset" INT 0 65535;
+BA_DEF_ BU_  "NmAsrCanMsgReducedTime" INT 0 65535;
+BA_DEF_ BU_  "NmAsrNode" ENUM  "no","yes";
+BA_DEF_ BU_  "NmAsrNodeIdentifier" INT 0 255;
+BA_DEF_  "ProtocolType" STRING ;
+BA_DEF_  "BusType" STRING ;
+BA_DEF_  "DBName" STRING ;
+BA_DEF_  "NmAsrBaseAddress" HEX 0 536870911;
+BA_DEF_  "NmAsrCanMsgCycleTime" INT 0 65535;
+BA_DEF_  "NmAsrMessageCount" INT 0 256;
+BA_DEF_  "NmAsrRepeatMessageTime" INT 0 65535;
+BA_DEF_  "NmAsrTimeoutTime" INT 0 65535;
+BA_DEF_  "NmAsrWaitBusSleepTime" INT 0 65535;
+BA_DEF_  "NmType" STRING ;
+BA_DEF_  "SAE_J1939_21_SpecVersion" STRING ;
+BA_DEF_  "SAE_J1939_71_SpecVersion" STRING ;
+BA_DEF_  "SAE_J1939_73_SpecVersion" STRING ;
+BA_DEF_  "SAE_J1939_75_SpecVersion" STRING ;
+BA_DEF_  "DatabaseVersion" STRING ;
+BA_DEF_  "Baudrate" INT 0 10000000;
+BA_DEF_ BO_  "CanDootDecode" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootDecodeBus" INT 0 6;
+BA_DEF_ BO_  "CanDootPaused" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulate" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulateBus" INT 0 6;
+BA_DEF_ BO_  "CanDootSimulateCycleTime" INT 0 50000;
+BA_DEF_ BO_  "CG_MessageInstName" STRING ;
+BA_DEF_ BO_  "CG_RX_TX" ENUM  "RX","TX","NONE";
+BA_DEF_ SG_  "CanDootGroup" ENUM  "None","g1","g2","g3","g4","g5","g6","g7","g8","g9","gA","gB","gC","gD","gE","gF";
+BA_DEF_ SG_  "CanDootHidden" ENUM  "No","Yes";
+BA_DEF_ SG_  "CanDootBroadcast" ENUM  "No","Yes";
+BA_DEF_ SG_  "CG_VarType" ENUM  "bool","uint8_t","int8_t","uint16_t","int16_t","uint32_t","int32_t","float","double";
+BA_DEF_ SG_  "SystemSignalLongSymbol" STRING ;
+BA_DEF_DEF_  "E2EP01SyncCounterInit" 0;
+BA_DEF_DEF_  "E2EP01DataIdNibbleOffset" 0;
+BA_DEF_DEF_  "E2EP01DataIdMode" "all16Bit";
+BA_DEF_DEF_  "E2EP01CounterOffset" 0;
+BA_DEF_DEF_  "E2EP01CrcOffset" 0;
+BA_DEF_DEF_  "E2EP01ProfileBehavior" "R4_2";
+BA_DEF_DEF_  "E2EP01Offset" 0;
+BA_DEF_DEF_  "E2EProfile" "PXX";
+BA_DEF_DEF_  "E2EDataLength" 0;
+BA_DEF_DEF_  "E2EDataId01" 0;
+BA_DEF_DEF_  "E2EP01WindowSize" 0;
+BA_DEF_DEF_  "E2EP01UpperHeaderBitsToShift" 0;
+BA_DEF_DEF_  "E2EP01MinOkStateValid" 0;
+BA_DEF_DEF_  "E2EP01MinOkStateInvalid" 0;
+BA_DEF_DEF_  "E2EP01MinOkStateInit" 0;
+BA_DEF_DEF_  "E2EP01MaxNoNewOrRepeatedData" 15;
+BA_DEF_DEF_  "E2EP01MaxErrorStateValid" 0;
+BA_DEF_DEF_  "E2EP01MaxErrorStateInvalid" 0;
+BA_DEF_DEF_  "E2EP01MaxErrorStateInit" 0;
+BA_DEF_DEF_  "E2EP01MaxDeltaCounter" 15;
+BA_DEF_DEF_  "E2EP01ProfileName" "PROFILE_01";
+BA_DEF_DEF_  "SPN" 0;
+BA_DEF_DEF_  "GenSigStartValue" 0;
+BA_DEF_DEF_  "GenSigInactiveValue" 0;
+BA_DEF_DEF_  "GenSigSendType" "NoSigSendType";
+BA_DEF_DEF_  "GenSigILSupport" "Yes";
+BA_DEF_DEF_  "GenSigEVName" "Env@Nodename_@Signame";
+BA_DEF_DEF_  "SigType" "Default";
+BA_DEF_DEF_  "VFrameFormat" "J1939PG";
+BA_DEF_DEF_  "GenMsgCycleTime" 0;
+BA_DEF_DEF_  "GenMsgRequestable" 1;
+BA_DEF_DEF_  "GenMsgSendType" "noMsgSendType";
+BA_DEF_DEF_  "GenMsgStartDelayTime" 0;
+BA_DEF_DEF_  "GenMsgILSupport" "Yes";
+BA_DEF_DEF_  "GenMsgDelayTime" 0;
+BA_DEF_DEF_  "GenMsgNrOfRepetition" 0;
+BA_DEF_DEF_  "GenMsgCycleTimeFast" 0;
+BA_DEF_DEF_  "GenMsgFastOnStart" 0;
+BA_DEF_DEF_  "TpJ1939VarDlc" "No";
+BA_DEF_DEF_  "NmAsrMessage" "no";
+BA_DEF_DEF_  "DiagRequest" "No";
+BA_DEF_DEF_  "DiagResponse" "No";
+BA_DEF_DEF_  "DiagState" "No";
+BA_DEF_DEF_  "DiagConnection" 0;
+BA_DEF_DEF_  "NmStationAddress" 254;
+BA_DEF_DEF_  "NmJ1939AAC" 0;
+BA_DEF_DEF_  "NmJ1939ECUInstance" 0;
+BA_DEF_DEF_  "NmJ1939Function" 0;
+BA_DEF_DEF_  "NmJ1939FunctionInstance" 0;
+BA_DEF_DEF_  "NmJ1939IdentityNumber" 0;
+BA_DEF_DEF_  "NmJ1939IndustryGroup" 0;
+BA_DEF_DEF_  "NmJ1939ManufacturerCode" 0;
+BA_DEF_DEF_  "NmJ1939System" 0;
+BA_DEF_DEF_  "NmJ1939SystemInstance" 0;
+BA_DEF_DEF_  "ECU" "";
+BA_DEF_DEF_  "NodeLayerModules" "J1939_IL.dll";
+BA_DEF_DEF_  "NmAsrCanMsgCycleOffset" 0;
+BA_DEF_DEF_  "NmAsrCanMsgReducedTime" 50;
+BA_DEF_DEF_  "NmAsrNode" "yes";
+BA_DEF_DEF_  "NmAsrNodeIdentifier" 0;
+BA_DEF_DEF_  "ProtocolType" "J1939";
+BA_DEF_DEF_  "BusType" "CAN";
+BA_DEF_DEF_  "DBName" "";
+BA_DEF_DEF_  "NmAsrBaseAddress" 486506496;
+BA_DEF_DEF_  "NmAsrCanMsgCycleTime" 100;
+BA_DEF_DEF_  "NmAsrMessageCount" 64;
+BA_DEF_DEF_  "NmAsrRepeatMessageTime" 400;
+BA_DEF_DEF_  "NmAsrTimeoutTime" 1000;
+BA_DEF_DEF_  "NmAsrWaitBusSleepTime" 750;
+BA_DEF_DEF_  "NmType" "";
+BA_DEF_DEF_  "SAE_J1939_21_SpecVersion" "";
+BA_DEF_DEF_  "SAE_J1939_71_SpecVersion" "";
+BA_DEF_DEF_  "SAE_J1939_73_SpecVersion" "";
+BA_DEF_DEF_  "SAE_J1939_75_SpecVersion" "";
+BA_DEF_DEF_  "DatabaseVersion" "";
+BA_DEF_DEF_  "Baudrate" 500000;
+BA_DEF_DEF_  "CanDootDecode" "Yes";
+BA_DEF_DEF_  "CanDootDecodeBus" 1;
+BA_DEF_DEF_  "CanDootPaused" "No";
+BA_DEF_DEF_  "CanDootSimulate" "No";
+BA_DEF_DEF_  "CanDootSimulateBus" 1;
+BA_DEF_DEF_  "CanDootSimulateCycleTime" 100;
+BA_DEF_DEF_  "CG_MessageInstName" "";
+BA_DEF_DEF_  "CG_RX_TX" "RX";
+BA_DEF_DEF_  "CanDootGroup" "None";
+BA_DEF_DEF_  "CanDootHidden" "No";
+BA_DEF_DEF_  "CanDootBroadcast" "Yes";
+BA_DEF_DEF_  "CG_VarType" "uint8_t";
+BA_DEF_DEF_  "SystemSignalLongSymbol" "";
+BA_ "E2EP01MaxNoNewOrRepeatedData" 14;
+BA_ "E2EP01SyncCounterInit" 1;
+BA_ "E2EP01CrcOffset" 56;
+BA_ "E2EP01CounterOffset" 52;
+BA_ "BusType" "CAN";
+BA_ "NmAsrMessageCount" 256;
+BA_ "Baudrate" 250000;
+BA_ "E2EP01WindowSize" 1;
+BA_ "E2EP01MinOkStateValid" 1;
+BA_ "E2EP01MinOkStateInvalid" 1;
+BA_ "E2EP01MinOkStateInit" 1;
+BA_ "E2EP01MaxDeltaCounter" 4;
+BA_ "DBName" "SensataEVCC";
+BA_ "NmStationAddress" BU_ EV 130;
+BA_ "NodeLayerModules" BU_ EV "J1939_IL.dll, ASRNM33.dll";
+BA_ "NmAsrNodeIdentifier" BU_ EV 130;
+BA_ "NmStationAddress" BU_ EVCC 128;
+BA_ "ECU" BU_ EVCC "VCVCCU";
+BA_ "NodeLayerModules" BU_ EVCC "J1939_IL.dll, ASRNM33.dll";
+BA_ "NmAsrNodeIdentifier" BU_ EVCC 128;
+BA_ "CanDootPaused" BO_ 2566855296 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566855296 6;
+BA_ "GenMsgCycleTime" BO_ 2566855296 10;
+BA_ "GenMsgRequestable" BO_ 2566855296 0;
+BA_ "GenMsgSendType" BO_ 2566855296 0;
+BA_ "CanDootDecode" BO_ 2566855296 1;
+BA_ "CanDootDecodeBus" BO_ 2566855296 6;
+BA_ "CanDootSimulate" BO_ 2566855296 0;
+BA_ "CanDootSimulateBus" BO_ 2566855296 6;
+BA_ "CG_RX_TX" BO_ 2566855296 0;
+BA_ "CG_MessageInstName" BO_ 2566855296 "inlet_status_2";
+BA_ "VFrameFormat" BO_ 2566855296 3;
+BA_ "CanDootPaused" BO_ 2566872448 0;
+BA_ "CG_MessageInstName" BO_ 2566872448 "state_machines";
+BA_ "GenMsgCycleTime" BO_ 2566872448 500;
+BA_ "GenMsgRequestable" BO_ 2566872448 0;
+BA_ "GenMsgSendType" BO_ 2566872448 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566872448 138;
+BA_ "GenMsgDelayTime" BO_ 2566872448 0;
+BA_ "GenMsgNrOfRepetition" BO_ 2566872448 4;
+BA_ "GenMsgCycleTimeFast" BO_ 2566872448 20;
+BA_ "CanDootDecode" BO_ 2566872448 1;
+BA_ "CanDootDecodeBus" BO_ 2566872448 6;
+BA_ "CanDootSimulate" BO_ 2566872448 0;
+BA_ "CanDootSimulateBus" BO_ 2566872448 6;
+BA_ "CG_RX_TX" BO_ 2566872448 0;
+BA_ "VFrameFormat" BO_ 2566872448 3;
+BA_ "CanDootPaused" BO_ 2566871680 0;
+BA_ "GenMsgCycleTime" BO_ 2566871680 500;
+BA_ "GenMsgRequestable" BO_ 2566871680 0;
+BA_ "GenMsgSendType" BO_ 2566871680 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566871680 114;
+BA_ "GenMsgDelayTime" BO_ 2566871680 0;
+BA_ "GenMsgNrOfRepetition" BO_ 2566871680 4;
+BA_ "GenMsgCycleTimeFast" BO_ 2566871680 20;
+BA_ "CanDootDecode" BO_ 2566871680 1;
+BA_ "CanDootDecodeBus" BO_ 2566871680 6;
+BA_ "CanDootSimulate" BO_ 2566871680 0;
+BA_ "CanDootSimulateBus" BO_ 2566871680 6;
+BA_ "CG_RX_TX" BO_ 2566871680 0;
+BA_ "CG_MessageInstName" BO_ 2566871680 "evse_present_voltage";
+BA_ "VFrameFormat" BO_ 2566871680 3;
+BA_ "CanDootPaused" BO_ 2566871424 0;
+BA_ "GenMsgCycleTime" BO_ 2566871424 500;
+BA_ "GenMsgRequestable" BO_ 2566871424 0;
+BA_ "GenMsgSendType" BO_ 2566871424 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566871424 102;
+BA_ "GenMsgDelayTime" BO_ 2566871424 0;
+BA_ "GenMsgNrOfRepetition" BO_ 2566871424 4;
+BA_ "GenMsgCycleTimeFast" BO_ 2566871424 20;
+BA_ "CanDootDecode" BO_ 2566871424 1;
+BA_ "CanDootDecodeBus" BO_ 2566871424 6;
+BA_ "CanDootSimulate" BO_ 2566871424 0;
+BA_ "CanDootSimulateBus" BO_ 2566871424 6;
+BA_ "CG_RX_TX" BO_ 2566871424 0;
+BA_ "CG_MessageInstName" BO_ 2566871424 "evse_present_current";
+BA_ "VFrameFormat" BO_ 2566871424 3;
+BA_ "CanDootPaused" BO_ 2566870912 0;
+BA_ "GenMsgCycleTime" BO_ 2566870912 500;
+BA_ "GenMsgRequestable" BO_ 2566870912 0;
+BA_ "GenMsgSendType" BO_ 2566870912 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566870912 88;
+BA_ "GenMsgDelayTime" BO_ 2566870912 0;
+BA_ "GenMsgNrOfRepetition" BO_ 2566870912 4;
+BA_ "GenMsgCycleTimeFast" BO_ 2566870912 20;
+BA_ "CanDootDecode" BO_ 2566870912 1;
+BA_ "CanDootDecodeBus" BO_ 2566870912 6;
+BA_ "CanDootSimulate" BO_ 2566870912 0;
+BA_ "CanDootSimulateBus" BO_ 2566870912 6;
+BA_ "CG_RX_TX" BO_ 2566870912 0;
+BA_ "CG_MessageInstName" BO_ 2566870912 "evse_minimum_voltage_limit";
+BA_ "VFrameFormat" BO_ 2566870912 3;
+BA_ "CanDootPaused" BO_ 2566870656 0;
+BA_ "GenMsgCycleTime" BO_ 2566870656 500;
+BA_ "GenMsgRequestable" BO_ 2566870656 0;
+BA_ "GenMsgSendType" BO_ 2566870656 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566870656 76;
+BA_ "GenMsgDelayTime" BO_ 2566870656 0;
+BA_ "GenMsgNrOfRepetition" BO_ 2566870656 4;
+BA_ "GenMsgCycleTimeFast" BO_ 2566870656 20;
+BA_ "CanDootDecode" BO_ 2566870656 1;
+BA_ "CanDootDecodeBus" BO_ 2566870656 6;
+BA_ "CanDootSimulate" BO_ 2566870656 0;
+BA_ "CanDootSimulateBus" BO_ 2566870656 6;
+BA_ "CG_RX_TX" BO_ 2566870656 0;
+BA_ "CG_MessageInstName" BO_ 2566870656 "evse_minimum_current_limit";
+BA_ "VFrameFormat" BO_ 2566870656 3;
+BA_ "CanDootPaused" BO_ 2566870400 0;
+BA_ "GenMsgCycleTime" BO_ 2566870400 500;
+BA_ "GenMsgRequestable" BO_ 2566870400 0;
+BA_ "GenMsgSendType" BO_ 2566870400 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566870400 64;
+BA_ "GenMsgDelayTime" BO_ 2566870400 0;
+BA_ "GenMsgNrOfRepetition" BO_ 2566870400 4;
+BA_ "GenMsgCycleTimeFast" BO_ 2566870400 20;
+BA_ "CanDootDecode" BO_ 2566870400 1;
+BA_ "CanDootDecodeBus" BO_ 2566870400 6;
+BA_ "CanDootSimulate" BO_ 2566870400 0;
+BA_ "CanDootSimulateBus" BO_ 2566870400 6;
+BA_ "CG_RX_TX" BO_ 2566870400 0;
+BA_ "CG_MessageInstName" BO_ 2566870400 "evse_maximum_voltage_limit";
+BA_ "VFrameFormat" BO_ 2566870400 3;
+BA_ "CanDootPaused" BO_ 2566870144 0;
+BA_ "GenMsgCycleTime" BO_ 2566870144 500;
+BA_ "GenMsgRequestable" BO_ 2566870144 0;
+BA_ "GenMsgSendType" BO_ 2566870144 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566870144 52;
+BA_ "GenMsgDelayTime" BO_ 2566870144 0;
+BA_ "GenMsgNrOfRepetition" BO_ 2566870144 4;
+BA_ "GenMsgCycleTimeFast" BO_ 2566870144 20;
+BA_ "CanDootDecode" BO_ 2566870144 1;
+BA_ "CanDootDecodeBus" BO_ 2566870144 6;
+BA_ "CanDootSimulate" BO_ 2566870144 0;
+BA_ "CanDootSimulateBus" BO_ 2566870144 6;
+BA_ "CG_RX_TX" BO_ 2566870144 0;
+BA_ "CG_MessageInstName" BO_ 2566870144 "evse_maximum_power_limit";
+BA_ "VFrameFormat" BO_ 2566870144 3;
+BA_ "CanDootPaused" BO_ 2566869888 0;
+BA_ "GenMsgCycleTime" BO_ 2566869888 500;
+BA_ "GenMsgRequestable" BO_ 2566869888 0;
+BA_ "GenMsgSendType" BO_ 2566869888 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566869888 40;
+BA_ "GenMsgDelayTime" BO_ 2566869888 0;
+BA_ "GenMsgNrOfRepetition" BO_ 2566869888 4;
+BA_ "GenMsgCycleTimeFast" BO_ 2566869888 20;
+BA_ "CanDootDecode" BO_ 2566869888 1;
+BA_ "CanDootDecodeBus" BO_ 2566869888 6;
+BA_ "CanDootSimulate" BO_ 2566869888 0;
+BA_ "CanDootSimulateBus" BO_ 2566869888 6;
+BA_ "CG_RX_TX" BO_ 2566869888 0;
+BA_ "CG_MessageInstName" BO_ 2566869888 "evse_maximum_current_limit";
+BA_ "VFrameFormat" BO_ 2566869888 3;
+BA_ "CanDootPaused" BO_ 2566863234 0;
+BA_ "CanDootSimulateBus" BO_ 2566863234 6;
+BA_ "CanDootSimulate" BO_ 2566863234 0;
+BA_ "CG_MessageInstName" BO_ 2566863234 "ev_max_voltage_limit";
+BA_ "GenMsgCycleTime" BO_ 2566863234 200;
+BA_ "GenMsgRequestable" BO_ 2566863234 0;
+BA_ "GenMsgSendType" BO_ 2566863234 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566863234 50;
+BA_ "GenMsgDelayTime" BO_ 2566863234 0;
+BA_ "CanDootDecode" BO_ 2566863234 1;
+BA_ "CanDootDecodeBus" BO_ 2566863234 6;
+BA_ "CG_RX_TX" BO_ 2566863234 1;
+BA_ "VFrameFormat" BO_ 2566863234 3;
+BA_ "CanDootPaused" BO_ 2566862978 0;
+BA_ "CanDootSimulateBus" BO_ 2566862978 6;
+BA_ "CanDootSimulate" BO_ 2566862978 0;
+BA_ "CG_MessageInstName" BO_ 2566862978 "ev_max_power_limit";
+BA_ "GenMsgCycleTime" BO_ 2566862978 200;
+BA_ "GenMsgRequestable" BO_ 2566862978 0;
+BA_ "GenMsgSendType" BO_ 2566862978 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566862978 40;
+BA_ "GenMsgDelayTime" BO_ 2566862978 0;
+BA_ "CanDootDecode" BO_ 2566862978 1;
+BA_ "CanDootDecodeBus" BO_ 2566862978 6;
+BA_ "CG_RX_TX" BO_ 2566862978 1;
+BA_ "VFrameFormat" BO_ 2566862978 3;
+BA_ "CanDootPaused" BO_ 2566862722 0;
+BA_ "CanDootSimulateBus" BO_ 2566862722 6;
+BA_ "CanDootSimulate" BO_ 2566862722 0;
+BA_ "CG_MessageInstName" BO_ 2566862722 "ev_max_current_limit";
+BA_ "GenMsgCycleTime" BO_ 2566862722 200;
+BA_ "GenMsgRequestable" BO_ 2566862722 0;
+BA_ "GenMsgSendType" BO_ 2566862722 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566862722 30;
+BA_ "GenMsgDelayTime" BO_ 2566862722 0;
+BA_ "CanDootDecode" BO_ 2566862722 1;
+BA_ "CanDootDecodeBus" BO_ 2566862722 6;
+BA_ "CG_RX_TX" BO_ 2566862722 1;
+BA_ "VFrameFormat" BO_ 2566862722 3;
+BA_ "CanDootPaused" BO_ 2566869120 0;
+BA_ "GenMsgCycleTime" BO_ 2566869120 500;
+BA_ "GenMsgRequestable" BO_ 2566869120 0;
+BA_ "GenMsgSendType" BO_ 2566869120 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566869120 126;
+BA_ "GenMsgDelayTime" BO_ 2566869120 0;
+BA_ "GenMsgNrOfRepetition" BO_ 2566869120 4;
+BA_ "GenMsgCycleTimeFast" BO_ 2566869120 20;
+BA_ "CanDootDecode" BO_ 2566869120 1;
+BA_ "CanDootDecodeBus" BO_ 2566869120 6;
+BA_ "CanDootSimulate" BO_ 2566869120 0;
+BA_ "CanDootSimulateBus" BO_ 2566869120 6;
+BA_ "CG_RX_TX" BO_ 2566869120 0;
+BA_ "CG_MessageInstName" BO_ 2566869120 "evse_status";
+BA_ "VFrameFormat" BO_ 2566869120 3;
+BA_ "CanDootPaused" BO_ 2566861954 0;
+BA_ "CanDootSimulateBus" BO_ 2566861954 6;
+BA_ "CanDootSimulate" BO_ 2566861954 0;
+BA_ "CG_MessageInstName" BO_ 2566861954 "ev_target_current";
+BA_ "GenMsgCycleTime" BO_ 2566861954 200;
+BA_ "GenMsgRequestable" BO_ 2566861954 0;
+BA_ "GenMsgSendType" BO_ 2566861954 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566861954 60;
+BA_ "GenMsgDelayTime" BO_ 2566861954 0;
+BA_ "CanDootDecode" BO_ 2566861954 1;
+BA_ "CanDootDecodeBus" BO_ 2566861954 6;
+BA_ "CG_RX_TX" BO_ 2566861954 1;
+BA_ "VFrameFormat" BO_ 2566861954 3;
+BA_ "CanDootPaused" BO_ 2566861698 0;
+BA_ "CanDootSimulateBus" BO_ 2566861698 6;
+BA_ "CanDootSimulate" BO_ 2566861698 0;
+BA_ "CG_MessageInstName" BO_ 2566861698 "ev_target_voltage";
+BA_ "GenMsgCycleTime" BO_ 2566861698 200;
+BA_ "GenMsgRequestable" BO_ 2566861698 0;
+BA_ "GenMsgSendType" BO_ 2566861698 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566861698 70;
+BA_ "GenMsgDelayTime" BO_ 2566861698 0;
+BA_ "CanDootDecode" BO_ 2566861698 1;
+BA_ "CanDootDecodeBus" BO_ 2566861698 6;
+BA_ "CG_RX_TX" BO_ 2566861698 1;
+BA_ "VFrameFormat" BO_ 2566861698 3;
+BA_ "CanDootPaused" BO_ 2566860930 0;
+BA_ "CanDootSimulateBus" BO_ 2566860930 6;
+BA_ "CanDootSimulate" BO_ 2566860930 0;
+BA_ "CG_MessageInstName" BO_ 2566860930 "vehicle_status";
+BA_ "GenMsgCycleTime" BO_ 2566860930 200;
+BA_ "GenMsgRequestable" BO_ 2566860930 0;
+BA_ "GenMsgSendType" BO_ 2566860930 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566860930 100;
+BA_ "GenMsgDelayTime" BO_ 2566860930 0;
+BA_ "CanDootDecode" BO_ 2566860930 1;
+BA_ "CanDootDecodeBus" BO_ 2566860930 6;
+BA_ "CG_RX_TX" BO_ 2566860930 1;
+BA_ "VFrameFormat" BO_ 2566860930 3;
+BA_ "CanDootPaused" BO_ 2566857090 0;
+BA_ "CanDootSimulateBus" BO_ 2566857090 6;
+BA_ "CanDootSimulate" BO_ 2566857090 0;
+BA_ "E2EDataId01" BO_ 2566857090 65313;
+BA_ "E2EDataLength" BO_ 2566857090 64;
+BA_ "E2EProfile" BO_ 2566857090 "P01";
+BA_ "GenMsgCycleTime" BO_ 2566857090 20;
+BA_ "GenMsgRequestable" BO_ 2566857090 0;
+BA_ "GenMsgSendType" BO_ 2566857090 0;
+BA_ "CanDootDecode" BO_ 2566857090 1;
+BA_ "CanDootDecodeBus" BO_ 2566857090 6;
+BA_ "CG_RX_TX" BO_ 2566857090 1;
+BA_ "CG_MessageInstName" BO_ 2566857090 "charge_from_vehicle";
+BA_ "VFrameFormat" BO_ 2566857090 3;
+BA_ "CanDootPaused" BO_ 2566854528 0;
+BA_ "E2EDataLength" BO_ 2566854528 64;
+BA_ "GenMsgCycleTime" BO_ 2566854528 20;
+BA_ "GenMsgRequestable" BO_ 2566854528 0;
+BA_ "GenMsgSendType" BO_ 2566854528 0;
+BA_ "GenMsgNrOfRepetition" BO_ 2566854528 4;
+BA_ "GenMsgCycleTimeFast" BO_ 2566854528 20;
+BA_ "E2EDataId01" BO_ 2566854528 65303;
+BA_ "E2EProfile" BO_ 2566854528 "P01";
+BA_ "CanDootDecode" BO_ 2566854528 1;
+BA_ "CanDootDecodeBus" BO_ 2566854528 6;
+BA_ "CanDootSimulate" BO_ 2566854528 0;
+BA_ "CanDootSimulateBus" BO_ 2566854528 6;
+BA_ "CG_RX_TX" BO_ 2566854528 0;
+BA_ "CG_MessageInstName" BO_ 2566854528 "charge_to_vehicle";
+BA_ "VFrameFormat" BO_ 2566854528 3;
+BA_ "CanDootPaused" BO_ 2566856834 0;
+BA_ "CanDootSimulateBus" BO_ 2566856834 6;
+BA_ "CanDootSimulate" BO_ 2566856834 0;
+BA_ "CG_MessageInstName" BO_ 2566856834 "request";
+BA_ "GenMsgCycleTime" BO_ 2566856834 250;
+BA_ "GenMsgRequestable" BO_ 2566856834 0;
+BA_ "GenMsgSendType" BO_ 2566856834 0;
+BA_ "CanDootDecode" BO_ 2566856834 1;
+BA_ "CanDootDecodeBus" BO_ 2566856834 6;
+BA_ "CG_RX_TX" BO_ 2566856834 1;
+BA_ "VFrameFormat" BO_ 2566856834 3;
+BA_ "CanDootPaused" BO_ 2566854016 0;
+BA_ "CG_MessageInstName" BO_ 2566854016 "output_status";
+BA_ "GenMsgCycleTime" BO_ 2566854016 500;
+BA_ "GenMsgRequestable" BO_ 2566854016 0;
+BA_ "GenMsgSendType" BO_ 2566854016 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566854016 8;
+BA_ "GenMsgNrOfRepetition" BO_ 2566854016 4;
+BA_ "GenMsgCycleTimeFast" BO_ 2566854016 20;
+BA_ "CanDootDecode" BO_ 2566854016 1;
+BA_ "CanDootDecodeBus" BO_ 2566854016 6;
+BA_ "CanDootSimulate" BO_ 2566854016 0;
+BA_ "CanDootSimulateBus" BO_ 2566854016 6;
+BA_ "CG_RX_TX" BO_ 2566854016 0;
+BA_ "VFrameFormat" BO_ 2566854016 3;
+BA_ "CanDootPaused" BO_ 2566853760 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566853760 2;
+BA_ "GenMsgCycleTime" BO_ 2566853760 10;
+BA_ "GenMsgRequestable" BO_ 2566853760 0;
+BA_ "GenMsgSendType" BO_ 2566853760 0;
+BA_ "CanDootDecode" BO_ 2566853760 1;
+BA_ "CanDootDecodeBus" BO_ 2566853760 6;
+BA_ "CanDootSimulate" BO_ 2566853760 0;
+BA_ "CanDootSimulateBus" BO_ 2566853760 6;
+BA_ "CG_RX_TX" BO_ 2566853760 0;
+BA_ "CG_MessageInstName" BO_ 2566853760 "control_pilot_status";
+BA_ "VFrameFormat" BO_ 2566853760 3;
+BA_ "CanDootPaused" BO_ 2566853504 0;
+BA_ "GenMsgStartDelayTime" BO_ 2566853504 4;
+BA_ "GenMsgCycleTime" BO_ 2566853504 10;
+BA_ "GenMsgRequestable" BO_ 2566853504 0;
+BA_ "GenMsgSendType" BO_ 2566853504 0;
+BA_ "CanDootDecode" BO_ 2566853504 1;
+BA_ "CanDootDecodeBus" BO_ 2566853504 6;
+BA_ "CanDootSimulate" BO_ 2566853504 0;
+BA_ "CanDootSimulateBus" BO_ 2566853504 6;
+BA_ "CG_RX_TX" BO_ 2566853504 0;
+BA_ "CG_MessageInstName" BO_ 2566853504 "inlet_status";
+BA_ "VFrameFormat" BO_ 2566853504 3;
+BA_ "CanDootPaused" BO_ 2566853248 0;
+BA_ "CG_MessageInstName" BO_ 2566853248 "ptc2";
+BA_ "GenMsgStartDelayTime" BO_ 2566853248 4;
+BA_ "GenMsgCycleTime" BO_ 2566853248 10;
+BA_ "GenMsgRequestable" BO_ 2566853248 0;
+BA_ "GenMsgSendType" BO_ 2566853248 0;
+BA_ "CanDootDecode" BO_ 2566853248 1;
+BA_ "CanDootDecodeBus" BO_ 2566853248 6;
+BA_ "CanDootSimulate" BO_ 2566853248 0;
+BA_ "CanDootSimulateBus" BO_ 2566853248 6;
+BA_ "CG_RX_TX" BO_ 2566853248 0;
+BA_ "VFrameFormat" BO_ 2566853248 3;
+BA_ "CanDootPaused" BO_ 2566852992 0;
+BA_ "CG_MessageInstName" BO_ 2566852992 "ptc1";
+BA_ "GenMsgStartDelayTime" BO_ 2566852992 2;
+BA_ "GenMsgCycleTime" BO_ 2566852992 10;
+BA_ "GenMsgRequestable" BO_ 2566852992 0;
+BA_ "GenMsgSendType" BO_ 2566852992 0;
+BA_ "CanDootDecode" BO_ 2566852992 1;
+BA_ "CanDootDecodeBus" BO_ 2566852992 6;
+BA_ "CanDootSimulate" BO_ 2566852992 0;
+BA_ "CanDootSimulateBus" BO_ 2566852992 6;
+BA_ "CG_RX_TX" BO_ 2566852992 0;
+BA_ "VFrameFormat" BO_ 2566852992 3;
+BA_ "CanDootPaused" BO_ 2566852736 0;
+BA_ "CG_MessageInstName" BO_ 2566852736 "ptc0";
+BA_ "GenMsgCycleTime" BO_ 2566852736 10;
+BA_ "GenMsgRequestable" BO_ 2566852736 0;
+BA_ "GenMsgSendType" BO_ 2566852736 0;
+BA_ "CanDootDecode" BO_ 2566852736 1;
+BA_ "CanDootDecodeBus" BO_ 2566852736 6;
+BA_ "CanDootSimulate" BO_ 2566852736 0;
+BA_ "CanDootSimulateBus" BO_ 2566852736 6;
+BA_ "CG_RX_TX" BO_ 2566852736 0;
+BA_ "VFrameFormat" BO_ 2566852736 3;
+BA_ "CanDootHidden" SG_ 2566855296 protective_earth_offset 0;
+BA_ "CanDootGroup" SG_ 2566855296 protective_earth_offset 0;
+BA_ "CanDootBroadcast" SG_ 2566855296 protective_earth_offset 0;
+BA_ "GenSigStartValue" SG_ 2566855296 protective_earth_offset 65535;
+BA_ "GenSigSendType" SG_ 2566855296 protective_earth_offset 7;
+BA_ "CG_VarType" SG_ 2566855296 protective_earth_offset 7;
+BA_ "CanDootHidden" SG_ 2566855296 control_pilot_min_voltage 0;
+BA_ "CanDootGroup" SG_ 2566855296 control_pilot_min_voltage 0;
+BA_ "CanDootBroadcast" SG_ 2566855296 control_pilot_min_voltage 0;
+BA_ "GenSigStartValue" SG_ 2566855296 control_pilot_min_voltage 65535;
+BA_ "GenSigSendType" SG_ 2566855296 control_pilot_min_voltage 7;
+BA_ "CG_VarType" SG_ 2566855296 control_pilot_min_voltage 7;
+BA_ "CanDootHidden" SG_ 2566855296 plug_present_voltage 0;
+BA_ "CanDootGroup" SG_ 2566855296 plug_present_voltage 0;
+BA_ "CanDootBroadcast" SG_ 2566855296 plug_present_voltage 0;
+BA_ "GenSigStartValue" SG_ 2566855296 plug_present_voltage 65535;
+BA_ "GenSigSendType" SG_ 2566855296 plug_present_voltage 7;
+BA_ "CG_VarType" SG_ 2566855296 plug_present_voltage 7;
+BA_ "CanDootHidden" SG_ 2566872448 appl_scc_func_mode_req 0;
+BA_ "CanDootGroup" SG_ 2566872448 appl_scc_func_mode_req 0;
+BA_ "CanDootBroadcast" SG_ 2566872448 appl_scc_func_mode_req 0;
+BA_ "GenSigSendType" SG_ 2566872448 appl_scc_func_mode_req 4;
+BA_ "CG_VarType" SG_ 2566872448 appl_scc_func_mode_req 1;
+BA_ "CanDootHidden" SG_ 2566872448 appl_scc_charge_mode_req 0;
+BA_ "CanDootGroup" SG_ 2566872448 appl_scc_charge_mode_req 0;
+BA_ "CanDootBroadcast" SG_ 2566872448 appl_scc_charge_mode_req 0;
+BA_ "GenSigSendType" SG_ 2566872448 appl_scc_charge_mode_req 4;
+BA_ "CG_VarType" SG_ 2566872448 appl_scc_charge_mode_req 1;
+BA_ "CanDootHidden" SG_ 2566872448 statem_internet_available 0;
+BA_ "CanDootGroup" SG_ 2566872448 statem_internet_available 0;
+BA_ "CanDootBroadcast" SG_ 2566872448 statem_internet_available 0;
+BA_ "GenSigStartValue" SG_ 2566872448 statem_internet_available 0;
+BA_ "GenSigSendType" SG_ 2566872448 statem_internet_available 4;
+BA_ "CG_VarType" SG_ 2566872448 statem_internet_available 0;
+BA_ "CanDootHidden" SG_ 2566872448 statem_state_machine_status 0;
+BA_ "CanDootGroup" SG_ 2566872448 statem_state_machine_status 0;
+BA_ "CanDootBroadcast" SG_ 2566872448 statem_state_machine_status 0;
+BA_ "GenSigStartValue" SG_ 2566872448 statem_state_machine_status 0;
+BA_ "GenSigSendType" SG_ 2566872448 statem_state_machine_status 4;
+BA_ "CG_VarType" SG_ 2566872448 statem_state_machine_status 1;
+BA_ "CanDootHidden" SG_ 2566872448 statem_state_machine_message_sta 0;
+BA_ "CanDootGroup" SG_ 2566872448 statem_state_machine_message_sta 0;
+BA_ "CanDootBroadcast" SG_ 2566872448 statem_state_machine_message_sta 0;
+BA_ "GenSigStartValue" SG_ 2566872448 statem_state_machine_message_sta 0;
+BA_ "GenSigSendType" SG_ 2566872448 statem_state_machine_message_sta 4;
+BA_ "CG_VarType" SG_ 2566872448 statem_state_machine_message_sta 1;
+BA_ "SystemSignalLongSymbol" SG_ 2566872448 statem_state_machine_message_sta "statem_state_machine_message_state";
+BA_ "CanDootHidden" SG_ 2566872448 statem_state_machine_error 0;
+BA_ "CanDootGroup" SG_ 2566872448 statem_state_machine_error 0;
+BA_ "CanDootBroadcast" SG_ 2566872448 statem_state_machine_error 0;
+BA_ "GenSigStartValue" SG_ 2566872448 statem_state_machine_error 0;
+BA_ "GenSigSendType" SG_ 2566872448 statem_state_machine_error 4;
+BA_ "CG_VarType" SG_ 2566872448 statem_state_machine_error 1;
+BA_ "CanDootHidden" SG_ 2566872448 statem_energy_transfer_mode_flag 0;
+BA_ "CanDootGroup" SG_ 2566872448 statem_energy_transfer_mode_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566872448 statem_energy_transfer_mode_flag 0;
+BA_ "GenSigStartValue" SG_ 2566872448 statem_energy_transfer_mode_flag 0;
+BA_ "GenSigSendType" SG_ 2566872448 statem_energy_transfer_mode_flag 4;
+BA_ "CG_VarType" SG_ 2566872448 statem_energy_transfer_mode_flag 1;
+BA_ "SystemSignalLongSymbol" SG_ 2566872448 statem_energy_transfer_mode_flag "statem_energy_transfer_mode_flags";
+BA_ "CanDootHidden" SG_ 2566871680 present_voltage_unit_flag 0;
+BA_ "CanDootGroup" SG_ 2566871680 present_voltage_unit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566871680 present_voltage_unit_flag 0;
+BA_ "GenSigSendType" SG_ 2566871680 present_voltage_unit_flag 4;
+BA_ "CG_VarType" SG_ 2566871680 present_voltage_unit_flag 1;
+BA_ "CanDootHidden" SG_ 2566871680 present_voltage_value 0;
+BA_ "CanDootGroup" SG_ 2566871680 present_voltage_value 0;
+BA_ "CanDootBroadcast" SG_ 2566871680 present_voltage_value 0;
+BA_ "GenSigSendType" SG_ 2566871680 present_voltage_value 4;
+BA_ "CG_VarType" SG_ 2566871680 present_voltage_value 7;
+BA_ "CanDootHidden" SG_ 2566871680 present_voltage_multiplier 0;
+BA_ "CanDootGroup" SG_ 2566871680 present_voltage_multiplier 0;
+BA_ "CanDootBroadcast" SG_ 2566871680 present_voltage_multiplier 0;
+BA_ "GenSigSendType" SG_ 2566871680 present_voltage_multiplier 4;
+BA_ "CG_VarType" SG_ 2566871680 present_voltage_multiplier 2;
+BA_ "CanDootHidden" SG_ 2566871680 present_voltage_unit 0;
+BA_ "CanDootGroup" SG_ 2566871680 present_voltage_unit 0;
+BA_ "CanDootBroadcast" SG_ 2566871680 present_voltage_unit 0;
+BA_ "GenSigSendType" SG_ 2566871680 present_voltage_unit 4;
+BA_ "CG_VarType" SG_ 2566871680 present_voltage_unit 1;
+BA_ "CanDootHidden" SG_ 2566871424 present_current_unit_flag 0;
+BA_ "CanDootGroup" SG_ 2566871424 present_current_unit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566871424 present_current_unit_flag 0;
+BA_ "GenSigSendType" SG_ 2566871424 present_current_unit_flag 4;
+BA_ "CG_VarType" SG_ 2566871424 present_current_unit_flag 1;
+BA_ "CanDootHidden" SG_ 2566871424 present_current_value 0;
+BA_ "CanDootGroup" SG_ 2566871424 present_current_value 0;
+BA_ "CanDootBroadcast" SG_ 2566871424 present_current_value 0;
+BA_ "GenSigSendType" SG_ 2566871424 present_current_value 4;
+BA_ "CG_VarType" SG_ 2566871424 present_current_value 7;
+BA_ "CanDootHidden" SG_ 2566871424 present_current_multiplier 0;
+BA_ "CanDootGroup" SG_ 2566871424 present_current_multiplier 0;
+BA_ "CanDootBroadcast" SG_ 2566871424 present_current_multiplier 0;
+BA_ "GenSigSendType" SG_ 2566871424 present_current_multiplier 4;
+BA_ "CG_VarType" SG_ 2566871424 present_current_multiplier 2;
+BA_ "CanDootHidden" SG_ 2566871424 present_current_unit 0;
+BA_ "CanDootGroup" SG_ 2566871424 present_current_unit 0;
+BA_ "CanDootBroadcast" SG_ 2566871424 present_current_unit 0;
+BA_ "GenSigSendType" SG_ 2566871424 present_current_unit 4;
+BA_ "CG_VarType" SG_ 2566871424 present_current_unit 1;
+BA_ "CanDootHidden" SG_ 2566870912 minimum_voltage_limit_unit_flag 0;
+BA_ "CanDootGroup" SG_ 2566870912 minimum_voltage_limit_unit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566870912 minimum_voltage_limit_unit_flag 0;
+BA_ "GenSigSendType" SG_ 2566870912 minimum_voltage_limit_unit_flag 4;
+BA_ "CG_VarType" SG_ 2566870912 minimum_voltage_limit_unit_flag 1;
+BA_ "CanDootHidden" SG_ 2566870912 minimum_voltage_limit_value 0;
+BA_ "CanDootGroup" SG_ 2566870912 minimum_voltage_limit_value 0;
+BA_ "CanDootBroadcast" SG_ 2566870912 minimum_voltage_limit_value 0;
+BA_ "GenSigSendType" SG_ 2566870912 minimum_voltage_limit_value 4;
+BA_ "CG_VarType" SG_ 2566870912 minimum_voltage_limit_value 7;
+BA_ "CanDootHidden" SG_ 2566870912 minimum_voltage_limit_multiplier 0;
+BA_ "CanDootGroup" SG_ 2566870912 minimum_voltage_limit_multiplier 0;
+BA_ "CanDootBroadcast" SG_ 2566870912 minimum_voltage_limit_multiplier 0;
+BA_ "GenSigSendType" SG_ 2566870912 minimum_voltage_limit_multiplier 4;
+BA_ "CG_VarType" SG_ 2566870912 minimum_voltage_limit_multiplier 2;
+BA_ "CanDootHidden" SG_ 2566870912 minimum_voltage_limit_unit 0;
+BA_ "CanDootGroup" SG_ 2566870912 minimum_voltage_limit_unit 0;
+BA_ "CanDootBroadcast" SG_ 2566870912 minimum_voltage_limit_unit 0;
+BA_ "GenSigSendType" SG_ 2566870912 minimum_voltage_limit_unit 4;
+BA_ "CG_VarType" SG_ 2566870912 minimum_voltage_limit_unit 1;
+BA_ "CanDootHidden" SG_ 2566870656 minimum_current_limit_unit_flag 0;
+BA_ "CanDootGroup" SG_ 2566870656 minimum_current_limit_unit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566870656 minimum_current_limit_unit_flag 0;
+BA_ "GenSigSendType" SG_ 2566870656 minimum_current_limit_unit_flag 4;
+BA_ "CG_VarType" SG_ 2566870656 minimum_current_limit_unit_flag 1;
+BA_ "CanDootHidden" SG_ 2566870656 minimum_current_limit_value 0;
+BA_ "CanDootGroup" SG_ 2566870656 minimum_current_limit_value 0;
+BA_ "CanDootBroadcast" SG_ 2566870656 minimum_current_limit_value 0;
+BA_ "GenSigSendType" SG_ 2566870656 minimum_current_limit_value 4;
+BA_ "CG_VarType" SG_ 2566870656 minimum_current_limit_value 7;
+BA_ "CanDootHidden" SG_ 2566870656 minimum_current_limit_multiplier 0;
+BA_ "CanDootGroup" SG_ 2566870656 minimum_current_limit_multiplier 0;
+BA_ "CanDootBroadcast" SG_ 2566870656 minimum_current_limit_multiplier 0;
+BA_ "GenSigSendType" SG_ 2566870656 minimum_current_limit_multiplier 4;
+BA_ "CG_VarType" SG_ 2566870656 minimum_current_limit_multiplier 2;
+BA_ "CanDootHidden" SG_ 2566870656 minimum_current_limit_unit 0;
+BA_ "CanDootGroup" SG_ 2566870656 minimum_current_limit_unit 0;
+BA_ "CanDootBroadcast" SG_ 2566870656 minimum_current_limit_unit 0;
+BA_ "GenSigSendType" SG_ 2566870656 minimum_current_limit_unit 4;
+BA_ "CG_VarType" SG_ 2566870656 minimum_current_limit_unit 1;
+BA_ "CanDootHidden" SG_ 2566870400 maximum_voltage_limit_unit_flag 0;
+BA_ "CanDootGroup" SG_ 2566870400 maximum_voltage_limit_unit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566870400 maximum_voltage_limit_unit_flag 0;
+BA_ "GenSigSendType" SG_ 2566870400 maximum_voltage_limit_unit_flag 4;
+BA_ "CG_VarType" SG_ 2566870400 maximum_voltage_limit_unit_flag 1;
+BA_ "CanDootHidden" SG_ 2566870400 maximum_voltage_limit_value 0;
+BA_ "CanDootGroup" SG_ 2566870400 maximum_voltage_limit_value 0;
+BA_ "CanDootBroadcast" SG_ 2566870400 maximum_voltage_limit_value 0;
+BA_ "GenSigSendType" SG_ 2566870400 maximum_voltage_limit_value 4;
+BA_ "CG_VarType" SG_ 2566870400 maximum_voltage_limit_value 7;
+BA_ "CanDootHidden" SG_ 2566870400 maximum_voltage_limit_multiplier 0;
+BA_ "CanDootGroup" SG_ 2566870400 maximum_voltage_limit_multiplier 0;
+BA_ "CanDootBroadcast" SG_ 2566870400 maximum_voltage_limit_multiplier 0;
+BA_ "GenSigSendType" SG_ 2566870400 maximum_voltage_limit_multiplier 4;
+BA_ "CG_VarType" SG_ 2566870400 maximum_voltage_limit_multiplier 2;
+BA_ "CanDootHidden" SG_ 2566870400 maximum_voltage_limit_flag 0;
+BA_ "CanDootGroup" SG_ 2566870400 maximum_voltage_limit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566870400 maximum_voltage_limit_flag 0;
+BA_ "GenSigStartValue" SG_ 2566870400 maximum_voltage_limit_flag 3;
+BA_ "GenSigSendType" SG_ 2566870400 maximum_voltage_limit_flag 4;
+BA_ "CG_VarType" SG_ 2566870400 maximum_voltage_limit_flag 1;
+BA_ "CanDootHidden" SG_ 2566870400 maximum_voltage_limit_unit 0;
+BA_ "CanDootGroup" SG_ 2566870400 maximum_voltage_limit_unit 0;
+BA_ "CanDootBroadcast" SG_ 2566870400 maximum_voltage_limit_unit 0;
+BA_ "GenSigSendType" SG_ 2566870400 maximum_voltage_limit_unit 4;
+BA_ "CG_VarType" SG_ 2566870400 maximum_voltage_limit_unit 1;
+BA_ "CanDootHidden" SG_ 2566870144 maximum_powerL_lmit_unit_flag 0;
+BA_ "CanDootGroup" SG_ 2566870144 maximum_powerL_lmit_unit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566870144 maximum_powerL_lmit_unit_flag 0;
+BA_ "GenSigSendType" SG_ 2566870144 maximum_powerL_lmit_unit_flag 4;
+BA_ "CG_VarType" SG_ 2566870144 maximum_powerL_lmit_unit_flag 1;
+BA_ "CanDootHidden" SG_ 2566870144 maximum_power_limit_value 0;
+BA_ "CanDootGroup" SG_ 2566870144 maximum_power_limit_value 0;
+BA_ "CanDootBroadcast" SG_ 2566870144 maximum_power_limit_value 0;
+BA_ "GenSigSendType" SG_ 2566870144 maximum_power_limit_value 4;
+BA_ "CG_VarType" SG_ 2566870144 maximum_power_limit_value 7;
+BA_ "CanDootHidden" SG_ 2566870144 maximum_power_limit_multiplier 0;
+BA_ "CanDootGroup" SG_ 2566870144 maximum_power_limit_multiplier 0;
+BA_ "CanDootBroadcast" SG_ 2566870144 maximum_power_limit_multiplier 0;
+BA_ "GenSigSendType" SG_ 2566870144 maximum_power_limit_multiplier 4;
+BA_ "CG_VarType" SG_ 2566870144 maximum_power_limit_multiplier 2;
+BA_ "CanDootHidden" SG_ 2566870144 maximum_power_limit_flag 0;
+BA_ "CanDootGroup" SG_ 2566870144 maximum_power_limit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566870144 maximum_power_limit_flag 0;
+BA_ "GenSigStartValue" SG_ 2566870144 maximum_power_limit_flag 3;
+BA_ "GenSigSendType" SG_ 2566870144 maximum_power_limit_flag 4;
+BA_ "CG_VarType" SG_ 2566870144 maximum_power_limit_flag 1;
+BA_ "CanDootHidden" SG_ 2566870144 maximum_power_limit_unit 0;
+BA_ "CanDootGroup" SG_ 2566870144 maximum_power_limit_unit 0;
+BA_ "CanDootBroadcast" SG_ 2566870144 maximum_power_limit_unit 0;
+BA_ "GenSigSendType" SG_ 2566870144 maximum_power_limit_unit 4;
+BA_ "CG_VarType" SG_ 2566870144 maximum_power_limit_unit 1;
+BA_ "CanDootHidden" SG_ 2566869888 maximum_current_limit_unit_flag 0;
+BA_ "CanDootGroup" SG_ 2566869888 maximum_current_limit_unit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566869888 maximum_current_limit_unit_flag 0;
+BA_ "GenSigSendType" SG_ 2566869888 maximum_current_limit_unit_flag 4;
+BA_ "CG_VarType" SG_ 2566869888 maximum_current_limit_unit_flag 1;
+BA_ "CanDootHidden" SG_ 2566869888 maximum_current_limit_value 0;
+BA_ "CanDootGroup" SG_ 2566869888 maximum_current_limit_value 0;
+BA_ "CanDootBroadcast" SG_ 2566869888 maximum_current_limit_value 0;
+BA_ "GenSigSendType" SG_ 2566869888 maximum_current_limit_value 4;
+BA_ "CG_VarType" SG_ 2566869888 maximum_current_limit_value 7;
+BA_ "CanDootHidden" SG_ 2566869888 maximum_current_limit_multiplier 0;
+BA_ "CanDootGroup" SG_ 2566869888 maximum_current_limit_multiplier 0;
+BA_ "CanDootBroadcast" SG_ 2566869888 maximum_current_limit_multiplier 0;
+BA_ "GenSigSendType" SG_ 2566869888 maximum_current_limit_multiplier 4;
+BA_ "CG_VarType" SG_ 2566869888 maximum_current_limit_multiplier 2;
+BA_ "CanDootHidden" SG_ 2566869888 maximum_current_limit_flag 0;
+BA_ "CanDootGroup" SG_ 2566869888 maximum_current_limit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566869888 maximum_current_limit_flag 0;
+BA_ "GenSigStartValue" SG_ 2566869888 maximum_current_limit_flag 3;
+BA_ "GenSigSendType" SG_ 2566869888 maximum_current_limit_flag 4;
+BA_ "CG_VarType" SG_ 2566869888 maximum_current_limit_flag 1;
+BA_ "CanDootHidden" SG_ 2566869888 maximum_current_limit_unit 0;
+BA_ "CanDootGroup" SG_ 2566869888 maximum_current_limit_unit 0;
+BA_ "CanDootBroadcast" SG_ 2566869888 maximum_current_limit_unit 0;
+BA_ "GenSigSendType" SG_ 2566869888 maximum_current_limit_unit 4;
+BA_ "CG_VarType" SG_ 2566869888 maximum_current_limit_unit 1;
+BA_ "CanDootHidden" SG_ 2566863234 maximum_voltage_limit_unit_flag 0;
+BA_ "CanDootGroup" SG_ 2566863234 maximum_voltage_limit_unit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566863234 maximum_voltage_limit_unit_flag 0;
+BA_ "CG_VarType" SG_ 2566863234 maximum_voltage_limit_unit_flag 1;
+BA_ "CanDootHidden" SG_ 2566863234 maximum_voltage_limit_value 0;
+BA_ "CanDootGroup" SG_ 2566863234 maximum_voltage_limit_value 0;
+BA_ "CanDootBroadcast" SG_ 2566863234 maximum_voltage_limit_value 0;
+BA_ "CG_VarType" SG_ 2566863234 maximum_voltage_limit_value 7;
+BA_ "CanDootHidden" SG_ 2566863234 maximum_voltage_limit_multiplier 0;
+BA_ "CanDootGroup" SG_ 2566863234 maximum_voltage_limit_multiplier 0;
+BA_ "CanDootBroadcast" SG_ 2566863234 maximum_voltage_limit_multiplier 0;
+BA_ "CG_VarType" SG_ 2566863234 maximum_voltage_limit_multiplier 2;
+BA_ "CanDootHidden" SG_ 2566863234 maximum_voltage_limit_flag 0;
+BA_ "CanDootGroup" SG_ 2566863234 maximum_voltage_limit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566863234 maximum_voltage_limit_flag 0;
+BA_ "GenSigStartValue" SG_ 2566863234 maximum_voltage_limit_flag 3;
+BA_ "CG_VarType" SG_ 2566863234 maximum_voltage_limit_flag 1;
+BA_ "CanDootHidden" SG_ 2566863234 maximum_voltage_limit_unit 0;
+BA_ "CanDootGroup" SG_ 2566863234 maximum_voltage_limit_unit 0;
+BA_ "CanDootBroadcast" SG_ 2566863234 maximum_voltage_limit_unit 0;
+BA_ "CG_VarType" SG_ 2566863234 maximum_voltage_limit_unit 1;
+BA_ "CanDootHidden" SG_ 2566862978 maximum_power_limit_unit_flag 0;
+BA_ "CanDootGroup" SG_ 2566862978 maximum_power_limit_unit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566862978 maximum_power_limit_unit_flag 0;
+BA_ "CG_VarType" SG_ 2566862978 maximum_power_limit_unit_flag 1;
+BA_ "CanDootHidden" SG_ 2566862978 maximum_power_limit_value 0;
+BA_ "CanDootGroup" SG_ 2566862978 maximum_power_limit_value 0;
+BA_ "CanDootBroadcast" SG_ 2566862978 maximum_power_limit_value 0;
+BA_ "CG_VarType" SG_ 2566862978 maximum_power_limit_value 7;
+BA_ "CanDootHidden" SG_ 2566862978 maximum_power_limit_multiplier 0;
+BA_ "CanDootGroup" SG_ 2566862978 maximum_power_limit_multiplier 0;
+BA_ "CanDootBroadcast" SG_ 2566862978 maximum_power_limit_multiplier 0;
+BA_ "CG_VarType" SG_ 2566862978 maximum_power_limit_multiplier 2;
+BA_ "CanDootHidden" SG_ 2566862978 maximum_power_limit_flag 0;
+BA_ "CanDootGroup" SG_ 2566862978 maximum_power_limit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566862978 maximum_power_limit_flag 0;
+BA_ "GenSigStartValue" SG_ 2566862978 maximum_power_limit_flag 3;
+BA_ "CG_VarType" SG_ 2566862978 maximum_power_limit_flag 1;
+BA_ "CanDootHidden" SG_ 2566862978 maximum_power_limit_unit 0;
+BA_ "CanDootGroup" SG_ 2566862978 maximum_power_limit_unit 0;
+BA_ "CanDootBroadcast" SG_ 2566862978 maximum_power_limit_unit 0;
+BA_ "CG_VarType" SG_ 2566862978 maximum_power_limit_unit 1;
+BA_ "CanDootHidden" SG_ 2566862722 maximum_current_limit_unit_flag 0;
+BA_ "CanDootGroup" SG_ 2566862722 maximum_current_limit_unit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566862722 maximum_current_limit_unit_flag 0;
+BA_ "CG_VarType" SG_ 2566862722 maximum_current_limit_unit_flag 1;
+BA_ "CanDootHidden" SG_ 2566862722 maximum_current_limit_value 0;
+BA_ "CanDootGroup" SG_ 2566862722 maximum_current_limit_value 0;
+BA_ "CanDootBroadcast" SG_ 2566862722 maximum_current_limit_value 0;
+BA_ "CG_VarType" SG_ 2566862722 maximum_current_limit_value 7;
+BA_ "CanDootHidden" SG_ 2566862722 maximum_current_limit_multiplier 0;
+BA_ "CanDootGroup" SG_ 2566862722 maximum_current_limit_multiplier 0;
+BA_ "CanDootBroadcast" SG_ 2566862722 maximum_current_limit_multiplier 0;
+BA_ "CG_VarType" SG_ 2566862722 maximum_current_limit_multiplier 2;
+BA_ "CanDootHidden" SG_ 2566862722 maximum_current_limit_flag 0;
+BA_ "CanDootGroup" SG_ 2566862722 maximum_current_limit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566862722 maximum_current_limit_flag 0;
+BA_ "GenSigStartValue" SG_ 2566862722 maximum_current_limit_flag 3;
+BA_ "CG_VarType" SG_ 2566862722 maximum_current_limit_flag 1;
+BA_ "CanDootHidden" SG_ 2566862722 maximum_current_limit_unit 0;
+BA_ "CanDootGroup" SG_ 2566862722 maximum_current_limit_unit 0;
+BA_ "CanDootBroadcast" SG_ 2566862722 maximum_current_limit_unit 0;
+BA_ "CG_VarType" SG_ 2566862722 maximum_current_limit_unit 1;
+BA_ "CanDootHidden" SG_ 2566869120 notification_max_delay 0;
+BA_ "CanDootGroup" SG_ 2566869120 notification_max_delay 0;
+BA_ "CanDootBroadcast" SG_ 2566869120 notification_max_delay 0;
+BA_ "GenSigSendType" SG_ 2566869120 notification_max_delay 4;
+BA_ "CG_VarType" SG_ 2566869120 notification_max_delay 5;
+BA_ "CanDootHidden" SG_ 2566869120 response_code 0;
+BA_ "CanDootGroup" SG_ 2566869120 response_code 0;
+BA_ "CanDootBroadcast" SG_ 2566869120 response_code 0;
+BA_ "GenSigSendType" SG_ 2566869120 response_code 4;
+BA_ "CG_VarType" SG_ 2566869120 response_code 1;
+BA_ "CanDootHidden" SG_ 2566869120 date_time_now_flag 0;
+BA_ "CanDootGroup" SG_ 2566869120 date_time_now_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566869120 date_time_now_flag 0;
+BA_ "GenSigStartValue" SG_ 2566869120 date_time_now_flag 3;
+BA_ "GenSigSendType" SG_ 2566869120 date_time_now_flag 4;
+BA_ "CG_VarType" SG_ 2566869120 date_time_now_flag 1;
+BA_ "CanDootHidden" SG_ 2566869120 power_limit_achieved 0;
+BA_ "CanDootGroup" SG_ 2566869120 power_limit_achieved 0;
+BA_ "CanDootBroadcast" SG_ 2566869120 power_limit_achieved 0;
+BA_ "GenSigStartValue" SG_ 2566869120 power_limit_achieved 3;
+BA_ "GenSigSendType" SG_ 2566869120 power_limit_achieved 4;
+BA_ "CG_VarType" SG_ 2566869120 power_limit_achieved 1;
+BA_ "CanDootHidden" SG_ 2566869120 voltage_limit_achieved 0;
+BA_ "CanDootGroup" SG_ 2566869120 voltage_limit_achieved 0;
+BA_ "CanDootBroadcast" SG_ 2566869120 voltage_limit_achieved 0;
+BA_ "GenSigStartValue" SG_ 2566869120 voltage_limit_achieved 3;
+BA_ "GenSigSendType" SG_ 2566869120 voltage_limit_achieved 4;
+BA_ "CG_VarType" SG_ 2566869120 voltage_limit_achieved 1;
+BA_ "CanDootHidden" SG_ 2566869120 status_code 0;
+BA_ "CanDootGroup" SG_ 2566869120 status_code 0;
+BA_ "CanDootBroadcast" SG_ 2566869120 status_code 0;
+BA_ "GenSigSendType" SG_ 2566869120 status_code 4;
+BA_ "CG_VarType" SG_ 2566869120 status_code 1;
+BA_ "CanDootHidden" SG_ 2566869120 processing 0;
+BA_ "CanDootGroup" SG_ 2566869120 processing 0;
+BA_ "CanDootBroadcast" SG_ 2566869120 processing 0;
+BA_ "GenSigSendType" SG_ 2566869120 processing 4;
+BA_ "CG_VarType" SG_ 2566869120 processing 1;
+BA_ "CanDootHidden" SG_ 2566869120 notification 0;
+BA_ "CanDootGroup" SG_ 2566869120 notification 0;
+BA_ "CanDootBroadcast" SG_ 2566869120 notification 0;
+BA_ "GenSigSendType" SG_ 2566869120 notification 4;
+BA_ "CG_VarType" SG_ 2566869120 notification 1;
+BA_ "CanDootHidden" SG_ 2566869120 isolation_status_flag 0;
+BA_ "CanDootGroup" SG_ 2566869120 isolation_status_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566869120 isolation_status_flag 0;
+BA_ "GenSigStartValue" SG_ 2566869120 isolation_status_flag 3;
+BA_ "GenSigSendType" SG_ 2566869120 isolation_status_flag 4;
+BA_ "CG_VarType" SG_ 2566869120 isolation_status_flag 1;
+BA_ "CanDootHidden" SG_ 2566869120 isolation_status 0;
+BA_ "CanDootGroup" SG_ 2566869120 isolation_status 0;
+BA_ "CanDootBroadcast" SG_ 2566869120 isolation_status 0;
+BA_ "GenSigSendType" SG_ 2566869120 isolation_status 4;
+BA_ "CG_VarType" SG_ 2566869120 isolation_status 1;
+BA_ "CanDootHidden" SG_ 2566869120 current_limit_achieved 0;
+BA_ "CanDootGroup" SG_ 2566869120 current_limit_achieved 0;
+BA_ "CanDootBroadcast" SG_ 2566869120 current_limit_achieved 0;
+BA_ "GenSigStartValue" SG_ 2566869120 current_limit_achieved 3;
+BA_ "GenSigSendType" SG_ 2566869120 current_limit_achieved 4;
+BA_ "CG_VarType" SG_ 2566869120 current_limit_achieved 1;
+BA_ "CanDootHidden" SG_ 2566861954 target_current_unit 0;
+BA_ "CanDootGroup" SG_ 2566861954 target_current_unit 0;
+BA_ "CanDootBroadcast" SG_ 2566861954 target_current_unit 0;
+BA_ "CG_VarType" SG_ 2566861954 target_current_unit 1;
+BA_ "CanDootHidden" SG_ 2566861954 target_current_unit_flag 0;
+BA_ "CanDootGroup" SG_ 2566861954 target_current_unit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566861954 target_current_unit_flag 0;
+BA_ "CG_VarType" SG_ 2566861954 target_current_unit_flag 1;
+BA_ "CanDootHidden" SG_ 2566861954 target_current_multiplier 0;
+BA_ "CanDootGroup" SG_ 2566861954 target_current_multiplier 0;
+BA_ "CanDootBroadcast" SG_ 2566861954 target_current_multiplier 0;
+BA_ "CG_VarType" SG_ 2566861954 target_current_multiplier 2;
+BA_ "CanDootHidden" SG_ 2566861954 target_current_value 0;
+BA_ "CanDootGroup" SG_ 2566861954 target_current_value 0;
+BA_ "CanDootBroadcast" SG_ 2566861954 target_current_value 0;
+BA_ "CG_VarType" SG_ 2566861954 target_current_value 7;
+BA_ "CanDootHidden" SG_ 2566861698 target_voltage_unit 0;
+BA_ "CanDootGroup" SG_ 2566861698 target_voltage_unit 0;
+BA_ "CanDootBroadcast" SG_ 2566861698 target_voltage_unit 0;
+BA_ "CG_VarType" SG_ 2566861698 target_voltage_unit 1;
+BA_ "CanDootHidden" SG_ 2566861698 target_voltage_unit_flag 0;
+BA_ "CanDootGroup" SG_ 2566861698 target_voltage_unit_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566861698 target_voltage_unit_flag 0;
+BA_ "CG_VarType" SG_ 2566861698 target_voltage_unit_flag 1;
+BA_ "CanDootHidden" SG_ 2566861698 target_voltage_multiplier 0;
+BA_ "CanDootGroup" SG_ 2566861698 target_voltage_multiplier 0;
+BA_ "CanDootBroadcast" SG_ 2566861698 target_voltage_multiplier 0;
+BA_ "CG_VarType" SG_ 2566861698 target_voltage_multiplier 2;
+BA_ "CanDootHidden" SG_ 2566861698 target_voltage_value 0;
+BA_ "CanDootGroup" SG_ 2566861698 target_voltage_value 0;
+BA_ "CanDootBroadcast" SG_ 2566861698 target_voltage_value 0;
+BA_ "CG_VarType" SG_ 2566861698 target_voltage_value 7;
+BA_ "CanDootHidden" SG_ 2566860930 ress_soc 0;
+BA_ "CanDootGroup" SG_ 2566860930 ress_soc 0;
+BA_ "CanDootBroadcast" SG_ 2566860930 ress_soc 0;
+BA_ "CG_VarType" SG_ 2566860930 ress_soc 2;
+BA_ "CanDootHidden" SG_ 2566860930 full_soc 0;
+BA_ "CanDootGroup" SG_ 2566860930 full_soc 0;
+BA_ "CanDootBroadcast" SG_ 2566860930 full_soc 0;
+BA_ "CG_VarType" SG_ 2566860930 full_soc 2;
+BA_ "CanDootHidden" SG_ 2566860930 bulk_soc 0;
+BA_ "CanDootGroup" SG_ 2566860930 bulk_soc 0;
+BA_ "CanDootBroadcast" SG_ 2566860930 bulk_soc 0;
+BA_ "CG_VarType" SG_ 2566860930 bulk_soc 2;
+BA_ "CanDootHidden" SG_ 2566860930 statem_energy_transfer_mode 0;
+BA_ "CanDootGroup" SG_ 2566860930 statem_energy_transfer_mode 0;
+BA_ "CanDootBroadcast" SG_ 2566860930 statem_energy_transfer_mode 0;
+BA_ "GenSigStartValue" SG_ 2566860930 statem_energy_transfer_mode 15;
+BA_ "CG_VarType" SG_ 2566860930 statem_energy_transfer_mode 1;
+BA_ "CanDootHidden" SG_ 2566860930 power_delivery_parameter_flag 0;
+BA_ "CanDootGroup" SG_ 2566860930 power_delivery_parameter_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566860930 power_delivery_parameter_flag 0;
+BA_ "GenSigStartValue" SG_ 2566860930 power_delivery_parameter_flag 3;
+BA_ "CG_VarType" SG_ 2566860930 power_delivery_parameter_flag 1;
+BA_ "CanDootHidden" SG_ 2566860930 ress_conditioning_flag 0;
+BA_ "CanDootGroup" SG_ 2566860930 ress_conditioning_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566860930 ress_conditioning_flag 0;
+BA_ "GenSigStartValue" SG_ 2566860930 ress_conditioning_flag 3;
+BA_ "CG_VarType" SG_ 2566860930 ress_conditioning_flag 1;
+BA_ "CanDootHidden" SG_ 2566860930 ress_conditioning 0;
+BA_ "CanDootGroup" SG_ 2566860930 ress_conditioning 0;
+BA_ "CanDootBroadcast" SG_ 2566860930 ress_conditioning 0;
+BA_ "GenSigStartValue" SG_ 2566860930 ress_conditioning 3;
+BA_ "CG_VarType" SG_ 2566860930 ress_conditioning 1;
+BA_ "CanDootHidden" SG_ 2566860930 ready 0;
+BA_ "CanDootGroup" SG_ 2566860930 ready 0;
+BA_ "CanDootBroadcast" SG_ 2566860930 ready 0;
+BA_ "GenSigStartValue" SG_ 2566860930 ready 3;
+BA_ "CG_VarType" SG_ 2566860930 ready 1;
+BA_ "CanDootHidden" SG_ 2566860930 cabin_conditioning_flag 0;
+BA_ "CanDootGroup" SG_ 2566860930 cabin_conditioning_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566860930 cabin_conditioning_flag 0;
+BA_ "GenSigStartValue" SG_ 2566860930 cabin_conditioning_flag 3;
+BA_ "CG_VarType" SG_ 2566860930 cabin_conditioning_flag 1;
+BA_ "CanDootHidden" SG_ 2566860930 cabin_conditioning 0;
+BA_ "CanDootGroup" SG_ 2566860930 cabin_conditioning 0;
+BA_ "CanDootBroadcast" SG_ 2566860930 cabin_conditioning 0;
+BA_ "GenSigStartValue" SG_ 2566860930 cabin_conditioning 3;
+BA_ "CG_VarType" SG_ 2566860930 cabin_conditioning 1;
+BA_ "CanDootHidden" SG_ 2566860930 charging_complete 0;
+BA_ "CanDootGroup" SG_ 2566860930 charging_complete 0;
+BA_ "CanDootBroadcast" SG_ 2566860930 charging_complete 0;
+BA_ "GenSigStartValue" SG_ 2566860930 charging_complete 3;
+BA_ "CG_VarType" SG_ 2566860930 charging_complete 1;
+BA_ "CanDootHidden" SG_ 2566860930 full_soc_flag 0;
+BA_ "CanDootGroup" SG_ 2566860930 full_soc_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566860930 full_soc_flag 0;
+BA_ "GenSigStartValue" SG_ 2566860930 full_soc_flag 3;
+BA_ "CG_VarType" SG_ 2566860930 full_soc_flag 1;
+BA_ "CanDootHidden" SG_ 2566860930 bulk_soc_flag 0;
+BA_ "CanDootGroup" SG_ 2566860930 bulk_soc_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566860930 bulk_soc_flag 0;
+BA_ "GenSigStartValue" SG_ 2566860930 bulk_soc_flag 3;
+BA_ "CG_VarType" SG_ 2566860930 bulk_soc_flag 1;
+BA_ "CanDootHidden" SG_ 2566860930 bulk_charging_complete_flag 0;
+BA_ "CanDootGroup" SG_ 2566860930 bulk_charging_complete_flag 0;
+BA_ "CanDootBroadcast" SG_ 2566860930 bulk_charging_complete_flag 0;
+BA_ "GenSigStartValue" SG_ 2566860930 bulk_charging_complete_flag 3;
+BA_ "CG_VarType" SG_ 2566860930 bulk_charging_complete_flag 1;
+BA_ "CanDootHidden" SG_ 2566860930 bulk_charging_complete 0;
+BA_ "CanDootGroup" SG_ 2566860930 bulk_charging_complete 0;
+BA_ "CanDootBroadcast" SG_ 2566860930 bulk_charging_complete 0;
+BA_ "GenSigStartValue" SG_ 2566860930 bulk_charging_complete 3;
+BA_ "CG_VarType" SG_ 2566860930 bulk_charging_complete 1;
+BA_ "CanDootHidden" SG_ 2566860930 error_code 0;
+BA_ "CanDootGroup" SG_ 2566860930 error_code 0;
+BA_ "CanDootBroadcast" SG_ 2566860930 error_code 0;
+BA_ "CG_VarType" SG_ 2566860930 error_code 1;
+BA_ "CanDootHidden" SG_ 2566857090 pwm_charge_mode_request 0;
+BA_ "CanDootGroup" SG_ 2566857090 pwm_charge_mode_request 0;
+BA_ "CanDootBroadcast" SG_ 2566857090 pwm_charge_mode_request 0;
+BA_ "GenSigStartValue" SG_ 2566857090 pwm_charge_mode_request 3;
+BA_ "CG_VarType" SG_ 2566857090 pwm_charge_mode_request 1;
+BA_ "CanDootHidden" SG_ 2566857090 renegotiate 0;
+BA_ "CanDootGroup" SG_ 2566857090 renegotiate 0;
+BA_ "CanDootBroadcast" SG_ 2566857090 renegotiate 0;
+BA_ "GenSigStartValue" SG_ 2566857090 renegotiate 3;
+BA_ "CG_VarType" SG_ 2566857090 renegotiate 1;
+BA_ "CanDootHidden" SG_ 2566857090 charge_selection 0;
+BA_ "CanDootGroup" SG_ 2566857090 charge_selection 0;
+BA_ "CanDootBroadcast" SG_ 2566857090 charge_selection 0;
+BA_ "GenSigStartValue" SG_ 2566857090 charge_selection 3;
+BA_ "CG_VarType" SG_ 2566857090 charge_selection 1;
+BA_ "CanDootHidden" SG_ 2566857090 stop_charge 0;
+BA_ "CanDootGroup" SG_ 2566857090 stop_charge 0;
+BA_ "CanDootBroadcast" SG_ 2566857090 stop_charge 0;
+BA_ "GenSigStartValue" SG_ 2566857090 stop_charge 3;
+BA_ "CG_VarType" SG_ 2566857090 stop_charge 1;
+BA_ "CanDootHidden" SG_ 2566857090 contactor_status 0;
+BA_ "CanDootGroup" SG_ 2566857090 contactor_status 0;
+BA_ "CanDootBroadcast" SG_ 2566857090 contactor_status 0;
+BA_ "GenSigStartValue" SG_ 2566857090 contactor_status 3;
+BA_ "CG_VarType" SG_ 2566857090 contactor_status 1;
+BA_ "CanDootHidden" SG_ 2566857090 charge_permission 0;
+BA_ "CanDootGroup" SG_ 2566857090 charge_permission 0;
+BA_ "CanDootBroadcast" SG_ 2566857090 charge_permission 0;
+BA_ "GenSigStartValue" SG_ 2566857090 charge_permission 3;
+BA_ "CG_VarType" SG_ 2566857090 charge_permission 1;
+BA_ "CanDootHidden" SG_ 2566857090 plug_unlock_permission 0;
+BA_ "CanDootGroup" SG_ 2566857090 plug_unlock_permission 0;
+BA_ "CanDootBroadcast" SG_ 2566857090 plug_unlock_permission 0;
+BA_ "GenSigStartValue" SG_ 2566857090 plug_unlock_permission 3;
+BA_ "CG_VarType" SG_ 2566857090 plug_unlock_permission 1;
+BA_ "CanDootHidden" SG_ 2566857090 plug_lock_permission 0;
+BA_ "CanDootGroup" SG_ 2566857090 plug_lock_permission 0;
+BA_ "CanDootBroadcast" SG_ 2566857090 plug_lock_permission 0;
+BA_ "GenSigStartValue" SG_ 2566857090 plug_lock_permission 3;
+BA_ "CG_VarType" SG_ 2566857090 plug_lock_permission 1;
+BA_ "CanDootHidden" SG_ 2566857090 isolation_measurement_status 0;
+BA_ "CanDootGroup" SG_ 2566857090 isolation_measurement_status 0;
+BA_ "CanDootBroadcast" SG_ 2566857090 isolation_measurement_status 0;
+BA_ "GenSigStartValue" SG_ 2566857090 isolation_measurement_status 3;
+BA_ "CG_VarType" SG_ 2566857090 isolation_measurement_status 1;
+BA_ "CanDootHidden" SG_ 2566857090 link_voltage 0;
+BA_ "CanDootGroup" SG_ 2566857090 link_voltage 0;
+BA_ "CanDootBroadcast" SG_ 2566857090 link_voltage 0;
+BA_ "GenSigStartValue" SG_ 2566857090 link_voltage 65535;
+BA_ "CG_VarType" SG_ 2566857090 link_voltage 7;
+BA_ "CanDootHidden" SG_ 2566857090 contactor_voltage 0;
+BA_ "CanDootGroup" SG_ 2566857090 contactor_voltage 0;
+BA_ "CanDootBroadcast" SG_ 2566857090 contactor_voltage 0;
+BA_ "GenSigStartValue" SG_ 2566857090 contactor_voltage 65535;
+BA_ "CG_VarType" SG_ 2566857090 contactor_voltage 7;
+BA_ "CanDootHidden" SG_ 2566854528 state_charge_from_vehicle 0;
+BA_ "CanDootGroup" SG_ 2566854528 state_charge_from_vehicle 0;
+BA_ "CanDootBroadcast" SG_ 2566854528 state_charge_from_vehicle 0;
+BA_ "GenSigStartValue" SG_ 2566854528 state_charge_from_vehicle 0;
+BA_ "CG_VarType" SG_ 2566854528 state_charge_from_vehicle 1;
+BA_ "CanDootHidden" SG_ 2566854528 mobilization_status 0;
+BA_ "CanDootGroup" SG_ 2566854528 mobilization_status 0;
+BA_ "CanDootBroadcast" SG_ 2566854528 mobilization_status 0;
+BA_ "GenSigStartValue" SG_ 2566854528 mobilization_status 3;
+BA_ "CG_VarType" SG_ 2566854528 mobilization_status 1;
+BA_ "CanDootHidden" SG_ 2566854528 charging_status 0;
+BA_ "CanDootGroup" SG_ 2566854528 charging_status 0;
+BA_ "CanDootBroadcast" SG_ 2566854528 charging_status 0;
+BA_ "GenSigStartValue" SG_ 2566854528 charging_status 3;
+BA_ "CG_VarType" SG_ 2566854528 charging_status 1;
+BA_ "CanDootHidden" SG_ 2566854528 charge_selection_ack 0;
+BA_ "CanDootGroup" SG_ 2566854528 charge_selection_ack 0;
+BA_ "CanDootBroadcast" SG_ 2566854528 charge_selection_ack 0;
+BA_ "GenSigStartValue" SG_ 2566854528 charge_selection_ack 3;
+BA_ "CG_VarType" SG_ 2566854528 charge_selection_ack 1;
+BA_ "CanDootHidden" SG_ 2566854528 contactor_request 0;
+BA_ "CanDootGroup" SG_ 2566854528 contactor_request 0;
+BA_ "CanDootBroadcast" SG_ 2566854528 contactor_request 0;
+BA_ "GenSigStartValue" SG_ 2566854528 contactor_request 3;
+BA_ "CG_VarType" SG_ 2566854528 contactor_request 1;
+BA_ "CanDootHidden" SG_ 2566854528 isolation_measurement_request 0;
+BA_ "CanDootGroup" SG_ 2566854528 isolation_measurement_request 0;
+BA_ "CanDootBroadcast" SG_ 2566854528 isolation_measurement_request 0;
+BA_ "GenSigStartValue" SG_ 2566854528 isolation_measurement_request 3;
+BA_ "CG_VarType" SG_ 2566854528 isolation_measurement_request 1;
+BA_ "CanDootHidden" SG_ 2566856834 Inlet_MotorRequest 0;
+BA_ "CanDootGroup" SG_ 2566856834 Inlet_MotorRequest 0;
+BA_ "CanDootBroadcast" SG_ 2566856834 Inlet_MotorRequest 0;
+BA_ "GenSigStartValue" SG_ 2566856834 Inlet_MotorRequest 3;
+BA_ "CG_VarType" SG_ 2566856834 Inlet_MotorRequest 1;
+BA_ "CanDootHidden" SG_ 2566856834 charge_unit_request 0;
+BA_ "CanDootGroup" SG_ 2566856834 charge_unit_request 0;
+BA_ "CanDootBroadcast" SG_ 2566856834 charge_unit_request 0;
+BA_ "GenSigStartValue" SG_ 2566856834 charge_unit_request 3;
+BA_ "CG_VarType" SG_ 2566856834 charge_unit_request 1;
+BA_ "CanDootHidden" SG_ 2566856834 control_pilot_charge_mode_reques 0;
+BA_ "CanDootGroup" SG_ 2566856834 control_pilot_charge_mode_reques 0;
+BA_ "CanDootBroadcast" SG_ 2566856834 control_pilot_charge_mode_reques 0;
+BA_ "GenSigStartValue" SG_ 2566856834 control_pilot_charge_mode_reques 7;
+BA_ "CG_VarType" SG_ 2566856834 control_pilot_charge_mode_reques 1;
+BA_ "SystemSignalLongSymbol" SG_ 2566856834 control_pilot_charge_mode_reques "control_pilot_charge_mode_request";
+BA_ "CanDootHidden" SG_ 2566856834 rtc_timer_value 0;
+BA_ "CanDootGroup" SG_ 2566856834 rtc_timer_value 0;
+BA_ "CanDootBroadcast" SG_ 2566856834 rtc_timer_value 0;
+BA_ "GenSigStartValue" SG_ 2566856834 rtc_timer_value 255;
+BA_ "CG_VarType" SG_ 2566856834 rtc_timer_value 1;
+BA_ "CanDootHidden" SG_ 2566856834 plug_lock_motor_request 0;
+BA_ "CanDootGroup" SG_ 2566856834 plug_lock_motor_request 0;
+BA_ "CanDootBroadcast" SG_ 2566856834 plug_lock_motor_request 0;
+BA_ "GenSigStartValue" SG_ 2566856834 plug_lock_motor_request 7;
+BA_ "CG_VarType" SG_ 2566856834 plug_lock_motor_request 1;
+BA_ "CanDootHidden" SG_ 2566856834 rtc_timer_request 0;
+BA_ "CanDootGroup" SG_ 2566856834 rtc_timer_request 0;
+BA_ "CanDootBroadcast" SG_ 2566856834 rtc_timer_request 0;
+BA_ "GenSigStartValue" SG_ 2566856834 rtc_timer_request 3;
+BA_ "CG_VarType" SG_ 2566856834 rtc_timer_request 1;
+BA_ "CanDootHidden" SG_ 2566856834 highside_out_4_request 0;
+BA_ "CanDootGroup" SG_ 2566856834 highside_out_4_request 0;
+BA_ "CanDootBroadcast" SG_ 2566856834 highside_out_4_request 0;
+BA_ "GenSigStartValue" SG_ 2566856834 highside_out_4_request 3;
+BA_ "CG_VarType" SG_ 2566856834 highside_out_4_request 1;
+BA_ "CanDootHidden" SG_ 2566856834 highside_out_3_request 0;
+BA_ "CanDootGroup" SG_ 2566856834 highside_out_3_request 0;
+BA_ "CanDootBroadcast" SG_ 2566856834 highside_out_3_request 0;
+BA_ "GenSigStartValue" SG_ 2566856834 highside_out_3_request 3;
+BA_ "CG_VarType" SG_ 2566856834 highside_out_3_request 1;
+BA_ "CanDootHidden" SG_ 2566856834 highside_out_2_request 0;
+BA_ "CanDootGroup" SG_ 2566856834 highside_out_2_request 0;
+BA_ "CanDootBroadcast" SG_ 2566856834 highside_out_2_request 0;
+BA_ "GenSigStartValue" SG_ 2566856834 highside_out_2_request 3;
+BA_ "CG_VarType" SG_ 2566856834 highside_out_2_request 1;
+BA_ "CanDootHidden" SG_ 2566856834 highside_out_1_request 0;
+BA_ "CanDootGroup" SG_ 2566856834 highside_out_1_request 0;
+BA_ "CanDootBroadcast" SG_ 2566856834 highside_out_1_request 0;
+BA_ "GenSigStartValue" SG_ 2566856834 highside_out_1_request 3;
+BA_ "CG_VarType" SG_ 2566856834 highside_out_1_request 1;
+BA_ "CanDootHidden" SG_ 2566856834 highside_out_0_request 0;
+BA_ "CanDootGroup" SG_ 2566856834 highside_out_0_request 0;
+BA_ "CanDootBroadcast" SG_ 2566856834 highside_out_0_request 0;
+BA_ "GenSigStartValue" SG_ 2566856834 highside_out_0_request 3;
+BA_ "CG_VarType" SG_ 2566856834 highside_out_0_request 1;
+BA_ "CanDootHidden" SG_ 2566856834 led_2_request 0;
+BA_ "CanDootGroup" SG_ 2566856834 led_2_request 0;
+BA_ "CanDootBroadcast" SG_ 2566856834 led_2_request 0;
+BA_ "GenSigStartValue" SG_ 2566856834 led_2_request 255;
+BA_ "CG_VarType" SG_ 2566856834 led_2_request 1;
+BA_ "CanDootHidden" SG_ 2566856834 led_1_request 0;
+BA_ "CanDootGroup" SG_ 2566856834 led_1_request 0;
+BA_ "CanDootBroadcast" SG_ 2566856834 led_1_request 0;
+BA_ "GenSigStartValue" SG_ 2566856834 led_1_request 255;
+BA_ "CG_VarType" SG_ 2566856834 led_1_request 1;
+BA_ "CanDootHidden" SG_ 2566856834 led_0_request 0;
+BA_ "CanDootGroup" SG_ 2566856834 led_0_request 0;
+BA_ "CanDootBroadcast" SG_ 2566856834 led_0_request 0;
+BA_ "GenSigStartValue" SG_ 2566856834 led_0_request 255;
+BA_ "CG_VarType" SG_ 2566856834 led_0_request 1;
+BA_ "CanDootHidden" SG_ 2566854016 highside_out_3_input_wakeup 0;
+BA_ "CanDootGroup" SG_ 2566854016 highside_out_3_input_wakeup 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 highside_out_3_input_wakeup 0;
+BA_ "GenSigStartValue" SG_ 2566854016 highside_out_3_input_wakeup 3;
+BA_ "GenSigSendType" SG_ 2566854016 highside_out_3_input_wakeup 4;
+BA_ "CG_VarType" SG_ 2566854016 highside_out_3_input_wakeup 1;
+BA_ "CanDootHidden" SG_ 2566854016 highside_out_4_input_status 0;
+BA_ "CanDootGroup" SG_ 2566854016 highside_out_4_input_status 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 highside_out_4_input_status 0;
+BA_ "GenSigStartValue" SG_ 2566854016 highside_out_4_input_status 3;
+BA_ "GenSigSendType" SG_ 2566854016 highside_out_4_input_status 4;
+BA_ "CG_VarType" SG_ 2566854016 highside_out_4_input_status 1;
+BA_ "CanDootHidden" SG_ 2566854016 highside_out_4_input_debounced_s 0;
+BA_ "CanDootGroup" SG_ 2566854016 highside_out_4_input_debounced_s 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 highside_out_4_input_debounced_s 0;
+BA_ "GenSigStartValue" SG_ 2566854016 highside_out_4_input_debounced_s 3;
+BA_ "GenSigSendType" SG_ 2566854016 highside_out_4_input_debounced_s 4;
+BA_ "CG_VarType" SG_ 2566854016 highside_out_4_input_debounced_s 1;
+BA_ "SystemSignalLongSymbol" SG_ 2566854016 highside_out_4_input_debounced_s "highside_out_4_input_debounced_status";
+BA_ "CanDootHidden" SG_ 2566854016 highside_out_3_input_status 0;
+BA_ "CanDootGroup" SG_ 2566854016 highside_out_3_input_status 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 highside_out_3_input_status 0;
+BA_ "GenSigStartValue" SG_ 2566854016 highside_out_3_input_status 3;
+BA_ "GenSigSendType" SG_ 2566854016 highside_out_3_input_status 4;
+BA_ "CG_VarType" SG_ 2566854016 highside_out_3_input_status 1;
+BA_ "CanDootHidden" SG_ 2566854016 high_side_out_3_input_debounced_ 0;
+BA_ "CanDootGroup" SG_ 2566854016 high_side_out_3_input_debounced_ 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 high_side_out_3_input_debounced_ 0;
+BA_ "GenSigStartValue" SG_ 2566854016 high_side_out_3_input_debounced_ 3;
+BA_ "GenSigSendType" SG_ 2566854016 high_side_out_3_input_debounced_ 4;
+BA_ "CG_VarType" SG_ 2566854016 high_side_out_3_input_debounced_ 1;
+BA_ "SystemSignalLongSymbol" SG_ 2566854016 high_side_out_3_input_debounced_ "high_side_out_3_input_debounced_status";
+BA_ "CanDootHidden" SG_ 2566854016 highside_out_2_input_status 0;
+BA_ "CanDootGroup" SG_ 2566854016 highside_out_2_input_status 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 highside_out_2_input_status 0;
+BA_ "GenSigStartValue" SG_ 2566854016 highside_out_2_input_status 3;
+BA_ "GenSigSendType" SG_ 2566854016 highside_out_2_input_status 4;
+BA_ "CG_VarType" SG_ 2566854016 highside_out_2_input_status 1;
+BA_ "CanDootHidden" SG_ 2566854016 highside_out_2_input_debounced_s 0;
+BA_ "CanDootGroup" SG_ 2566854016 highside_out_2_input_debounced_s 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 highside_out_2_input_debounced_s 0;
+BA_ "GenSigStartValue" SG_ 2566854016 highside_out_2_input_debounced_s 3;
+BA_ "GenSigSendType" SG_ 2566854016 highside_out_2_input_debounced_s 4;
+BA_ "CG_VarType" SG_ 2566854016 highside_out_2_input_debounced_s 1;
+BA_ "SystemSignalLongSymbol" SG_ 2566854016 highside_out_2_input_debounced_s "highside_out_2_input_debounced_status";
+BA_ "CanDootHidden" SG_ 2566854016 highside_out_1_input_status 0;
+BA_ "CanDootGroup" SG_ 2566854016 highside_out_1_input_status 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 highside_out_1_input_status 0;
+BA_ "GenSigStartValue" SG_ 2566854016 highside_out_1_input_status 3;
+BA_ "GenSigSendType" SG_ 2566854016 highside_out_1_input_status 4;
+BA_ "CG_VarType" SG_ 2566854016 highside_out_1_input_status 1;
+BA_ "CanDootHidden" SG_ 2566854016 highside_out_1_input_debounced_s 0;
+BA_ "CanDootGroup" SG_ 2566854016 highside_out_1_input_debounced_s 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 highside_out_1_input_debounced_s 0;
+BA_ "GenSigStartValue" SG_ 2566854016 highside_out_1_input_debounced_s 3;
+BA_ "GenSigSendType" SG_ 2566854016 highside_out_1_input_debounced_s 4;
+BA_ "CG_VarType" SG_ 2566854016 highside_out_1_input_debounced_s 1;
+BA_ "SystemSignalLongSymbol" SG_ 2566854016 highside_out_1_input_debounced_s "highside_out_1_input_debounced_status";
+BA_ "CanDootHidden" SG_ 2566854016 highside_out_0_input_status 0;
+BA_ "CanDootGroup" SG_ 2566854016 highside_out_0_input_status 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 highside_out_0_input_status 0;
+BA_ "GenSigStartValue" SG_ 2566854016 highside_out_0_input_status 3;
+BA_ "GenSigSendType" SG_ 2566854016 highside_out_0_input_status 4;
+BA_ "CG_VarType" SG_ 2566854016 highside_out_0_input_status 1;
+BA_ "CanDootHidden" SG_ 2566854016 highside_out_0_Input_debounced_s 0;
+BA_ "CanDootGroup" SG_ 2566854016 highside_out_0_Input_debounced_s 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 highside_out_0_Input_debounced_s 0;
+BA_ "GenSigStartValue" SG_ 2566854016 highside_out_0_Input_debounced_s 3;
+BA_ "GenSigSendType" SG_ 2566854016 highside_out_0_Input_debounced_s 4;
+BA_ "CG_VarType" SG_ 2566854016 highside_out_0_Input_debounced_s 1;
+BA_ "SystemSignalLongSymbol" SG_ 2566854016 highside_out_0_Input_debounced_s "highside_out_0_Input_debounced_status";
+BA_ "CanDootHidden" SG_ 2566854016 led_2_self_diagnostic_status 0;
+BA_ "CanDootGroup" SG_ 2566854016 led_2_self_diagnostic_status 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 led_2_self_diagnostic_status 0;
+BA_ "GenSigStartValue" SG_ 2566854016 led_2_self_diagnostic_status 7;
+BA_ "GenSigSendType" SG_ 2566854016 led_2_self_diagnostic_status 4;
+BA_ "CG_VarType" SG_ 2566854016 led_2_self_diagnostic_status 1;
+BA_ "CanDootHidden" SG_ 2566854016 led_1_self_diagnostic_status 0;
+BA_ "CanDootGroup" SG_ 2566854016 led_1_self_diagnostic_status 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 led_1_self_diagnostic_status 0;
+BA_ "GenSigStartValue" SG_ 2566854016 led_1_self_diagnostic_status 7;
+BA_ "GenSigSendType" SG_ 2566854016 led_1_self_diagnostic_status 4;
+BA_ "CG_VarType" SG_ 2566854016 led_1_self_diagnostic_status 1;
+BA_ "CanDootHidden" SG_ 2566854016 led_0_self_diagnostic_status 0;
+BA_ "CanDootGroup" SG_ 2566854016 led_0_self_diagnostic_status 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 led_0_self_diagnostic_status 0;
+BA_ "GenSigStartValue" SG_ 2566854016 led_0_self_diagnostic_status 7;
+BA_ "GenSigSendType" SG_ 2566854016 led_0_self_diagnostic_status 4;
+BA_ "CG_VarType" SG_ 2566854016 led_0_self_diagnostic_status 1;
+BA_ "CanDootHidden" SG_ 2566854016 highside_out_4_self_diagnostic_s 0;
+BA_ "CanDootGroup" SG_ 2566854016 highside_out_4_self_diagnostic_s 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 highside_out_4_self_diagnostic_s 0;
+BA_ "GenSigStartValue" SG_ 2566854016 highside_out_4_self_diagnostic_s 7;
+BA_ "GenSigSendType" SG_ 2566854016 highside_out_4_self_diagnostic_s 4;
+BA_ "CG_VarType" SG_ 2566854016 highside_out_4_self_diagnostic_s 1;
+BA_ "SystemSignalLongSymbol" SG_ 2566854016 highside_out_4_self_diagnostic_s "highside_out_4_self_diagnostic_status";
+BA_ "CanDootHidden" SG_ 2566854016 highside_out_3_self_diagnostic_s 0;
+BA_ "CanDootGroup" SG_ 2566854016 highside_out_3_self_diagnostic_s 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 highside_out_3_self_diagnostic_s 0;
+BA_ "GenSigStartValue" SG_ 2566854016 highside_out_3_self_diagnostic_s 7;
+BA_ "GenSigSendType" SG_ 2566854016 highside_out_3_self_diagnostic_s 4;
+BA_ "CG_VarType" SG_ 2566854016 highside_out_3_self_diagnostic_s 1;
+BA_ "SystemSignalLongSymbol" SG_ 2566854016 highside_out_3_self_diagnostic_s "highside_out_3_self_diagnostic_status";
+BA_ "CanDootHidden" SG_ 2566854016 highside_out_2_self_diagnostic_s 0;
+BA_ "CanDootGroup" SG_ 2566854016 highside_out_2_self_diagnostic_s 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 highside_out_2_self_diagnostic_s 0;
+BA_ "GenSigStartValue" SG_ 2566854016 highside_out_2_self_diagnostic_s 7;
+BA_ "GenSigSendType" SG_ 2566854016 highside_out_2_self_diagnostic_s 4;
+BA_ "CG_VarType" SG_ 2566854016 highside_out_2_self_diagnostic_s 1;
+BA_ "SystemSignalLongSymbol" SG_ 2566854016 highside_out_2_self_diagnostic_s "highside_out_2_self_diagnostic_status";
+BA_ "CanDootHidden" SG_ 2566854016 highside_out_1_self_diagnostic_s 0;
+BA_ "CanDootGroup" SG_ 2566854016 highside_out_1_self_diagnostic_s 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 highside_out_1_self_diagnostic_s 0;
+BA_ "GenSigStartValue" SG_ 2566854016 highside_out_1_self_diagnostic_s 7;
+BA_ "GenSigSendType" SG_ 2566854016 highside_out_1_self_diagnostic_s 4;
+BA_ "CG_VarType" SG_ 2566854016 highside_out_1_self_diagnostic_s 1;
+BA_ "SystemSignalLongSymbol" SG_ 2566854016 highside_out_1_self_diagnostic_s "highside_out_1_self_diagnostic_status";
+BA_ "CanDootHidden" SG_ 2566854016 highside_out_0_self_diagnostic_s 0;
+BA_ "CanDootGroup" SG_ 2566854016 highside_out_0_self_diagnostic_s 0;
+BA_ "CanDootBroadcast" SG_ 2566854016 highside_out_0_self_diagnostic_s 0;
+BA_ "GenSigStartValue" SG_ 2566854016 highside_out_0_self_diagnostic_s 7;
+BA_ "GenSigSendType" SG_ 2566854016 highside_out_0_self_diagnostic_s 4;
+BA_ "CG_VarType" SG_ 2566854016 highside_out_0_self_diagnostic_s 1;
+BA_ "SystemSignalLongSymbol" SG_ 2566854016 highside_out_0_self_diagnostic_s "highside_out_0_self_diagnostic_status";
+BA_ "CanDootHidden" SG_ 2566853760 charge_unit_max_current 0;
+BA_ "CanDootGroup" SG_ 2566853760 charge_unit_max_current 0;
+BA_ "CanDootBroadcast" SG_ 2566853760 charge_unit_max_current 0;
+BA_ "GenSigStartValue" SG_ 2566853760 charge_unit_max_current 255;
+BA_ "GenSigSendType" SG_ 2566853760 charge_unit_max_current 7;
+BA_ "CG_VarType" SG_ 2566853760 charge_unit_max_current 7;
+BA_ "CanDootHidden" SG_ 2566853760 charge_unit_state 0;
+BA_ "CanDootGroup" SG_ 2566853760 charge_unit_state 0;
+BA_ "CanDootBroadcast" SG_ 2566853760 charge_unit_state 0;
+BA_ "GenSigStartValue" SG_ 2566853760 charge_unit_state 7;
+BA_ "GenSigSendType" SG_ 2566853760 charge_unit_state 7;
+BA_ "CG_VarType" SG_ 2566853760 charge_unit_state 1;
+BA_ "CanDootHidden" SG_ 2566853760 charge_unit_mode 0;
+BA_ "CanDootGroup" SG_ 2566853760 charge_unit_mode 0;
+BA_ "CanDootBroadcast" SG_ 2566853760 charge_unit_mode 0;
+BA_ "GenSigStartValue" SG_ 2566853760 charge_unit_mode 7;
+BA_ "GenSigSendType" SG_ 2566853760 charge_unit_mode 7;
+BA_ "CG_VarType" SG_ 2566853760 charge_unit_mode 1;
+BA_ "CanDootHidden" SG_ 2566853760 control_pilot_wakeup 0;
+BA_ "CanDootGroup" SG_ 2566853760 control_pilot_wakeup 0;
+BA_ "CanDootBroadcast" SG_ 2566853760 control_pilot_wakeup 0;
+BA_ "GenSigStartValue" SG_ 2566853760 control_pilot_wakeup 3;
+BA_ "GenSigSendType" SG_ 2566853760 control_pilot_wakeup 7;
+BA_ "CG_VarType" SG_ 2566853760 control_pilot_wakeup 1;
+BA_ "CanDootHidden" SG_ 2566853760 control_pilot_voltage 0;
+BA_ "CanDootGroup" SG_ 2566853760 control_pilot_voltage 0;
+BA_ "CanDootBroadcast" SG_ 2566853760 control_pilot_voltage 0;
+BA_ "GenSigStartValue" SG_ 2566853760 control_pilot_voltage 65535;
+BA_ "GenSigSendType" SG_ 2566853760 control_pilot_voltage 7;
+BA_ "CG_VarType" SG_ 2566853760 control_pilot_voltage 7;
+BA_ "CanDootHidden" SG_ 2566853760 control_pilot_duty_cycle 0;
+BA_ "CanDootGroup" SG_ 2566853760 control_pilot_duty_cycle 0;
+BA_ "CanDootBroadcast" SG_ 2566853760 control_pilot_duty_cycle 0;
+BA_ "GenSigStartValue" SG_ 2566853760 control_pilot_duty_cycle 255;
+BA_ "GenSigSendType" SG_ 2566853760 control_pilot_duty_cycle 7;
+BA_ "CG_VarType" SG_ 2566853760 control_pilot_duty_cycle 7;
+BA_ "CanDootHidden" SG_ 2566853760 control_pilot_frequency 0;
+BA_ "CanDootGroup" SG_ 2566853760 control_pilot_frequency 0;
+BA_ "CanDootBroadcast" SG_ 2566853760 control_pilot_frequency 0;
+BA_ "GenSigStartValue" SG_ 2566853760 control_pilot_frequency 65535;
+BA_ "GenSigSendType" SG_ 2566853760 control_pilot_frequency 7;
+BA_ "CG_VarType" SG_ 2566853760 control_pilot_frequency 3;
+BA_ "CanDootHidden" SG_ 2566853504 s3_switch_debounced_status 0;
+BA_ "CanDootGroup" SG_ 2566853504 s3_switch_debounced_status 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 s3_switch_debounced_status 0;
+BA_ "GenSigStartValue" SG_ 2566853504 s3_switch_debounced_status 3;
+BA_ "GenSigSendType" SG_ 2566853504 s3_switch_debounced_status 7;
+BA_ "CG_VarType" SG_ 2566853504 s3_switch_debounced_status 1;
+BA_ "CanDootHidden" SG_ 2566853504 s3_switch_status 0;
+BA_ "CanDootGroup" SG_ 2566853504 s3_switch_status 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 s3_switch_status 0;
+BA_ "GenSigStartValue" SG_ 2566853504 s3_switch_status 3;
+BA_ "GenSigSendType" SG_ 2566853504 s3_switch_status 7;
+BA_ "CG_VarType" SG_ 2566853504 s3_switch_status 1;
+BA_ "CanDootHidden" SG_ 2566853504 inlet_connection_status 0;
+BA_ "CanDootGroup" SG_ 2566853504 inlet_connection_status 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 inlet_connection_status 0;
+BA_ "GenSigStartValue" SG_ 2566853504 inlet_connection_status 3;
+BA_ "GenSigSendType" SG_ 2566853504 inlet_connection_status 7;
+BA_ "CG_VarType" SG_ 2566853504 inlet_connection_status 1;
+BA_ "CanDootHidden" SG_ 2566853504 digital_input_debounced_status 0;
+BA_ "CanDootGroup" SG_ 2566853504 digital_input_debounced_status 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 digital_input_debounced_status 0;
+BA_ "GenSigStartValue" SG_ 2566853504 digital_input_debounced_status 3;
+BA_ "GenSigSendType" SG_ 2566853504 digital_input_debounced_status 7;
+BA_ "CG_VarType" SG_ 2566853504 digital_input_debounced_status 1;
+BA_ "CanDootHidden" SG_ 2566853504 inlet_max_current 0;
+BA_ "CanDootGroup" SG_ 2566853504 inlet_max_current 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 inlet_max_current 0;
+BA_ "GenSigStartValue" SG_ 2566853504 inlet_max_current 255;
+BA_ "GenSigSendType" SG_ 2566853504 inlet_max_current 7;
+BA_ "CG_VarType" SG_ 2566853504 inlet_max_current 7;
+BA_ "CanDootHidden" SG_ 2566853504 inlet_motor_status 0;
+BA_ "CanDootGroup" SG_ 2566853504 inlet_motor_status 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 inlet_motor_status 0;
+BA_ "GenSigStartValue" SG_ 2566853504 inlet_motor_status 7;
+BA_ "GenSigSendType" SG_ 2566853504 inlet_motor_status 7;
+BA_ "CG_VarType" SG_ 2566853504 inlet_motor_status 1;
+BA_ "CanDootHidden" SG_ 2566853504 digital_input_wakeup 0;
+BA_ "CanDootGroup" SG_ 2566853504 digital_input_wakeup 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 digital_input_wakeup 0;
+BA_ "GenSigStartValue" SG_ 2566853504 digital_input_wakeup 3;
+BA_ "GenSigSendType" SG_ 2566853504 digital_input_wakeup 7;
+BA_ "CG_VarType" SG_ 2566853504 digital_input_wakeup 1;
+BA_ "CanDootHidden" SG_ 2566853504 digital_input_status 0;
+BA_ "CanDootGroup" SG_ 2566853504 digital_input_status 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 digital_input_status 0;
+BA_ "GenSigStartValue" SG_ 2566853504 digital_input_status 3;
+BA_ "GenSigSendType" SG_ 2566853504 digital_input_status 7;
+BA_ "CG_VarType" SG_ 2566853504 digital_input_status 1;
+BA_ "CanDootHidden" SG_ 2566853504 inlet_hw_variant 0;
+BA_ "CanDootGroup" SG_ 2566853504 inlet_hw_variant 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 inlet_hw_variant 0;
+BA_ "GenSigStartValue" SG_ 2566853504 inlet_hw_variant 3;
+BA_ "GenSigSendType" SG_ 2566853504 inlet_hw_variant 7;
+BA_ "CG_VarType" SG_ 2566853504 inlet_hw_variant 1;
+BA_ "CanDootHidden" SG_ 2566853504 plug_lock_output1_self_diagnosti 0;
+BA_ "CanDootGroup" SG_ 2566853504 plug_lock_output1_self_diagnosti 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 plug_lock_output1_self_diagnosti 0;
+BA_ "GenSigStartValue" SG_ 2566853504 plug_lock_output1_self_diagnosti 7;
+BA_ "GenSigSendType" SG_ 2566853504 plug_lock_output1_self_diagnosti 7;
+BA_ "CG_VarType" SG_ 2566853504 plug_lock_output1_self_diagnosti 1;
+BA_ "SystemSignalLongSymbol" SG_ 2566853504 plug_lock_output1_self_diagnosti "plug_lock_output1_self_diagnostic_status";
+BA_ "CanDootHidden" SG_ 2566853504 plug_lock_output0_self_diagnosti 0;
+BA_ "CanDootGroup" SG_ 2566853504 plug_lock_output0_self_diagnosti 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 plug_lock_output0_self_diagnosti 0;
+BA_ "GenSigStartValue" SG_ 2566853504 plug_lock_output0_self_diagnosti 7;
+BA_ "GenSigSendType" SG_ 2566853504 plug_lock_output0_self_diagnosti 7;
+BA_ "CG_VarType" SG_ 2566853504 plug_lock_output0_self_diagnosti 1;
+BA_ "SystemSignalLongSymbol" SG_ 2566853504 plug_lock_output0_self_diagnosti "plug_lock_output0_self_diagnostic_status";
+BA_ "CanDootHidden" SG_ 2566853504 plug_lock_motor_status 0;
+BA_ "CanDootGroup" SG_ 2566853504 plug_lock_motor_status 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 plug_lock_motor_status 0;
+BA_ "GenSigStartValue" SG_ 2566853504 plug_lock_motor_status 7;
+BA_ "GenSigSendType" SG_ 2566853504 plug_lock_motor_status 7;
+BA_ "CG_VarType" SG_ 2566853504 plug_lock_motor_status 1;
+BA_ "CanDootHidden" SG_ 2566853504 pos_feedback_self_diagnostic_sta 0;
+BA_ "CanDootGroup" SG_ 2566853504 pos_feedback_self_diagnostic_sta 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 pos_feedback_self_diagnostic_sta 0;
+BA_ "GenSigStartValue" SG_ 2566853504 pos_feedback_self_diagnostic_sta 7;
+BA_ "GenSigSendType" SG_ 2566853504 pos_feedback_self_diagnostic_sta 7;
+BA_ "CG_VarType" SG_ 2566853504 pos_feedback_self_diagnostic_sta 1;
+BA_ "SystemSignalLongSymbol" SG_ 2566853504 pos_feedback_self_diagnostic_sta "pos_feedback_self_diagnostic_status";
+BA_ "CanDootHidden" SG_ 2566853504 plug_present_wakeup 0;
+BA_ "CanDootGroup" SG_ 2566853504 plug_present_wakeup 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 plug_present_wakeup 0;
+BA_ "GenSigStartValue" SG_ 2566853504 plug_present_wakeup 3;
+BA_ "GenSigSendType" SG_ 2566853504 plug_present_wakeup 7;
+BA_ "CG_VarType" SG_ 2566853504 plug_present_wakeup 1;
+BA_ "CanDootHidden" SG_ 2566853504 plug_present_status 0;
+BA_ "CanDootGroup" SG_ 2566853504 plug_present_status 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 plug_present_status 0;
+BA_ "GenSigStartValue" SG_ 2566853504 plug_present_status 3;
+BA_ "GenSigSendType" SG_ 2566853504 plug_present_status 7;
+BA_ "CG_VarType" SG_ 2566853504 plug_present_status 1;
+BA_ "CanDootHidden" SG_ 2566853504 plug_present_resistance 0;
+BA_ "CanDootGroup" SG_ 2566853504 plug_present_resistance 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 plug_present_resistance 0;
+BA_ "GenSigStartValue" SG_ 2566853504 plug_present_resistance 7;
+BA_ "GenSigSendType" SG_ 2566853504 plug_present_resistance 7;
+BA_ "CG_VarType" SG_ 2566853504 plug_present_resistance 1;
+BA_ "CanDootHidden" SG_ 2566853504 plug_present_self_diagnostic_sta 0;
+BA_ "CanDootGroup" SG_ 2566853504 plug_present_self_diagnostic_sta 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 plug_present_self_diagnostic_sta 0;
+BA_ "GenSigStartValue" SG_ 2566853504 plug_present_self_diagnostic_sta 7;
+BA_ "GenSigSendType" SG_ 2566853504 plug_present_self_diagnostic_sta 7;
+BA_ "CG_VarType" SG_ 2566853504 plug_present_self_diagnostic_sta 1;
+BA_ "SystemSignalLongSymbol" SG_ 2566853504 plug_present_self_diagnostic_sta "plug_present_self_diagnostic_status";
+BA_ "CanDootHidden" SG_ 2566853504 pos_feedback_voltage 0;
+BA_ "CanDootGroup" SG_ 2566853504 pos_feedback_voltage 0;
+BA_ "CanDootBroadcast" SG_ 2566853504 pos_feedback_voltage 0;
+BA_ "GenSigStartValue" SG_ 2566853504 pos_feedback_voltage 65535;
+BA_ "GenSigSendType" SG_ 2566853504 pos_feedback_voltage 7;
+BA_ "CG_VarType" SG_ 2566853504 pos_feedback_voltage 7;
+BA_ "CanDootHidden" SG_ 2566853248 ptc_2_self_diagnostic_status 0;
+BA_ "CanDootGroup" SG_ 2566853248 ptc_2_self_diagnostic_status 0;
+BA_ "CanDootBroadcast" SG_ 2566853248 ptc_2_self_diagnostic_status 0;
+BA_ "GenSigStartValue" SG_ 2566853248 ptc_2_self_diagnostic_status 7;
+BA_ "GenSigSendType" SG_ 2566853248 ptc_2_self_diagnostic_status 7;
+BA_ "CG_VarType" SG_ 2566853248 ptc_2_self_diagnostic_status 1;
+BA_ "CanDootHidden" SG_ 2566853248 ptc_2_temperature 0;
+BA_ "CanDootGroup" SG_ 2566853248 ptc_2_temperature 0;
+BA_ "CanDootBroadcast" SG_ 2566853248 ptc_2_temperature 0;
+BA_ "GenSigStartValue" SG_ 2566853248 ptc_2_temperature 65535;
+BA_ "GenSigSendType" SG_ 2566853248 ptc_2_temperature 7;
+BA_ "CG_VarType" SG_ 2566853248 ptc_2_temperature 7;
+BA_ "CanDootHidden" SG_ 2566853248 ptc_2_resistance 0;
+BA_ "CanDootGroup" SG_ 2566853248 ptc_2_resistance 0;
+BA_ "CanDootBroadcast" SG_ 2566853248 ptc_2_resistance 0;
+BA_ "GenSigStartValue" SG_ 2566853248 ptc_2_resistance 65535;
+BA_ "GenSigSendType" SG_ 2566853248 ptc_2_resistance 7;
+BA_ "CG_VarType" SG_ 2566853248 ptc_2_resistance 7;
+BA_ "CanDootHidden" SG_ 2566853248 ptc_2_raw 0;
+BA_ "CanDootGroup" SG_ 2566853248 ptc_2_raw 0;
+BA_ "CanDootBroadcast" SG_ 2566853248 ptc_2_raw 0;
+BA_ "GenSigStartValue" SG_ 2566853248 ptc_2_raw 65535;
+BA_ "GenSigSendType" SG_ 2566853248 ptc_2_raw 7;
+BA_ "CG_VarType" SG_ 2566853248 ptc_2_raw 7;
+BA_ "CanDootHidden" SG_ 2566852992 ptc_1_self_diagnostic_status 0;
+BA_ "CanDootGroup" SG_ 2566852992 ptc_1_self_diagnostic_status 0;
+BA_ "CanDootBroadcast" SG_ 2566852992 ptc_1_self_diagnostic_status 0;
+BA_ "GenSigStartValue" SG_ 2566852992 ptc_1_self_diagnostic_status 7;
+BA_ "GenSigSendType" SG_ 2566852992 ptc_1_self_diagnostic_status 7;
+BA_ "CG_VarType" SG_ 2566852992 ptc_1_self_diagnostic_status 1;
+BA_ "CanDootHidden" SG_ 2566852992 ptc_1_temperature 0;
+BA_ "CanDootGroup" SG_ 2566852992 ptc_1_temperature 0;
+BA_ "CanDootBroadcast" SG_ 2566852992 ptc_1_temperature 0;
+BA_ "GenSigStartValue" SG_ 2566852992 ptc_1_temperature 65535;
+BA_ "GenSigSendType" SG_ 2566852992 ptc_1_temperature 7;
+BA_ "CG_VarType" SG_ 2566852992 ptc_1_temperature 7;
+BA_ "CanDootHidden" SG_ 2566852992 ptc_1_resistance 0;
+BA_ "CanDootGroup" SG_ 2566852992 ptc_1_resistance 0;
+BA_ "CanDootBroadcast" SG_ 2566852992 ptc_1_resistance 0;
+BA_ "GenSigStartValue" SG_ 2566852992 ptc_1_resistance 65535;
+BA_ "GenSigSendType" SG_ 2566852992 ptc_1_resistance 7;
+BA_ "CG_VarType" SG_ 2566852992 ptc_1_resistance 7;
+BA_ "CanDootHidden" SG_ 2566852992 ptc_1_raw 0;
+BA_ "CanDootGroup" SG_ 2566852992 ptc_1_raw 0;
+BA_ "CanDootBroadcast" SG_ 2566852992 ptc_1_raw 0;
+BA_ "GenSigStartValue" SG_ 2566852992 ptc_1_raw 65535;
+BA_ "GenSigSendType" SG_ 2566852992 ptc_1_raw 7;
+BA_ "CG_VarType" SG_ 2566852992 ptc_1_raw 7;
+BA_ "CanDootHidden" SG_ 2566852736 ptc_0_self_diagnostic_status 0;
+BA_ "CanDootGroup" SG_ 2566852736 ptc_0_self_diagnostic_status 0;
+BA_ "CanDootBroadcast" SG_ 2566852736 ptc_0_self_diagnostic_status 0;
+BA_ "GenSigStartValue" SG_ 2566852736 ptc_0_self_diagnostic_status 7;
+BA_ "GenSigSendType" SG_ 2566852736 ptc_0_self_diagnostic_status 7;
+BA_ "CG_VarType" SG_ 2566852736 ptc_0_self_diagnostic_status 1;
+BA_ "CanDootHidden" SG_ 2566852736 ptc_0_temperature 0;
+BA_ "CanDootGroup" SG_ 2566852736 ptc_0_temperature 0;
+BA_ "CanDootBroadcast" SG_ 2566852736 ptc_0_temperature 0;
+BA_ "GenSigStartValue" SG_ 2566852736 ptc_0_temperature 65535;
+BA_ "GenSigSendType" SG_ 2566852736 ptc_0_temperature 7;
+BA_ "CG_VarType" SG_ 2566852736 ptc_0_temperature 7;
+BA_ "CanDootHidden" SG_ 2566852736 ptc_0_resistance 0;
+BA_ "CanDootGroup" SG_ 2566852736 ptc_0_resistance 0;
+BA_ "CanDootBroadcast" SG_ 2566852736 ptc_0_resistance 0;
+BA_ "GenSigStartValue" SG_ 2566852736 ptc_0_resistance 65535;
+BA_ "GenSigSendType" SG_ 2566852736 ptc_0_resistance 7;
+BA_ "CG_VarType" SG_ 2566852736 ptc_0_resistance 7;
+BA_ "CanDootHidden" SG_ 2566852736 ptc_0_raw 0;
+BA_ "CanDootGroup" SG_ 2566852736 ptc_0_raw 0;
+BA_ "CanDootBroadcast" SG_ 2566852736 ptc_0_raw 0;
+BA_ "GenSigStartValue" SG_ 2566852736 ptc_0_raw 65535;
+BA_ "GenSigSendType" SG_ 2566852736 ptc_0_raw 7;
+BA_ "CG_VarType" SG_ 2566852736 ptc_0_raw 7;
+

--- a/decoder/D65/dbc/d65_brightloops.dbc
+++ b/decoder/D65/dbc/d65_brightloops.dbc
@@ -1,0 +1,4607 @@
+VERSION "ae3c"
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: Brightloop_Can_Loader ECU HVHV DCDC
+
+
+BO_ 2147487747 BL1_Node3Status: 8 HVHV
+ SG_ BPath1AcModeActivated m0 : 63|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1AcUfpError m0 : 62|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1AcOfpError m0 : 61|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath1AcFunctionMode m0 : 58|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BPath1FlgCapaError m0 : 57|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2FlgCapaError m1 : 57|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1ErrVAuxCell m0 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2ErrVAuxCell m1 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ IPath1Unbalance m0 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ IPath2Unbalance m1 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ BPath1RcpWarning m0 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2RcpWarning m1 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OcpError m0 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2OcpError m1 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OtpError m0 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2OtpError m1 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBUvpError m0 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideBUvpError m1 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAUvpError m0 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideAUvpError m1 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBOvpError m0 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideBOvpError m1 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAOvpError m0 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideAOvpError m1 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1Requested m0 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2Requested m1 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath1CurrentSideSelected m0 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2CurrentSideSelected m1 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1VoltageSideSelected m0 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2VoltageSideSelected m1 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1State m0 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NPath2State m1 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NMultiplexer M : 29|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BXcpError : 28|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NCellHwErrorFlags : 20|8@1+ (1,0) [0|255] ""  ECU
+ SG_ BSyncInputSignal : 18|1@1+ (1,0) [0|0] ""  ECU
+ SG_ BSyncRequested : 17|1@1+ (1,0) [0|0] ""  ECU
+ SG_ BInternalTemperatureError : 16|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BConfigSettingsError : 15|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxSupplyError : 14|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BCanTimeoutError : 13|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxIsoEnabled : 12|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeEnabled : 11|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BFaultSignal : 10|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BEnableSignal : 9|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeStatus : 8|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncStatus : 7|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BReadConfigAndSettingsRequested : 6|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSwResetModuleRequested : 5|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeRequested : 4|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NModuleState : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147489411 BL1_Node3Setpoints2Value: 6 HVHV
+ SG_ IqPath1AcLimitLo m9 : 38|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IqPath1AcLimitHi m9 : 28|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ PPath2LimitLo m2 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ IqPath1AcSetpoint m13 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IdPath1AcLimitLo m9 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IdPath1AcSetpoint m13 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IdPath1AcLimitHi m9 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ PPath2LimitHi m2 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ NMultiplexer M : 0|5@1+ (1,0) [0|31] ""  ECU
+
+BO_ 2147489347 BL1_Node3Setpoints1Value: 7 HVHV
+ SG_ NPath1AcFunctionMode m9 : 50|3@1+ (1,0) [0|7] ""  ECU
+ SG_ NPath2CurrentSideSelected m2 : 42|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2VoltageSideSelected m2 : 40|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1AcFrequencySetpoint m9 : 38|12@1+ (0.25,0) [0|1023.75] "Hz"  ECU
+ SG_ IPath2LimitLo m2 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VqPath1AcSetpoint m9 : 27|11@1+ (1,-1024) [-1024|1023] "V"  ECU
+ SG_ VdPath1AcSetpoint m9 : 16|11@1+ (1,-1024) [-1024|1023] "V"  ECU
+ SG_ IPath2LimitHi m2 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VDcPath1AcSetpoint m9 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPath2Setpoint m2 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ NMultiplexer M : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147488771 BL1_Node3PortB1Value: 7 HVHV
+ SG_ NPortB1OverloadCount : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortB1Average : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortB1Average : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Max : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Min : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147487875 BL1_Node3PortA1Value: 8 HVHV
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IqPhAPortA1RMS m3 : 42|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IqPortA1RMS m1 : 36|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ NFrequencyPortA1 m2 : 36|16@1+ (0.0125,0) [0|819.1875] "Hz"  ECU
+ SG_ IqPhCPortA1RMS m4 : 36|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IdPhAPortA1RMS m3 : 30|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IdPortA1RMS m1 : 24|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ VphCPortA1Peak m2 : 24|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ IdPhCPortA1RMS m4 : 24|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IphCPortA1Peak m3 : 20|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ VqPortA1RMS m1 : 12|12@1+ (0.5,-1024) [-1024|1023.5] "V"  ECU
+ SG_ VphBPortA1Peak m2 : 12|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ IqPhBPortA1RMS m4 : 12|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IphBPortA1Peak m3 : 10|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ VdPortA1RMS m1 : 0|12@1+ (0.5,-1024) [-1024|1023.5] "V"  ECU
+ SG_ VphAPortA1Peak m2 : 0|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ IphAPortA1Peak m3 : 0|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ IdPhBPortA1RMS m4 : 0|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+
+BO_ 2147487939 BL1_Node3PortA2Value: 8 HVHV
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ NPortA2OverloadCount m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortA2Average m0 : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortA2Average m0 : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA2Max m0 : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA2Min m0 : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147488387 BL1_Node3InternalPath1Value: 5 HVHV
+ SG_ VPath1FlgCapaLvl2Max : 30|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl2Min : 20|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl1Max : 10|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl1Min : 0|10@1+ (2,0) [0|2046] "V"  ECU
+
+BO_ 2147488451 BL1_Node3InternalPath2Value: 5 HVHV
+ SG_ VPath2FlgCapaLvl2Max : 30|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl2Min : 20|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl1Max : 10|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl1Min : 0|10@1+ (2,0) [0|2046] "V"  ECU
+
+BO_ 2147487811 BL1_Node3GlobalValue: 7 HVHV
+ SG_ NCellOtpErrorFlags m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ TCell3N2 m1 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAuxCell4N2 m9 : 48|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell3N1 m1 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TInternal m3 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NBootloaderId m4 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NApplicationId m5 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell3N2 m9 : 40|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NSyncNodeCount m0 : 39|5@1+ (1,0) [0|31] ""  ECU
+ SG_ NSyncNodeRank m0 : 34|5@1+ (1,0) [0|31] ""  ECU
+ SG_ NReleaseMode m0 : 32|2@1+ (1,0) [0|3] ""  ECU
+ SG_ TCell2N2 m1 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NCellVAuxErrorFlags m7 : 32|8@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell4N1 m8 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N2 m9 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell4N3 m10 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell4N3 m11 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux3Measured m0 : 24|8@1+ (0.01,0) [0|2.55] "V"  ECU
+ SG_ TCell2N1 m1 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NConfigCrc m4 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSettingsCrc m5 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSerial m6 : 24|32@1+ (1,0) [0|4294967295] ""  ECU
+ SG_ VAuxCell3N1 m8 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N2 m9 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell3N3 m10 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell3N3 m11 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux2Measured m0 : 16|8@1+ (0.02,0) [0|5.1] "V"  ECU
+ SG_ TCell1N2 m1 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N2 m2 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NCellXcpErrorFlags m7 : 16|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell2N1 m8 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N3 m10 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell2N3 m11 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux1Measured m0 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell1N1 m1 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N1 m2 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NConfigVersion m4 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSettingsVersion m5 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NChecksum m6 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NCellSwOcpErrorFlags m7 : 8|8@1+ (1,0) [0|255] ""  ECU
+ SG_ VAuxCell1N1 m8 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N3 m10 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell1N3 m11 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NMultiplexer M : 0|8@1+ (1,0) [0|255] ""  ECU
+
+BO_ 2147489475 BL1_Node3ConfigAndSettingsValue: 4 HVHV
+ SG_ NParameterValue : 16|16@1+ (1,0) [0|0] ""  ECU
+ SG_ NParameterIndex : 4|12@1+ (1,0) [0|0] ""  ECU
+ SG_ NReadZoneSelect : 0|4@1+ (1,0) [0|0] ""  ECU
+
+BO_ 2147489410 BL1_Node2Setpoints2Value: 6 HVHV
+ SG_ PPath2LimitLo m2 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ PPath2LimitHi m2 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ NMultiplexer M : 0|5@1+ (1,0) [0|31] ""  ECU
+
+BO_ 2147489346 BL1_Node2Setpoints1Value: 7 HVHV
+ SG_ NPath2CurrentSideSelected m2 : 42|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2VoltageSideSelected m2 : 40|2@1+ (1,0) [0|3] ""  ECU
+ SG_ IPath2LimitLo m2 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ IPath2LimitHi m2 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VPath2Setpoint m2 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ NMultiplexer M : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147488450 BL1_Node2InternalPath2Value: 5 HVHV
+ SG_ VPath2FlgCapaLvl2Max : 30|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl2Min : 20|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl1Max : 10|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl1Min : 0|10@1+ (2,0) [0|2046] "V"  ECU
+
+BO_ 2147488770 BL1_Node2PortB1Value: 7 HVHV
+ SG_ NPortB1OverloadCount : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortB1Average : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortB1Average : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Max : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Min : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147488127 ACUHV_SetpointsRead: 2 ECU
+ SG_ NCrc : 8|8@1+ (1,0) [0|255] ""  HVHV
+ SG_ NPathSelect : 4|4@1+ (1,0) [0|15] ""  HVHV
+ SG_ BPathAcCurrentSetpointSelect : 3|1@1+ (1,0) [0|1] ""  HVHV
+ SG_ BReadSetpointRequest : 0|1@1+ (1,0) [0|1] ""  HVHV
+
+BO_ 2147488063 ACUHV_AcknowledgeErrors: 3 ECU
+ SG_ NCrc : 16|8@1+ (1,0) [0|255] ""  HVHV
+ SG_ NModuleSelect M : 10|6@1+ (1,0) [0|63] ""  HVHV
+ SG_ BAckErrorsModuleRequest : 8|1@1+ (1,0) [0|1] ""  HVHV
+ SG_ BAckErrorsPath2Request : 1|1@1+ (1,0) [0|1] ""  HVHV
+ SG_ BAckErrorsPath1Request : 0|1@1+ (1,0) [0|1] ""  HVHV
+
+BO_ 2147487999 ACUHV_DcSetpoints2Write: 7 ECU
+ SG_ NCrc : 48|8@1+ (1,0) [0|255] ""  HVHV
+ SG_ NModuleSelect M : 40|6@1+ (1,0) [0|63] ""  HVHV
+ SG_ BL1_PPath2LimitLo m2 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  HVHV
+ SG_ BL2_PPath2LimitLo m2 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  HVHV
+ SG_ BL3_PPath2LimitLo m2 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  HVHV
+ SG_ BL4_PPath2LimitLo m2 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  HVHV
+ SG_ BL1_PPath2LimitHi m2 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  HVHV
+ SG_ BL2_PPath2LimitHi m2 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  HVHV
+ SG_ BL3_PPath2LimitHi m2 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  HVHV
+ SG_ BL4_PPath2LimitHi m2 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  HVHV
+ SG_ BL1_NMultiplexer m1M : 0|4@1+ (1,0) [0|15] ""  HVHV
+ SG_ BL2_NMultiplexer m2M : 0|4@1+ (1,0) [0|15] ""  HVHV
+ SG_ BL3_NMultiplexer m3M : 0|4@1+ (1,0) [0|15] ""  HVHV
+ SG_ BL4_NMultiplexer m4M : 0|4@1+ (1,0) [0|15] ""  HVHV
+
+BO_ 2147488191 ACUHV_AcSetpoints1Write: 8 ECU
+ SG_ NCrc : 56|8@1+ (1,0) [0|255] ""  HVHV
+ SG_ NModuleSelect M : 50|6@1+ (1,0) [0|63] ""  HVHV
+ SG_ BL1_NPath1AcFrequencySetpoint m1 : 38|12@1+ (0.25,0) [0|1023.75] "Hz"  HVHV
+ SG_ BL2_NPath1AcFrequencySetpoint m1 : 38|12@1+ (0.25,0) [0|1023.75] "Hz"  HVHV
+ SG_ BL3_NPath1AcFrequencySetpoint m1 : 38|12@1+ (0.25,0) [0|1023.75] "Hz"  HVHV
+ SG_ BL4_NPath1AcFrequencySetpoint m1 : 38|12@1+ (0.25,0) [0|1023.75] "Hz"  HVHV
+ SG_ BL1_VqPath1AcSetpoint m1 : 27|11@1+ (1,-1024) [-1024|1023] "V"  HVHV
+ SG_ BL2_VqPath1AcSetpoint m1 : 27|11@1+ (1,-1024) [-1024|1023] "V"  HVHV
+ SG_ BL3_VqPath1AcSetpoint m1 : 27|11@1+ (1,-1024) [-1024|1023] "V"  HVHV
+ SG_ BL4_VqPath1AcSetpoint m1 : 27|11@1+ (1,-1024) [-1024|1023] "V"  HVHV
+ SG_ BL1_VdPath1AcSetpoint m1 : 16|11@1+ (1,-1024) [-1024|1023] "V"  HVHV
+ SG_ BL2_VdPath1AcSetpoint m1 : 16|11@1+ (1,-1024) [-1024|1023] "V"  HVHV
+ SG_ BL3_VdPath1AcSetpoint m1 : 16|11@1+ (1,-1024) [-1024|1023] "V"  HVHV
+ SG_ BL4_VdPath1AcSetpoint m1 : 16|11@1+ (1,-1024) [-1024|1023] "V"  HVHV
+ SG_ BL1_VDcPath1AcSetpoint m1 : 4|12@1+ (1,0) [0|4095] "V"  HVHV
+ SG_ BL2_VDcPath1AcSetpoint m1 : 4|12@1+ (1,0) [0|4095] "V"  HVHV
+ SG_ BL3_VDcPath1AcSetpoint m1 : 4|12@1+ (1,0) [0|4095] "V"  HVHV
+ SG_ BL4_VDcPath1AcSetpoint m1 : 4|12@1+ (1,0) [0|4095] "V"  HVHV
+ SG_ BL1_NMultiplexer m1M : 0|4@1+ (1,0) [0|15] ""  HVHV
+ SG_ BL2_NMultiplexer m2M : 0|4@1+ (1,0) [0|15] ""  HVHV
+ SG_ BL3_NMultiplexer m3M : 0|4@1+ (1,0) [0|15] ""  HVHV
+ SG_ BL4_NMultiplexer m4M : 0|4@1+ (1,0) [0|15] ""  HVHV
+
+BO_ 2147488255 ACUHV_AcSetpoints2Write: 8 ECU
+ SG_ NCrc : 56|8@1+ (1,0) [0|255] ""  HVHV
+ SG_ NModuleSelect M : 48|6@1+ (1,0) [0|63] ""  HVHV
+ SG_ BL1_IqPath1AcLimitLo m1 : 38|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL2_IqPath1AcLimitLo m1 : 38|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL3_IqPath1AcLimitLo m1 : 38|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL4_IqPath1AcLimitLo m1 : 38|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL1_IqPath1AcLimitHi m1 : 28|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL2_IqPath1AcLimitHi m1 : 28|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL3_IqPath1AcLimitHi m1 : 28|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL4_IqPath1AcLimitHi m1 : 28|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL1_IqPath1AcSetpoint m5 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL1_IdPath1AcLimitLo m1 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL2_IdPath1AcLimitLo m1 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL2_IqPath1AcSetpoint m5 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL3_IqPath1AcSetpoint m5 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL3_IdPath1AcLimitLo m1 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL4_IqPath1AcSetpoint m5 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL4_IdPath1AcLimitLo m1 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL1_IdPath1AcSetpoint m5 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL1_IdPath1AcLimitHi m1 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL2_IdPath1AcLimitHi m1 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL2_IdPath1AcSetpoint m5 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL3_IdPath1AcSetpoint m5 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL3_IdPath1AcLimitHi m1 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL4_IdPath1AcSetpoint m5 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL4_IdPath1AcLimitHi m1 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  HVHV
+ SG_ BL1_NPath1AcFunctionMode m1 : 4|3@1+ (1,0) [0|7] ""  HVHV
+ SG_ BL2_NPath1AcFunctionMode m1 : 4|3@1+ (1,0) [0|7] ""  HVHV
+ SG_ BL3_NPath1AcFunctionMode m1 : 4|3@1+ (1,0) [0|7] ""  HVHV
+ SG_ BL4_NPath1AcFunctionMode m1 : 4|3@1+ (1,0) [0|7] ""  HVHV
+ SG_ BL1_NMultiplexer m1M : 0|4@1+ (1,0) [0|15] ""  HVHV
+ SG_ BL2_NMultiplexer m2M : 0|4@1+ (1,0) [0|15] ""  HVHV
+ SG_ BL3_NMultiplexer m3M : 0|4@1+ (1,0) [0|15] ""  HVHV
+ SG_ BL4_NMultiplexer m4M : 0|4@1+ (1,0) [0|15] ""  HVHV
+
+BO_ 2147487938 BL1_Node2PortA2Value: 8 HVHV
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ NPortA2OverloadCount m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortA2Average m0 : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortA2Average m0 : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA2Max m0 : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA2Min m0 : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147489474 BL1_Node2ConfigAndSettingsValue: 4 HVHV
+ SG_ NParameterValue : 16|16@1+ (1,0) [0|0] ""  ECU
+ SG_ NParameterIndex : 4|12@1+ (1,0) [0|0] ""  ECU
+ SG_ NReadZoneSelect : 0|4@1+ (1,0) [0|0] ""  ECU
+
+BO_ 2147487810 BL1_Node2GlobalValue: 7 HVHV
+ SG_ NCellOtpErrorFlags m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ TCell3N2 m1 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAuxCell4N2 m9 : 48|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell3N1 m1 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TInternal m3 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NBootloaderId m4 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NApplicationId m5 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell3N2 m9 : 40|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NSyncNodeCount m0 : 39|5@1+ (1,0) [0|31] ""  ECU
+ SG_ NSyncNodeRank m0 : 34|5@1+ (1,0) [0|31] ""  ECU
+ SG_ NReleaseMode m0 : 32|2@1+ (1,0) [0|3] ""  ECU
+ SG_ TCell2N2 m1 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NCellVAuxErrorFlags m7 : 32|8@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell4N1 m8 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N2 m9 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell4N3 m10 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell4N3 m11 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux3Measured m0 : 24|8@1+ (0.01,0) [0|2.55] "V"  ECU
+ SG_ TCell2N1 m1 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NConfigCrc m4 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSettingsCrc m5 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSerial m6 : 24|32@1+ (1,0) [0|4294967295] ""  ECU
+ SG_ VAuxCell3N1 m8 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N2 m9 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell3N3 m10 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell3N3 m11 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux2Measured m0 : 16|8@1+ (0.02,0) [0|5.1] "V"  ECU
+ SG_ TCell1N2 m1 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N2 m2 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NCellXcpErrorFlags m7 : 16|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell2N1 m8 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N3 m10 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell2N3 m11 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux1Measured m0 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell1N1 m1 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N1 m2 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NConfigVersion m4 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSettingsVersion m5 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NChecksum m6 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NCellSwOcpErrorFlags m7 : 8|8@1+ (1,0) [0|255] ""  ECU
+ SG_ VAuxCell1N1 m8 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N3 m10 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell1N3 m11 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NMultiplexer M : 0|8@1+ (1,0) [0|255] ""  ECU
+
+BO_ 2147487746 BL1_Node2Status: 8 HVHV
+ SG_ BPath2FlgCapaError m1 : 57|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2ErrVAuxCell m1 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ IPath2Unbalance m1 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ BPath2RcpWarning m1 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2OcpError m1 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2OtpError m1 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideBUvpError m1 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideAUvpError m1 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideBOvpError m1 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideAOvpError m1 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2Requested m1 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath2CurrentSideSelected m1 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2VoltageSideSelected m1 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2State m1 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NMultiplexer M : 29|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BXcpError : 28|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NCellHwErrorFlags : 20|8@1+ (1,0) [0|255] ""  ECU
+ SG_ BSyncInputSignal : 18|1@1+ (1,0) [0|0] ""  ECU
+ SG_ BSyncRequested : 17|1@1+ (1,0) [0|0] ""  ECU
+ SG_ BInternalTemperatureError : 16|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BConfigSettingsError : 15|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxSupplyError : 14|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BCanTimeoutError : 13|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxIsoEnabled : 12|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeEnabled : 11|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BFaultSignal : 10|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BEnableSignal : 9|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeStatus : 8|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncStatus : 7|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BReadConfigAndSettingsRequested : 6|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSwResetModuleRequested : 5|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeRequested : 4|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NModuleState : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147487935 ACUHV_DcSetpoints1Write: 8 ECU
+ SG_ NCrc : 56|8@1+ (1,0) [0|255] ""  HVHV
+ SG_ NModuleSelect M : 48|6@1+ (1,0) [0|63] ""  HVHV
+ SG_ BL1_NPath2CurrentSideSelect m2 : 42|2@1+ (1,0) [0|3] ""  HVHV
+ SG_ BL2_NPath2CurrentSideSelect m2 : 42|2@1+ (1,0) [0|3] ""  HVHV
+ SG_ BL3_NPath2CurrentSideSelect m2 : 42|2@1+ (1,0) [0|3] ""  HVHV
+ SG_ BL4_NPath2CurrentSideSelect m2 : 42|2@1+ (1,0) [0|3] ""  HVHV
+ SG_ BL1_NPath2VoltageSideSelect m2 : 40|2@1+ (1,0) [0|3] ""  HVHV
+ SG_ BL2_NPath2VoltageSideSelect m2 : 40|2@1+ (1,0) [0|3] ""  HVHV
+ SG_ BL3_NPath2VoltageSideSelect m2 : 40|2@1+ (1,0) [0|3] ""  HVHV
+ SG_ BL4_NPath2VoltageSideSelect m2 : 40|2@1+ (1,0) [0|3] ""  HVHV
+ SG_ BL1_IPath2LimitLo m2 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  HVHV
+ SG_ BL2_IPath2LimitLo m2 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  HVHV
+ SG_ BL3_IPath2LimitLo m2 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  HVHV
+ SG_ BL4_IPath2LimitLo m2 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  HVHV
+ SG_ BL1_IPath2LimitHi m2 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  HVHV
+ SG_ BL2_IPath2LimitHi m2 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  HVHV
+ SG_ BL3_IPath2LimitHi m2 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  HVHV
+ SG_ BL4_IPath2LimitHi m2 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  HVHV
+ SG_ BL1_VPath2Setpoint m2 : 4|12@1+ (1,0) [0|4095] "V"  HVHV
+ SG_ BL2_VPath2Setpoint m2 : 4|12@1+ (1,0) [0|4095] "V"  HVHV
+ SG_ BL3_VPath2Setpoint m2 : 4|12@1+ (1,0) [0|4095] "V"  HVHV
+ SG_ BL4_VPath2Setpoint m2 : 4|12@1+ (1,0) [0|4095] "V"  HVHV
+ SG_ BL1_NMultiplexer m1M : 0|4@1+ (1,0) [0|15] ""  HVHV
+ SG_ BL2_NMultiplexer m2M : 0|4@1+ (1,0) [0|15] ""  HVHV
+ SG_ BL3_NMultiplexer m3M : 0|4@1+ (1,0) [0|15] ""  HVHV
+ SG_ BL4_NMultiplexer m4M : 0|4@1+ (1,0) [0|15] ""  HVHV
+
+BO_ 2147487807 ACUHV_Control: 4 ECU
+ SG_ NCrc : 24|8@1+ (1,0) [0|255] ""  HVHV
+ SG_ NModuleSelect M : 18|6@1+ (1,0) [0|63] ""  HVHV
+ SG_ BSyncRequest : 15|1@1+ (1,0) [0|1] ""  HVHV
+ SG_ BReadConfigAndSettingsRequest : 14|1@1+ (1,0) [0|1] ""  HVHV
+ SG_ BSwResetModuleRequest : 13|1@1+ (1,0) [0|1] ""  HVHV
+ SG_ BSafetyDischargeRequest : 12|1@1+ (1,0) [0|1] ""  HVHV
+ SG_ BPath2Request : 5|1@1+ (1,0) [0|1] ""  HVHV
+ SG_ BPath1Request : 4|1@1+ (1,0) [0|1] ""  HVHV
+ SG_ NCounter : 0|4@1+ (1,0) [0|15] ""  HVHV
+
+BO_ 2147487749 BL2_Node5Status: 8 HVHV
+ SG_ BPath1AcModeActivated m0 : 63|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1AcUfpError m0 : 62|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1AcOfpError m0 : 61|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath1AcFunctionMode m0 : 58|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BPath2FlgCapaError m1 : 57|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1FlgCapaError m0 : 57|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2ErrVAuxCell m1 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1ErrVAuxCell m0 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ IPath2Unbalance m1 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ IPath1Unbalance m0 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ BPath2RcpWarning m1 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1RcpWarning m0 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2OcpError m1 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OcpError m0 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2OtpError m1 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OtpError m0 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideBUvpError m1 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBUvpError m0 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideAUvpError m1 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAUvpError m0 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideBOvpError m1 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBOvpError m0 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideAOvpError m1 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAOvpError m0 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2Requested m1 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1Requested m0 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath2CurrentSideSelected m1 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1CurrentSideSelected m0 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2VoltageSideSelected m1 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1VoltageSideSelected m0 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2State m1 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NPath1State m0 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NMultiplexer M : 29|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BXcpError : 28|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NCellHwErrorFlags : 20|8@1+ (1,0) [0|255] ""  ECU
+ SG_ BSyncInputSignal : 18|1@1+ (1,0) [0|0] ""  ECU
+ SG_ BSyncRequested : 17|1@1+ (1,0) [0|0] ""  ECU
+ SG_ BInternalTemperatureError : 16|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BConfigSettingsError : 15|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxSupplyError : 14|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BCanTimeoutError : 13|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxIsoEnabled : 12|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeEnabled : 11|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BFaultSignal : 10|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BEnableSignal : 9|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeStatus : 8|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncStatus : 7|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BReadConfigAndSettingsRequested : 6|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSwResetModuleRequested : 5|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeRequested : 4|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NModuleState : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147489413 BL2_Node5Setpoints2Value: 6 HVHV
+ SG_ IqPath1AcLimitLo m9 : 38|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IqPath1AcLimitHi m9 : 28|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ PPath2LimitLo m2 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ IdPath1AcLimitLo m9 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IqPath1AcSetpoint m13 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ PPath2LimitHi m2 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ IdPath1AcLimitHi m9 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IdPath1AcSetpoint m13 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ NMultiplexer M : 0|5@1+ (1,0) [0|31] ""  ECU
+
+BO_ 2147489349 BL2_Node5Setpoints1Value: 7 HVHV
+ SG_ NPath1AcFunctionMode m9 : 50|3@1+ (1,0) [0|7] ""  ECU
+ SG_ NPath2CurrentSideSelected m2 : 42|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2VoltageSideSelected m2 : 40|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1AcFrequencySetpoint m9 : 38|12@1+ (0.25,0) [0|1023.75] "Hz"  ECU
+ SG_ IPath2LimitLo m2 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VqPath1AcSetpoint m9 : 27|11@1+ (1,-1024) [-1024|1023] "V"  ECU
+ SG_ IPath2LimitHi m2 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VdPath1AcSetpoint m9 : 16|11@1+ (1,-1024) [-1024|1023] "V"  ECU
+ SG_ VPath2Setpoint m2 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VDcPath1AcSetpoint m9 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ NMultiplexer M : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147488773 BL2_Node5PortB1Value: 7 HVHV
+ SG_ NPortB1OverloadCount : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortB1Average : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortB1Average : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Max : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Min : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147487877 BL2_Node5PortA1Value: 8 HVHV
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IqPhAPortA1RMS m3 : 42|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IqPhCPortA1RMS m4 : 36|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ NFrequencyPortA1 m2 : 36|16@1+ (0.0125,0) [0|819.1875] "Hz"  ECU
+ SG_ IqPortA1RMS m1 : 36|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IdPhAPortA1RMS m3 : 30|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IdPhCPortA1RMS m4 : 24|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ VphCPortA1Peak m2 : 24|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ IdPortA1RMS m1 : 24|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IphCPortA1Peak m3 : 20|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ IqPhBPortA1RMS m4 : 12|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ VphBPortA1Peak m2 : 12|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ VqPortA1RMS m1 : 12|12@1+ (0.5,-1024) [-1024|1023.5] "V"  ECU
+ SG_ IphBPortA1Peak m3 : 10|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ IdPhBPortA1RMS m4 : 0|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IphAPortA1Peak m3 : 0|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ VphAPortA1Peak m2 : 0|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ VdPortA1RMS m1 : 0|12@1+ (0.5,-1024) [-1024|1023.5] "V"  ECU
+
+BO_ 2147487941 BL2_Node5PortA2Value: 8 HVHV
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ NPortA2OverloadCount m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortA2Average m0 : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortA2Average m0 : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA2Max m0 : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA2Min m0 : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147488389 BL2_Node5InternalPath1Value: 5 HVHV
+ SG_ VPath1FlgCapaLvl2Max : 30|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl2Min : 20|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl1Max : 10|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl1Min : 0|10@1+ (2,0) [0|2046] "V"  ECU
+
+BO_ 2147488453 BL2_Node5InternalPath2Value: 5 HVHV
+ SG_ VPath2FlgCapaLvl2Max : 30|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl2Min : 20|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl1Max : 10|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl1Min : 0|10@1+ (2,0) [0|2046] "V"  ECU
+
+BO_ 2147487813 BL2_Node5GlobalValue: 7 HVHV
+ SG_ VAuxCell4N2 m9 : 48|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell3N2 m1 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NCellOtpErrorFlags m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ VAuxCell3N2 m9 : 40|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NApplicationId m5 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NBootloaderId m4 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TInternal m3 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell3N1 m1 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NSyncNodeCount m0 : 39|5@1+ (1,0) [0|31] ""  ECU
+ SG_ NSyncNodeRank m0 : 34|5@1+ (1,0) [0|31] ""  ECU
+ SG_ TCell4N3 m11 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAuxCell4N3 m10 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N2 m9 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell4N1 m8 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NCellVAuxErrorFlags m7 : 32|8@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell2N2 m1 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NReleaseMode m0 : 32|2@1+ (1,0) [0|3] ""  ECU
+ SG_ TCell3N3 m11 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAuxCell3N3 m10 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N2 m9 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell3N1 m8 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NSerial m6 : 24|32@1+ (1,0) [0|4294967295] ""  ECU
+ SG_ NSettingsCrc m5 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NConfigCrc m4 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell2N1 m1 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux3Measured m0 : 24|8@1+ (0.01,0) [0|2.55] "V"  ECU
+ SG_ TCell2N3 m11 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAuxCell2N3 m10 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N1 m8 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NCellXcpErrorFlags m7 : 16|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell4N2 m2 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell1N2 m1 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux2Measured m0 : 16|8@1+ (0.02,0) [0|5.1] "V"  ECU
+ SG_ TCell1N3 m11 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAuxCell1N3 m10 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N1 m8 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NCellSwOcpErrorFlags m7 : 8|8@1+ (1,0) [0|255] ""  ECU
+ SG_ NChecksum m6 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSettingsVersion m5 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NConfigVersion m4 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell4N1 m2 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell1N1 m1 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux1Measured m0 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NMultiplexer M : 0|8@1+ (1,0) [0|255] ""  ECU
+
+BO_ 2147489477 BL2_Node5ConfigAndSettingsValue: 4 HVHV
+ SG_ NParameterValue : 16|16@1+ (1,0) [0|0] ""  ECU
+ SG_ NParameterIndex : 4|12@1+ (1,0) [0|0] ""  ECU
+ SG_ NReadZoneSelect : 0|4@1+ (1,0) [0|0] ""  ECU
+
+BO_ 2147489412 BL2_Node4Setpoints2Value: 6 HVHV
+ SG_ IqPath1AcLimitLo m9 : 38|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IqPath1AcLimitHi m9 : 28|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ PPath2LimitLo m2 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ IdPath1AcLimitLo m9 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IqPath1AcSetpoint m13 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ PPath2LimitHi m2 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ IdPath1AcLimitHi m9 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IdPath1AcSetpoint m13 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ NMultiplexer M : 0|5@1+ (1,0) [0|31] ""  ECU
+
+BO_ 2147489348 BL2_Node4Setpoints1Value: 7 HVHV
+ SG_ NPath1AcFunctionMode m9 : 50|3@1+ (1,0) [0|7] ""  ECU
+ SG_ NPath2CurrentSideSelected m2 : 42|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2VoltageSideSelected m2 : 40|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1AcFrequencySetpoint m9 : 38|12@1+ (0.25,0) [0|1023.75] "Hz"  ECU
+ SG_ IPath2LimitLo m2 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VqPath1AcSetpoint m9 : 27|11@1+ (1,-1024) [-1024|1023] "V"  ECU
+ SG_ IPath2LimitHi m2 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VdPath1AcSetpoint m9 : 16|11@1+ (1,-1024) [-1024|1023] "V"  ECU
+ SG_ VPath2Setpoint m2 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VDcPath1AcSetpoint m9 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ NMultiplexer M : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147488388 BL2_Node4InternalPath1Value: 5 HVHV
+ SG_ VPath1FlgCapaLvl2Max : 30|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl2Min : 20|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl1Max : 10|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl1Min : 0|10@1+ (2,0) [0|2046] "V"  ECU
+
+BO_ 2147488452 BL2_Node4InternalPath2Value: 5 HVHV
+ SG_ VPath2FlgCapaLvl2Max : 30|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl2Min : 20|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl1Max : 10|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl1Min : 0|10@1+ (2,0) [0|2046] "V"  ECU
+
+BO_ 2147488772 BL2_Node4PortB1Value: 7 HVHV
+ SG_ NPortB1OverloadCount : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortB1Average : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortB1Average : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Max : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Min : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147487876 BL2_Node4PortA1Value: 8 HVHV
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IqPhAPortA1RMS m3 : 42|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IqPhCPortA1RMS m4 : 36|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ NFrequencyPortA1 m2 : 36|16@1+ (0.0125,0) [0|819.1875] "Hz"  ECU
+ SG_ IqPortA1RMS m1 : 36|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IdPhAPortA1RMS m3 : 30|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IdPhCPortA1RMS m4 : 24|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ VphCPortA1Peak m2 : 24|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ IdPortA1RMS m1 : 24|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IphCPortA1Peak m3 : 20|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ IqPhBPortA1RMS m4 : 12|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ VphBPortA1Peak m2 : 12|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ VqPortA1RMS m1 : 12|12@1+ (0.5,-1024) [-1024|1023.5] "V"  ECU
+ SG_ IphBPortA1Peak m3 : 10|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ IdPhBPortA1RMS m4 : 0|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IphAPortA1Peak m3 : 0|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ VphAPortA1Peak m2 : 0|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ VdPortA1RMS m1 : 0|12@1+ (0.5,-1024) [-1024|1023.5] "V"  ECU
+
+BO_ 2147487940 BL2_Node4PortA2Value: 8 HVHV
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ NPortA2OverloadCount m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortA2Average m0 : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortA2Average m0 : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA2Max m0 : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA2Min m0 : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147489476 BL2_Node4ConfigAndSettingsValue: 4 HVHV
+ SG_ NParameterValue : 16|16@1+ (1,0) [0|0] ""  ECU
+ SG_ NParameterIndex : 4|12@1+ (1,0) [0|0] ""  ECU
+ SG_ NReadZoneSelect : 0|4@1+ (1,0) [0|0] ""  ECU
+
+BO_ 2147487812 BL2_Node4GlobalValue: 7 HVHV
+ SG_ VAuxCell4N2 m9 : 48|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell3N2 m1 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NCellOtpErrorFlags m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ VAuxCell3N2 m9 : 40|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NApplicationId m5 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NBootloaderId m4 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TInternal m3 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell3N1 m1 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NSyncNodeCount m0 : 39|5@1+ (1,0) [0|31] ""  ECU
+ SG_ NSyncNodeRank m0 : 34|5@1+ (1,0) [0|31] ""  ECU
+ SG_ TCell4N3 m11 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAuxCell4N3 m10 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N2 m9 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell4N1 m8 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NCellVAuxErrorFlags m7 : 32|8@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell2N2 m1 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NReleaseMode m0 : 32|2@1+ (1,0) [0|3] ""  ECU
+ SG_ TCell3N3 m11 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAuxCell3N3 m10 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N2 m9 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell3N1 m8 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NSerial m6 : 24|32@1+ (1,0) [0|4294967295] ""  ECU
+ SG_ NSettingsCrc m5 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NConfigCrc m4 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell2N1 m1 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux3Measured m0 : 24|8@1+ (0.01,0) [0|2.55] "V"  ECU
+ SG_ TCell2N3 m11 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAuxCell2N3 m10 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N1 m8 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NCellXcpErrorFlags m7 : 16|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell4N2 m2 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell1N2 m1 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux2Measured m0 : 16|8@1+ (0.02,0) [0|5.1] "V"  ECU
+ SG_ TCell1N3 m11 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAuxCell1N3 m10 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N1 m8 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NCellSwOcpErrorFlags m7 : 8|8@1+ (1,0) [0|255] ""  ECU
+ SG_ NChecksum m6 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSettingsVersion m5 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NConfigVersion m4 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell4N1 m2 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell1N1 m1 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux1Measured m0 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NMultiplexer M : 0|8@1+ (1,0) [0|255] ""  ECU
+
+BO_ 2147487748 BL2_Node4Status: 8 HVHV
+ SG_ BPath1AcModeActivated m0 : 63|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1AcUfpError m0 : 62|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1AcOfpError m0 : 61|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath1AcFunctionMode m0 : 58|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BPath2FlgCapaError m1 : 57|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1FlgCapaError m0 : 57|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2ErrVAuxCell m1 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1ErrVAuxCell m0 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ IPath2Unbalance m1 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ IPath1Unbalance m0 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ BPath2RcpWarning m1 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1RcpWarning m0 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2OcpError m1 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OcpError m0 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2OtpError m1 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OtpError m0 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideBUvpError m1 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBUvpError m0 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideAUvpError m1 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAUvpError m0 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideBOvpError m1 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBOvpError m0 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideAOvpError m1 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAOvpError m0 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2Requested m1 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1Requested m0 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath2CurrentSideSelected m1 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1CurrentSideSelected m0 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2VoltageSideSelected m1 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1VoltageSideSelected m0 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2State m1 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NPath1State m0 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NMultiplexer M : 29|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BXcpError : 28|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NCellHwErrorFlags : 20|8@1+ (1,0) [0|255] ""  ECU
+ SG_ BSyncInputSignal : 18|1@1+ (1,0) [0|0] ""  ECU
+ SG_ BSyncRequested : 17|1@1+ (1,0) [0|0] ""  ECU
+ SG_ BInternalTemperatureError : 16|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BConfigSettingsError : 15|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxSupplyError : 14|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BCanTimeoutError : 13|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxIsoEnabled : 12|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeEnabled : 11|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BFaultSignal : 10|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BEnableSignal : 9|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeStatus : 8|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncStatus : 7|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BReadConfigAndSettingsRequested : 6|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSwResetModuleRequested : 5|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeRequested : 4|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NModuleState : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147487751 BL3_Node7Status: 8 HVHV
+ SG_ BPath1AcModeActivated m0 : 63|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1AcUfpError m0 : 62|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1AcOfpError m0 : 61|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath1AcFunctionMode m0 : 58|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BPath1FlgCapaError m0 : 57|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2FlgCapaError m1 : 57|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1ErrVAuxCell m0 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2ErrVAuxCell m1 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ IPath1Unbalance m0 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ IPath2Unbalance m1 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ BPath1RcpWarning m0 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2RcpWarning m1 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OcpError m0 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2OcpError m1 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OtpError m0 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2OtpError m1 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBUvpError m0 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideBUvpError m1 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAUvpError m0 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideAUvpError m1 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBOvpError m0 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideBOvpError m1 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAOvpError m0 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideAOvpError m1 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1Requested m0 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2Requested m1 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath1CurrentSideSelected m0 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2CurrentSideSelected m1 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1VoltageSideSelected m0 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2VoltageSideSelected m1 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1State m0 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NPath2State m1 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NMultiplexer M : 29|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BXcpError : 28|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NCellHwErrorFlags : 20|8@1+ (1,0) [0|255] ""  ECU
+ SG_ BSyncInputSignal : 18|1@1+ (1,0) [0|0] ""  ECU
+ SG_ BSyncRequested : 17|1@1+ (1,0) [0|0] ""  ECU
+ SG_ BInternalTemperatureError : 16|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BConfigSettingsError : 15|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxSupplyError : 14|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BCanTimeoutError : 13|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxIsoEnabled : 12|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeEnabled : 11|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BFaultSignal : 10|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BEnableSignal : 9|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeStatus : 8|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncStatus : 7|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BReadConfigAndSettingsRequested : 6|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSwResetModuleRequested : 5|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeRequested : 4|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NModuleState : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147489415 BL3_Node7Setpoints2Value: 6 HVHV
+ SG_ IqPath1AcLimitLo m9 : 38|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IqPath1AcLimitHi m9 : 28|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ PPath2LimitLo m2 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ IqPath1AcSetpoint m13 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IdPath1AcLimitLo m9 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IdPath1AcSetpoint m13 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IdPath1AcLimitHi m9 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ PPath2LimitHi m2 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ NMultiplexer M : 0|5@1+ (1,0) [0|31] ""  ECU
+
+BO_ 2147489351 BL3_Node7Setpoints1Value: 7 HVHV
+ SG_ NPath1AcFunctionMode m9 : 50|3@1+ (1,0) [0|7] ""  ECU
+ SG_ NPath2CurrentSideSelected m2 : 42|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2VoltageSideSelected m2 : 40|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1AcFrequencySetpoint m9 : 38|12@1+ (0.25,0) [0|1023.75] "Hz"  ECU
+ SG_ IPath2LimitLo m2 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VqPath1AcSetpoint m9 : 27|11@1+ (1,-1024) [-1024|1023] "V"  ECU
+ SG_ VdPath1AcSetpoint m9 : 16|11@1+ (1,-1024) [-1024|1023] "V"  ECU
+ SG_ IPath2LimitHi m2 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VDcPath1AcSetpoint m9 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPath2Setpoint m2 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ NMultiplexer M : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147488775 BL3_Node7PortB1Value: 7 HVHV
+ SG_ NPortB1OverloadCount : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortB1Average : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortB1Average : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Max : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Min : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147487879 BL3_Node7PortA1Value: 8 HVHV
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IqPhAPortA1RMS m3 : 42|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IqPortA1RMS m1 : 36|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ NFrequencyPortA1 m2 : 36|16@1+ (0.0125,0) [0|819.1875] "Hz"  ECU
+ SG_ IqPhCPortA1RMS m4 : 36|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IdPhAPortA1RMS m3 : 30|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IdPortA1RMS m1 : 24|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ VphCPortA1Peak m2 : 24|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ IdPhCPortA1RMS m4 : 24|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IphCPortA1Peak m3 : 20|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ VqPortA1RMS m1 : 12|12@1+ (0.5,-1024) [-1024|1023.5] "V"  ECU
+ SG_ VphBPortA1Peak m2 : 12|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ IqPhBPortA1RMS m4 : 12|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IphBPortA1Peak m3 : 10|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ VdPortA1RMS m1 : 0|12@1+ (0.5,-1024) [-1024|1023.5] "V"  ECU
+ SG_ VphAPortA1Peak m2 : 0|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ IphAPortA1Peak m3 : 0|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ IdPhBPortA1RMS m4 : 0|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+
+BO_ 2147487943 BL3_Node7PortA2Value: 8 HVHV
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ NPortA2OverloadCount m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortA2Average m0 : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortA2Average m0 : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA2Max m0 : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA2Min m0 : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147488391 BL3_Node7InternalPath1Value: 5 HVHV
+ SG_ VPath1FlgCapaLvl2Max : 30|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl2Min : 20|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl1Max : 10|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl1Min : 0|10@1+ (2,0) [0|2046] "V"  ECU
+
+BO_ 2147488455 BL3_Node7InternalPath2Value: 5 HVHV
+ SG_ VPath2FlgCapaLvl2Max : 30|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl2Min : 20|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl1Max : 10|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl1Min : 0|10@1+ (2,0) [0|2046] "V"  ECU
+
+BO_ 2147487815 BL3_Node7GlobalValue: 7 HVHV
+ SG_ NCellOtpErrorFlags m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ TCell3N2 m1 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAuxCell4N2 m9 : 48|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell3N1 m1 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TInternal m3 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NBootloaderId m4 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NApplicationId m5 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell3N2 m9 : 40|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NSyncNodeCount m0 : 39|5@1+ (1,0) [0|31] ""  ECU
+ SG_ NSyncNodeRank m0 : 34|5@1+ (1,0) [0|31] ""  ECU
+ SG_ NReleaseMode m0 : 32|2@1+ (1,0) [0|3] ""  ECU
+ SG_ TCell2N2 m1 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NCellVAuxErrorFlags m7 : 32|8@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell4N1 m8 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N2 m9 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell4N3 m10 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell4N3 m11 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux3Measured m0 : 24|8@1+ (0.01,0) [0|2.55] "V"  ECU
+ SG_ TCell2N1 m1 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NConfigCrc m4 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSettingsCrc m5 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSerial m6 : 24|32@1+ (1,0) [0|4294967295] ""  ECU
+ SG_ VAuxCell3N1 m8 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N2 m9 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell3N3 m10 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell3N3 m11 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux2Measured m0 : 16|8@1+ (0.02,0) [0|5.1] "V"  ECU
+ SG_ TCell1N2 m1 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N2 m2 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NCellXcpErrorFlags m7 : 16|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell2N1 m8 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N3 m10 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell2N3 m11 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux1Measured m0 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell1N1 m1 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N1 m2 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NConfigVersion m4 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSettingsVersion m5 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NChecksum m6 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NCellSwOcpErrorFlags m7 : 8|8@1+ (1,0) [0|255] ""  ECU
+ SG_ VAuxCell1N1 m8 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N3 m10 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell1N3 m11 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NMultiplexer M : 0|8@1+ (1,0) [0|255] ""  ECU
+
+BO_ 2147489479 BL3_Node7ConfigAndSettingsValue: 4 HVHV
+ SG_ NParameterValue : 16|16@1+ (1,0) [0|0] ""  ECU
+ SG_ NParameterIndex : 4|12@1+ (1,0) [0|0] ""  ECU
+ SG_ NReadZoneSelect : 0|4@1+ (1,0) [0|0] ""  ECU
+
+BO_ 2147489414 BL3_Node6Setpoints2Value: 6 HVHV
+ SG_ IqPath1AcLimitLo m9 : 38|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IqPath1AcLimitHi m9 : 28|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ PPath2LimitLo m2 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ IqPath1AcSetpoint m13 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IdPath1AcLimitLo m9 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IdPath1AcSetpoint m13 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IdPath1AcLimitHi m9 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ PPath2LimitHi m2 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ NMultiplexer M : 0|5@1+ (1,0) [0|31] ""  ECU
+
+BO_ 2147489350 BL3_Node6Setpoints1Value: 7 HVHV
+ SG_ NPath1AcFunctionMode m9 : 50|3@1+ (1,0) [0|7] ""  ECU
+ SG_ NPath2CurrentSideSelected m2 : 42|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2VoltageSideSelected m2 : 40|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1AcFrequencySetpoint m9 : 38|12@1+ (0.25,0) [0|1023.75] "Hz"  ECU
+ SG_ IPath2LimitLo m2 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VqPath1AcSetpoint m9 : 27|11@1+ (1,-1024) [-1024|1023] "V"  ECU
+ SG_ VdPath1AcSetpoint m9 : 16|11@1+ (1,-1024) [-1024|1023] "V"  ECU
+ SG_ IPath2LimitHi m2 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VDcPath1AcSetpoint m9 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPath2Setpoint m2 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ NMultiplexer M : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147488390 BL3_Node6InternalPath1Value: 5 HVHV
+ SG_ VPath1FlgCapaLvl2Max : 30|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl2Min : 20|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl1Max : 10|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl1Min : 0|10@1+ (2,0) [0|2046] "V"  ECU
+
+BO_ 2147488454 BL3_Node6InternalPath2Value: 5 HVHV
+ SG_ VPath2FlgCapaLvl2Max : 30|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl2Min : 20|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl1Max : 10|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl1Min : 0|10@1+ (2,0) [0|2046] "V"  ECU
+
+BO_ 2147488774 BL3_Node6PortB1Value: 7 HVHV
+ SG_ NPortB1OverloadCount : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortB1Average : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortB1Average : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Max : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Min : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147487878 BL3_Node6PortA1Value: 8 HVHV
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IqPhAPortA1RMS m3 : 42|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IqPortA1RMS m1 : 36|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ NFrequencyPortA1 m2 : 36|16@1+ (0.0125,0) [0|819.1875] "Hz"  ECU
+ SG_ IqPhCPortA1RMS m4 : 36|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IdPhAPortA1RMS m3 : 30|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IdPortA1RMS m1 : 24|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ VphCPortA1Peak m2 : 24|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ IdPhCPortA1RMS m4 : 24|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IphCPortA1Peak m3 : 20|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ VqPortA1RMS m1 : 12|12@1+ (0.5,-1024) [-1024|1023.5] "V"  ECU
+ SG_ VphBPortA1Peak m2 : 12|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ IqPhBPortA1RMS m4 : 12|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IphBPortA1Peak m3 : 10|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ VdPortA1RMS m1 : 0|12@1+ (0.5,-1024) [-1024|1023.5] "V"  ECU
+ SG_ VphAPortA1Peak m2 : 0|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ IphAPortA1Peak m3 : 0|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ IdPhBPortA1RMS m4 : 0|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+
+BO_ 2147487942 BL3_Node6PortA2Value: 8 HVHV
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ NPortA2OverloadCount m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortA2Average m0 : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortA2Average m0 : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA2Max m0 : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA2Min m0 : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147489478 BL3_Node6ConfigAndSettingsValue: 4 HVHV
+ SG_ NParameterValue : 16|16@1+ (1,0) [0|0] ""  ECU
+ SG_ NParameterIndex : 4|12@1+ (1,0) [0|0] ""  ECU
+ SG_ NReadZoneSelect : 0|4@1+ (1,0) [0|0] ""  ECU
+
+BO_ 2147487814 BL3_Node6GlobalValue: 7 HVHV
+ SG_ NCellOtpErrorFlags m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ TCell3N2 m1 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAuxCell4N2 m9 : 48|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell3N1 m1 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TInternal m3 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NBootloaderId m4 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NApplicationId m5 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell3N2 m9 : 40|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NSyncNodeCount m0 : 39|5@1+ (1,0) [0|31] ""  ECU
+ SG_ NSyncNodeRank m0 : 34|5@1+ (1,0) [0|31] ""  ECU
+ SG_ NReleaseMode m0 : 32|2@1+ (1,0) [0|3] ""  ECU
+ SG_ TCell2N2 m1 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NCellVAuxErrorFlags m7 : 32|8@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell4N1 m8 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N2 m9 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell4N3 m10 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell4N3 m11 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux3Measured m0 : 24|8@1+ (0.01,0) [0|2.55] "V"  ECU
+ SG_ TCell2N1 m1 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NConfigCrc m4 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSettingsCrc m5 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSerial m6 : 24|32@1+ (1,0) [0|4294967295] ""  ECU
+ SG_ VAuxCell3N1 m8 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N2 m9 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell3N3 m10 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell3N3 m11 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux2Measured m0 : 16|8@1+ (0.02,0) [0|5.1] "V"  ECU
+ SG_ TCell1N2 m1 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N2 m2 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NCellXcpErrorFlags m7 : 16|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell2N1 m8 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N3 m10 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell2N3 m11 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux1Measured m0 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell1N1 m1 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N1 m2 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NConfigVersion m4 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSettingsVersion m5 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NChecksum m6 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NCellSwOcpErrorFlags m7 : 8|8@1+ (1,0) [0|255] ""  ECU
+ SG_ VAuxCell1N1 m8 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N3 m10 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell1N3 m11 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NMultiplexer M : 0|8@1+ (1,0) [0|255] ""  ECU
+
+BO_ 2147487750 BL3_Node6Status: 8 HVHV
+ SG_ BPath1AcModeActivated m0 : 63|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1AcUfpError m0 : 62|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1AcOfpError m0 : 61|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath1AcFunctionMode m0 : 58|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BPath1FlgCapaError m0 : 57|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2FlgCapaError m1 : 57|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1ErrVAuxCell m0 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2ErrVAuxCell m1 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ IPath1Unbalance m0 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ IPath2Unbalance m1 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ BPath1RcpWarning m0 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2RcpWarning m1 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OcpError m0 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2OcpError m1 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OtpError m0 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2OtpError m1 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBUvpError m0 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideBUvpError m1 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAUvpError m0 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideAUvpError m1 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBOvpError m0 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideBOvpError m1 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAOvpError m0 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideAOvpError m1 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1Requested m0 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2Requested m1 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath1CurrentSideSelected m0 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2CurrentSideSelected m1 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1VoltageSideSelected m0 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2VoltageSideSelected m1 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1State m0 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NPath2State m1 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NMultiplexer M : 29|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BXcpError : 28|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NCellHwErrorFlags : 20|8@1+ (1,0) [0|255] ""  ECU
+ SG_ BSyncInputSignal : 18|1@1+ (1,0) [0|0] ""  ECU
+ SG_ BSyncRequested : 17|1@1+ (1,0) [0|0] ""  ECU
+ SG_ BInternalTemperatureError : 16|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BConfigSettingsError : 15|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxSupplyError : 14|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BCanTimeoutError : 13|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxIsoEnabled : 12|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeEnabled : 11|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BFaultSignal : 10|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BEnableSignal : 9|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeStatus : 8|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncStatus : 7|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BReadConfigAndSettingsRequested : 6|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSwResetModuleRequested : 5|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeRequested : 4|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NModuleState : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147487753 BL4_Node9Status: 8 HVHV
+ SG_ BPath1AcModeActivated m0 : 63|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1AcUfpError m0 : 62|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1AcOfpError m0 : 61|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath1AcFunctionMode m0 : 58|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BPath1FlgCapaError m0 : 57|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2FlgCapaError m1 : 57|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1ErrVAuxCell m0 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2ErrVAuxCell m1 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ IPath1Unbalance m0 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ IPath2Unbalance m1 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ BPath1RcpWarning m0 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2RcpWarning m1 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OcpError m0 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2OcpError m1 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OtpError m0 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2OtpError m1 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBUvpError m0 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideBUvpError m1 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAUvpError m0 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideAUvpError m1 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBOvpError m0 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideBOvpError m1 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAOvpError m0 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideAOvpError m1 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1Requested m0 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2Requested m1 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath1CurrentSideSelected m0 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2CurrentSideSelected m1 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1VoltageSideSelected m0 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2VoltageSideSelected m1 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1State m0 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NPath2State m1 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NMultiplexer M : 29|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BXcpError : 28|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NCellHwErrorFlags : 20|8@1+ (1,0) [0|255] ""  ECU
+ SG_ BSyncInputSignal : 18|1@1+ (1,0) [0|0] ""  ECU
+ SG_ BSyncRequested : 17|1@1+ (1,0) [0|0] ""  ECU
+ SG_ BInternalTemperatureError : 16|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BConfigSettingsError : 15|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxSupplyError : 14|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BCanTimeoutError : 13|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxIsoEnabled : 12|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeEnabled : 11|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BFaultSignal : 10|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BEnableSignal : 9|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeStatus : 8|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncStatus : 7|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BReadConfigAndSettingsRequested : 6|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSwResetModuleRequested : 5|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeRequested : 4|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NModuleState : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147489417 BL4_Node9Setpoints2Value: 6 HVHV
+ SG_ IqPath1AcLimitLo m9 : 38|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IqPath1AcLimitHi m9 : 28|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ PPath2LimitLo m2 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ IqPath1AcSetpoint m13 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IdPath1AcLimitLo m9 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IdPath1AcSetpoint m13 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IdPath1AcLimitHi m9 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ PPath2LimitHi m2 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ NMultiplexer M : 0|5@1+ (1,0) [0|31] ""  ECU
+
+BO_ 2147489353 BL4_Node9Setpoints1Value: 7 HVHV
+ SG_ NPath1AcFunctionMode m9 : 50|3@1+ (1,0) [0|7] ""  ECU
+ SG_ NPath2CurrentSideSelected m2 : 42|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2VoltageSideSelected m2 : 40|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1AcFrequencySetpoint m9 : 38|12@1+ (0.25,0) [0|1023.75] "Hz"  ECU
+ SG_ IPath2LimitLo m2 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VqPath1AcSetpoint m9 : 27|11@1+ (1,-1024) [-1024|1023] "V"  ECU
+ SG_ VdPath1AcSetpoint m9 : 16|11@1+ (1,-1024) [-1024|1023] "V"  ECU
+ SG_ IPath2LimitHi m2 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VDcPath1AcSetpoint m9 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPath2Setpoint m2 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ NMultiplexer M : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147488777 BL4_Node9PortB1Value: 7 HVHV
+ SG_ NPortB1OverloadCount : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortB1Average : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortB1Average : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Max : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Min : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147487881 BL4_Node9PortA1Value: 8 HVHV
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IqPhAPortA1RMS m3 : 42|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IqPortA1RMS m1 : 36|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ NFrequencyPortA1 m2 : 36|16@1+ (0.0125,0) [0|819.1875] "Hz"  ECU
+ SG_ IqPhCPortA1RMS m4 : 36|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IdPhAPortA1RMS m3 : 30|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IdPortA1RMS m1 : 24|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ VphCPortA1Peak m2 : 24|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ IdPhCPortA1RMS m4 : 24|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IphCPortA1Peak m3 : 20|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ VqPortA1RMS m1 : 12|12@1+ (0.5,-1024) [-1024|1023.5] "V"  ECU
+ SG_ VphBPortA1Peak m2 : 12|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ IqPhBPortA1RMS m4 : 12|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IphBPortA1Peak m3 : 10|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ VdPortA1RMS m1 : 0|12@1+ (0.5,-1024) [-1024|1023.5] "V"  ECU
+ SG_ VphAPortA1Peak m2 : 0|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ IphAPortA1Peak m3 : 0|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ IdPhBPortA1RMS m4 : 0|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+
+BO_ 2147487945 BL4_Node9PortA2Value: 8 HVHV
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ NPortA2OverloadCount m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortA2Average m0 : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortA2Average m0 : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA2Max m0 : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA2Min m0 : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147488393 BL4_Node9InternalPath1Value: 5 HVHV
+ SG_ VPath1FlgCapaLvl2Max : 30|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl2Min : 20|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl1Max : 10|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl1Min : 0|10@1+ (2,0) [0|2046] "V"  ECU
+
+BO_ 2147488457 BL4_Node9InternalPath2Value: 5 HVHV
+ SG_ VPath2FlgCapaLvl2Max : 30|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl2Min : 20|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl1Max : 10|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl1Min : 0|10@1+ (2,0) [0|2046] "V"  ECU
+
+BO_ 2147487817 BL4_Node9GlobalValue: 7 HVHV
+ SG_ NCellOtpErrorFlags m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ TCell3N2 m1 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAuxCell4N2 m9 : 48|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell3N1 m1 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TInternal m3 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NBootloaderId m4 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NApplicationId m5 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell3N2 m9 : 40|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NSyncNodeCount m0 : 39|5@1+ (1,0) [0|31] ""  ECU
+ SG_ NSyncNodeRank m0 : 34|5@1+ (1,0) [0|31] ""  ECU
+ SG_ NReleaseMode m0 : 32|2@1+ (1,0) [0|3] ""  ECU
+ SG_ TCell2N2 m1 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NCellVAuxErrorFlags m7 : 32|8@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell4N1 m8 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N2 m9 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell4N3 m10 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell4N3 m11 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux3Measured m0 : 24|8@1+ (0.01,0) [0|2.55] "V"  ECU
+ SG_ TCell2N1 m1 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NConfigCrc m4 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSettingsCrc m5 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSerial m6 : 24|32@1+ (1,0) [0|4294967295] ""  ECU
+ SG_ VAuxCell3N1 m8 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N2 m9 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell3N3 m10 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell3N3 m11 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux2Measured m0 : 16|8@1+ (0.02,0) [0|5.1] "V"  ECU
+ SG_ TCell1N2 m1 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N2 m2 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NCellXcpErrorFlags m7 : 16|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell2N1 m8 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N3 m10 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell2N3 m11 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux1Measured m0 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell1N1 m1 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N1 m2 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NConfigVersion m4 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSettingsVersion m5 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NChecksum m6 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NCellSwOcpErrorFlags m7 : 8|8@1+ (1,0) [0|255] ""  ECU
+ SG_ VAuxCell1N1 m8 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N3 m10 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell1N3 m11 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NMultiplexer M : 0|8@1+ (1,0) [0|255] ""  ECU
+
+BO_ 2147489481 BL4_Node9ConfigAndSettingsValue: 4 HVHV
+ SG_ NParameterValue : 16|16@1+ (1,0) [0|0] ""  ECU
+ SG_ NParameterIndex : 4|12@1+ (1,0) [0|0] ""  ECU
+ SG_ NReadZoneSelect : 0|4@1+ (1,0) [0|0] ""  ECU
+
+BO_ 2147489416 BL4_Node8Setpoints2Value: 6 HVHV
+ SG_ IqPath1AcLimitLo m9 : 38|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IqPath1AcLimitHi m9 : 28|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ PPath2LimitLo m2 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ IqPath1AcSetpoint m13 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IdPath1AcLimitLo m9 : 18|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IdPath1AcSetpoint m13 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ IdPath1AcLimitHi m9 : 8|10@1+ (0.5,-256) [-256|255.5] "A"  ECU
+ SG_ PPath2LimitHi m2 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ NMultiplexer M : 0|5@1+ (1,0) [0|31] ""  ECU
+
+BO_ 2147489352 BL4_Node8Setpoints1Value: 7 HVHV
+ SG_ NPath1AcFunctionMode m9 : 50|3@1+ (1,0) [0|7] ""  ECU
+ SG_ NPath2CurrentSideSelected m2 : 42|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2VoltageSideSelected m2 : 40|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1AcFrequencySetpoint m9 : 38|12@1+ (0.25,0) [0|1023.75] "Hz"  ECU
+ SG_ IPath2LimitLo m2 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VqPath1AcSetpoint m9 : 27|11@1+ (1,-1024) [-1024|1023] "V"  ECU
+ SG_ VdPath1AcSetpoint m9 : 16|11@1+ (1,-1024) [-1024|1023] "V"  ECU
+ SG_ IPath2LimitHi m2 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VDcPath1AcSetpoint m9 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPath2Setpoint m2 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ NMultiplexer M : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147488392 BL4_Node8InternalPath1Value: 5 HVHV
+ SG_ VPath1FlgCapaLvl2Max : 30|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl2Min : 20|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl1Max : 10|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath1FlgCapaLvl1Min : 0|10@1+ (2,0) [0|2046] "V"  ECU
+
+BO_ 2147488456 BL4_Node8InternalPath2Value: 5 HVHV
+ SG_ VPath2FlgCapaLvl2Max : 30|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl2Min : 20|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl1Max : 10|10@1+ (2,0) [0|2046] "V"  ECU
+ SG_ VPath2FlgCapaLvl1Min : 0|10@1+ (2,0) [0|2046] "V"  ECU
+
+BO_ 2147488776 BL4_Node8PortB1Value: 7 HVHV
+ SG_ NPortB1OverloadCount : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortB1Average : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortB1Average : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Max : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Min : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147487880 BL4_Node8PortA1Value: 8 HVHV
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IqPhAPortA1RMS m3 : 42|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IqPortA1RMS m1 : 36|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ NFrequencyPortA1 m2 : 36|16@1+ (0.0125,0) [0|819.1875] "Hz"  ECU
+ SG_ IqPhCPortA1RMS m4 : 36|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IdPhAPortA1RMS m3 : 30|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IdPortA1RMS m1 : 24|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ VphCPortA1Peak m2 : 24|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ IdPhCPortA1RMS m4 : 24|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IphCPortA1Peak m3 : 20|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ VqPortA1RMS m1 : 12|12@1+ (0.5,-1024) [-1024|1023.5] "V"  ECU
+ SG_ VphBPortA1Peak m2 : 12|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ IqPhBPortA1RMS m4 : 12|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+ SG_ IphBPortA1Peak m3 : 10|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ VdPortA1RMS m1 : 0|12@1+ (0.5,-1024) [-1024|1023.5] "V"  ECU
+ SG_ VphAPortA1Peak m2 : 0|12@1+ (0.5,0) [0|2047.5] "V"  ECU
+ SG_ IphAPortA1Peak m3 : 0|10@1+ (0.25,0) [0|255.75] "A"  ECU
+ SG_ IdPhBPortA1RMS m4 : 0|12@1+ (0.125,-256) [-256|255.875] "A"  ECU
+
+BO_ 2147487944 BL4_Node8PortA2Value: 8 HVHV
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ NPortA2OverloadCount m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortA2Average m0 : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortA2Average m0 : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA2Max m0 : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA2Min m0 : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147489480 BL4_Node8ConfigAndSettingsValue: 4 HVHV
+ SG_ NParameterValue : 16|16@1+ (1,0) [0|0] ""  ECU
+ SG_ NParameterIndex : 4|12@1+ (1,0) [0|0] ""  ECU
+ SG_ NReadZoneSelect : 0|4@1+ (1,0) [0|0] ""  ECU
+
+BO_ 2147487816 BL4_Node8GlobalValue: 7 HVHV
+ SG_ NCellOtpErrorFlags m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ TCell3N2 m1 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAuxCell4N2 m9 : 48|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell3N1 m1 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TInternal m3 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NBootloaderId m4 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NApplicationId m5 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell3N2 m9 : 40|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NSyncNodeCount m0 : 39|5@1+ (1,0) [0|31] ""  ECU
+ SG_ NSyncNodeRank m0 : 34|5@1+ (1,0) [0|31] ""  ECU
+ SG_ NReleaseMode m0 : 32|2@1+ (1,0) [0|3] ""  ECU
+ SG_ TCell2N2 m1 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NCellVAuxErrorFlags m7 : 32|8@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell4N1 m8 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N2 m9 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell4N3 m10 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell4N3 m11 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux3Measured m0 : 24|8@1+ (0.01,0) [0|2.55] "V"  ECU
+ SG_ TCell2N1 m1 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NConfigCrc m4 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSettingsCrc m5 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSerial m6 : 24|32@1+ (1,0) [0|4294967295] ""  ECU
+ SG_ VAuxCell3N1 m8 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N2 m9 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell3N3 m10 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell3N3 m11 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux2Measured m0 : 16|8@1+ (0.02,0) [0|5.1] "V"  ECU
+ SG_ TCell1N2 m1 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N2 m2 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NCellXcpErrorFlags m7 : 16|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ VAuxCell2N1 m8 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N3 m10 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell2N3 m11 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux1Measured m0 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell1N1 m1 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N1 m2 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NConfigVersion m4 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSettingsVersion m5 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NChecksum m6 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NCellSwOcpErrorFlags m7 : 8|8@1+ (1,0) [0|255] ""  ECU
+ SG_ VAuxCell1N1 m8 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N3 m10 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell1N3 m11 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NMultiplexer M : 0|8@1+ (1,0) [0|255] ""  ECU
+
+BO_ 2147487752 BL4_Node8Status: 8 HVHV
+ SG_ BPath1AcModeActivated m0 : 63|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1AcUfpError m0 : 62|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1AcOfpError m0 : 61|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath1AcFunctionMode m0 : 58|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BPath1FlgCapaError m0 : 57|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2FlgCapaError m1 : 57|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1ErrVAuxCell m0 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2ErrVAuxCell m1 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ IPath1Unbalance m0 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ IPath2Unbalance m1 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ BPath1RcpWarning m0 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2RcpWarning m1 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OcpError m0 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2OcpError m1 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OtpError m0 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2OtpError m1 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBUvpError m0 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideBUvpError m1 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAUvpError m0 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideAUvpError m1 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBOvpError m0 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideBOvpError m1 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAOvpError m0 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2SideAOvpError m1 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1Requested m0 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath2Requested m1 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath1CurrentSideSelected m0 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2CurrentSideSelected m1 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1VoltageSideSelected m0 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath2VoltageSideSelected m1 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1State m0 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NPath2State m1 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NMultiplexer M : 29|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BXcpError : 28|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NCellHwErrorFlags : 20|8@1+ (1,0) [0|255] ""  ECU
+ SG_ BSyncInputSignal : 18|1@1+ (1,0) [0|0] ""  ECU
+ SG_ BSyncRequested : 17|1@1+ (1,0) [0|0] ""  ECU
+ SG_ BInternalTemperatureError : 16|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BConfigSettingsError : 15|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxSupplyError : 14|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BCanTimeoutError : 13|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxIsoEnabled : 12|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeEnabled : 11|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BFaultSignal : 10|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BEnableSignal : 9|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeStatus : 8|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncStatus : 7|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BReadConfigAndSettingsRequested : 6|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSwResetModuleRequested : 5|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeRequested : 4|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NModuleState : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147491393 BL5_Setpoints1Value: 7 DCDC
+ SG_ NPath1CurrentSideSelected m1 : 42|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1VoltageSideSelected m1 : 40|2@1+ (1,0) [0|3] ""  ECU
+ SG_ IPath1LimitLo m1 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ IPath1LimitHi m1 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VPath1Setpoint m1 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ NMultiplexer M : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147491457 BL5_Setpoints2Value: 6 DCDC
+ SG_ PPath1LimitLo m1 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ PPath1LimitHi m1 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ NMultiplexer M : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147490817 BL5_PortB1Value: 7 DCDC
+ SG_ NPortB1OverloadCount : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortB1Average : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortB1Average : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Max : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Min : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147490175 DCHVI_SetpointsRead: 2 ECU
+ SG_ NCRC : 8|8@1+ (1,0) [0|255] ""  DCDC
+ SG_ NPathSelect : 4|4@1+ (1,0) [0|15] ""  DCDC
+ SG_ BReadSetpointRequest : 0|1@1+ (1,0) [0|1] ""  DCDC
+
+BO_ 2147490111 DCHVI_AcknowledgeErrors: 3 ECU
+ SG_ NCRC : 16|8@1+ (1,0) [0|255] ""  DCDC
+ SG_ NModuleSelect M : 10|6@1+ (1,0) [0|63] ""  DCDC
+ SG_ BAckErrorsModuleRequest : 8|1@1+ (1,0) [0|1] ""  DCDC
+ SG_ BAckErrorsPath1Request : 0|1@1+ (1,0) [0|1] ""  DCDC
+
+BO_ 2147490047 DCHVI_Setpoints2Write: 7 ECU
+ SG_ NCRC : 48|8@1+ (1,0) [0|255] ""  DCDC
+ SG_ NModuleSelect M : 40|6@1+ (1,0) [0|63] ""  DCDC
+ SG_ BL5_PPath1LimitLo m1 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  DCDC
+ SG_ BL6_PPath1LimitLo m1 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  DCDC
+ SG_ BL7_PPath1LimitLo m1 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  DCDC
+ SG_ BL5_PPath1LimitHi m1 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  DCDC
+ SG_ BL6_PPath1LimitHi m1 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  DCDC
+ SG_ BL7_PPath1LimitHi m1 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  DCDC
+ SG_ BL5_NMultiplexer m1M : 0|4@1+ (1,0) [0|15] ""  DCDC
+ SG_ BL6_NMultiplexer m2M : 0|4@1+ (1,0) [0|15] ""  DCDC
+ SG_ BL7_NMultiplexer m3M : 0|4@1+ (1,0) [0|15] ""  DCDC
+
+BO_ 2147489921 BL5_PortA1Value: 8 DCDC
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ NPortA1OverloadCount m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortA1Average m0 : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortA1Average m0 : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA1Max m0 : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA1Min m0 : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147491521 BL5_ConfigAndSettingsValue: 4 DCDC
+ SG_ NParameterValue : 16|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NParameterIndex : 4|12@1+ (1,0) [0|4095] ""  ECU
+ SG_ NReadZoneSelect : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147489857 BL5_GlobalValue: 8 DCDC
+ SG_ BSetpointsApplied : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ VAuxCell6N1 m8 : 48|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell6N2 m2 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell3N2 m1 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NCellOtpErrorFlags m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ VAuxCell5N1 m8 : 40|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NApplicationId m5 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NBootloaderId m4 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TInternal m3 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell6N1 m2 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell3N1 m1 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NSyncNodeCount m0 : 39|5@1+ (1,0) [0|31] ""  ECU
+ SG_ NSyncNodeRank m0 : 34|5@1+ (1,0) [0|31] ""  ECU
+ SG_ VAuxCell4N1 m8 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NCellVAuxErrorFlags m7 : 32|8@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell8N2 m3 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell5N2 m2 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell2N2 m1 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NReleaseMode m0 : 32|2@1+ (1,0) [0|3] ""  ECU
+ SG_ VAuxCell3N1 m8 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NSerial m6 : 24|32@1+ (1,0) [0|4294967295] ""  ECU
+ SG_ NSettingsCrc m5 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NConfigCrc m4 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell8N1 m3 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell5N1 m2 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell2N1 m1 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux3Measured m0 : 24|8@1+ (0.01,0) [0|2.55] "V"  ECU
+ SG_ VAuxCell8N1 m9 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N1 m8 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NCellXcpErrorFlags m7 : 16|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell7N2 m3 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N2 m2 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell1N2 m1 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux2Measured m0 : 16|8@1+ (0.02,0) [0|5.1] "V"  ECU
+ SG_ VAuxCell7N1 m9 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N1 m8 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NCellSwOcpErrorFlags m7 : 8|8@1+ (1,0) [0|255] ""  ECU
+ SG_ NChecksum m6 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSettingsVersion m5 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NConfigVersion m4 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell7N1 m3 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N1 m2 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell1N1 m1 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux1Measured m0 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NMultiplexer M : 0|8@1+ (1,0) [0|255] ""  ECU
+
+BO_ 2147489793 BL5_Status: 8 DCDC
+ SG_ BPath1AcModeActivated m0 : 63|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1ErrVAuxCell m0 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ IPath1Unbalance m0 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ BPath1RcpWarning m0 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OcpError m0 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OtpError m0 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBUvpError m0 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAUvpError m0 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBOvpError m0 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAOvpError m0 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1Requested m0 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath1CurrentSideSelected m0 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1VoltageSideSelected m0 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1State m0 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NMultiplexer M : 29|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BXcpError : 28|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NCellHwErrorFlags : 20|8@1+ (1,0) [0|255] ""  ECU
+ SG_ BIsoError : 19|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncInputSignal : 18|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncRequested : 17|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BInternalTemperatureError : 16|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BConfigSettingsError : 15|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxSupplyError : 14|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BCanTimeoutError : 13|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxIsoEnabled : 12|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeEnabled : 11|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BFaultSignal : 10|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BEnableSignal : 9|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeStatus : 8|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncStatus : 7|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BReadConfigAndSettingsRequested : 6|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSwResetModuleRequested : 5|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeRequested : 4|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NModuleState : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147489983 DCHVI_DcSetpoints1Write: 8 ECU
+ SG_ NCRC : 56|8@1+ (1,0) [0|255] ""  DCDC
+ SG_ NModuleSelect M : 48|6@1+ (1,0) [0|63] ""  DCDC
+ SG_ BL5_NPath1CurrentSideSelect m1 : 42|2@1+ (1,0) [0|3] ""  DCDC
+ SG_ BL6_NPath1CurrentSideSelect m1 : 42|2@1+ (1,0) [0|3] ""  DCDC
+ SG_ BL7_NPath1CurrentSideSelect m1 : 42|2@1+ (1,0) [0|3] ""  DCDC
+ SG_ BL5_NPath1VoltageSideSelect m1 : 40|2@1+ (1,0) [0|3] ""  DCDC
+ SG_ BL6_NPath1VoltageSideSelect m1 : 40|2@1+ (1,0) [0|3] ""  DCDC
+ SG_ BL7_NPath1VoltageSideSelect m1 : 40|2@1+ (1,0) [0|3] ""  DCDC
+ SG_ BL5_IPath1LimitLo m1 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  DCDC
+ SG_ BL6_IPath1LimitLo m1 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  DCDC
+ SG_ BL7_IPath1LimitLo m1 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  DCDC
+ SG_ BL5_IPath1LimitHi m1 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  DCDC
+ SG_ BL6_IPath1LimitHi m1 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  DCDC
+ SG_ BL7_IPath1LimitHi m1 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  DCDC
+ SG_ BL5_VPath1Setpoint m1 : 4|12@1+ (1,0) [0|4095] "V"  DCDC
+ SG_ BL6_VPath1Setpoint m1 : 4|12@1+ (1,0) [0|4095] "V"  DCDC
+ SG_ BL7_VPath1Setpoint m1 : 4|12@1+ (1,0) [0|4095] "V"  DCDC
+ SG_ BL5_NMultiplexer m1M : 0|4@1+ (1,0) [0|15] ""  DCDC
+ SG_ BL6_NMultiplexer m2M : 0|4@1+ (1,0) [0|15] ""  DCDC
+ SG_ BL7_NMultiplexer m3M : 0|4@1+ (1,0) [0|15] ""  DCDC
+
+BO_ 2147489855 DCHVI_Control: 4 ECU
+ SG_ BIsoStandaloneRequest : 17|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ NCRC : 24|8@1+ (1,0) [0|255] ""  DCDC
+ SG_ NModuleSelect M : 18|6@1+ (1,0) [0|63] ""  DCDC
+ SG_ BSyncRequest : 15|1@1+ (1,0) [0|1] ""  DCDC
+ SG_ BReadConfigAndSettingsRequest : 14|1@1+ (1,0) [0|1] ""  DCDC
+ SG_ BSwResetModuleRequest : 13|1@1+ (1,0) [0|1] ""  DCDC
+ SG_ BSafetyDischargeRequest : 12|1@1+ (1,0) [0|1] ""  DCDC
+ SG_ BPath1Request : 4|1@1+ (1,0) [0|1] ""  DCDC
+ SG_ NCounter : 0|4@1+ (1,0) [0|15] ""  DCDC
+
+BO_ 2147491713 BL5_IsoStatus: 6 DCDC
+ SG_ BStartupTimeout : 40|1@1- (1,0) [0|1] ""  ECU
+ SG_ BOtpBuckAux : 39|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BOtpSecError : 38|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BOtpPriError : 37|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BXcpBuckAuxError : 36|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BXcpDcdcError : 35|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSecOcpError : 34|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPriOcpError : 33|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSecUvpError : 32|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSecOvpError : 31|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPriUvpError : 30|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPriOvpError : 29|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BBuckOcpError : 28|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSuppAuxUvpError : 27|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSuppAuxOvpError : 26|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BBuckAuxHwError : 25|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BBuckVAuxDriverError : 24|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxSupplyError : 23|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BCanIntTimeoutError : 22|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BCanTimeoutError : 21|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BConfigSettingsError : 20|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPowerRequested : 19|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NAuxBuckState : 16|3@1+ (1,0) [0|7] ""  ECU
+ SG_ NChan2State : 13|3@1+ (1,0) [0|7] ""  ECU
+ SG_ NChan1State : 10|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BAuxIsoEnabled : 9|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BFaultSignal : 8|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BEnableSignal : 7|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncInputSignal : 6|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncStatus : 5|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSwResetModuleRequested : 4|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NState : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147491777 BL5_IsoGlobalValues: 8 DCDC
+ SG_ TSecCh2D m4 : 56|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TSecCh1D m3 : 56|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh2D m2 : 56|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh1D m1 : 56|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NReleaseMode m11 : 48|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NApplicationId m9 : 48|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NSettingsVersion m8 : 48|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NConfigCrc m7 : 48|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NXcpDcdcErrorFlags m6 : 48|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NOtpDcdcErrorFlags m5 : 48|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ TSecCh2C m4 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TSecCh1C m3 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh2C m2 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh1C m1 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ V1v65Aux m0 : 48|8@1+ (0.01,0) [0|2.55] "V"  ECU
+ SG_ VBuckAuxDriver m5 : 40|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TSecCh2B m4 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TSecCh1B m3 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh2B m2 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh1B m1 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ V3v3Aux m0 : 40|8@1+ (0.02,0) [0|5.1] "V"  ECU
+ SG_ NMissedSyncPulseCount m12 : 32|16@1- (1,0) [0|65535] ""  ECU
+ SG_ NChecksum m11 : 32|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NSerial m10 : 32|32@1+ (1,0) [0|4294967296] ""  ECU
+ SG_ NSettingsCrc m9 : 32|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NBootloaderId m8 : 32|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NConfigVersion m7 : 32|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NOcpDcdcErrorFlags m6 : 32|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ TBuckAux m5 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TSecCh2A m4 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TSecCh1A m3 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh2A m2 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh1A m1 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VHvAux m0 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NMultiplexer M : 24|4@1+ (1,0) [0|15] ""  ECU
+ SG_ VSuppAux : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ IBuckAux : 0|8@1+ (0.25,-30) [-30|33.75] "A"  ECU
+
+BO_ 2147490689 BL5_IsoPortInternalValue: 6 DCDC
+ SG_ IPortInternalAverage : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortInternalAverage : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortInternalMax : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortInternalMin : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147490753 BL5_IsoPortC1Value: 6 DCDC
+ SG_ IPortC1Average : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortC1Average : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortC1Max : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortC1Min : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147491394 BL6_Setpoints1Value: 7 DCDC
+ SG_ NPath1CurrentSideSelected m1 : 42|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1VoltageSideSelected m1 : 40|2@1+ (1,0) [0|3] ""  ECU
+ SG_ IPath1LimitLo m1 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ IPath1LimitHi m1 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VPath1Setpoint m1 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ NMultiplexer M : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147491458 BL6_Setpoints2Value: 6 DCDC
+ SG_ PPath1LimitLo m1 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ PPath1LimitHi m1 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ NMultiplexer M : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147490818 BL6_PortB1Value: 7 DCDC
+ SG_ NPortB1OverloadCount : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortB1Average : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortB1Average : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Max : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Min : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147489922 BL6_PortA1Value: 8 DCDC
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ NPortA1OverloadCount m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortA1Average m0 : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortA1Average m0 : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA1Max m0 : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA1Min m0 : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147491522 BL6_ConfigAndSettingsValue: 4 DCDC
+ SG_ NParameterValue : 16|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NParameterIndex : 4|12@1+ (1,0) [0|4095] ""  ECU
+ SG_ NReadZoneSelect : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147489858 BL6_GlobalValue: 8 DCDC
+ SG_ BSetpointsApplied : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ VAuxCell6N1 m8 : 48|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell6N2 m2 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell3N2 m1 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NCellOtpErrorFlags m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ VAuxCell5N1 m8 : 40|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NApplicationId m5 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NBootloaderId m4 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TInternal m3 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell6N1 m2 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell3N1 m1 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NSyncNodeCount m0 : 39|5@1+ (1,0) [0|31] ""  ECU
+ SG_ NSyncNodeRank m0 : 34|5@1+ (1,0) [0|31] ""  ECU
+ SG_ VAuxCell4N1 m8 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NCellVAuxErrorFlags m7 : 32|8@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell8N2 m3 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell5N2 m2 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell2N2 m1 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NReleaseMode m0 : 32|2@1+ (1,0) [0|3] ""  ECU
+ SG_ VAuxCell3N1 m8 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NSerial m6 : 24|32@1+ (1,0) [0|4294967295] ""  ECU
+ SG_ NSettingsCrc m5 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NConfigCrc m4 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell8N1 m3 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell5N1 m2 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell2N1 m1 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux3Measured m0 : 24|8@1+ (0.01,0) [0|2.55] "V"  ECU
+ SG_ VAuxCell8N1 m9 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N1 m8 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NCellXcpErrorFlags m7 : 16|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell7N2 m3 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N2 m2 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell1N2 m1 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux2Measured m0 : 16|8@1+ (0.02,0) [0|5.1] "V"  ECU
+ SG_ VAuxCell7N1 m9 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N1 m8 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NCellSwOcpErrorFlags m7 : 8|8@1+ (1,0) [0|255] ""  ECU
+ SG_ NChecksum m6 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSettingsVersion m5 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NConfigVersion m4 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell7N1 m3 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N1 m2 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell1N1 m1 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux1Measured m0 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NMultiplexer M : 0|8@1+ (1,0) [0|255] ""  ECU
+
+BO_ 2147489794 BL6_Status: 8 DCDC
+ SG_ BPath1AcModeActivated m0 : 63|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1ErrVAuxCell m0 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ IPath1Unbalance m0 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ BPath1RcpWarning m0 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OcpError m0 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OtpError m0 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBUvpError m0 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAUvpError m0 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBOvpError m0 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAOvpError m0 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1Requested m0 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath1CurrentSideSelected m0 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1VoltageSideSelected m0 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1State m0 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NMultiplexer M : 29|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BXcpError : 28|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NCellHwErrorFlags : 20|8@1+ (1,0) [0|255] ""  ECU
+ SG_ BIsoError : 19|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncInputSignal : 18|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncRequested : 17|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BInternalTemperatureError : 16|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BConfigSettingsError : 15|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxSupplyError : 14|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BCanTimeoutError : 13|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxIsoEnabled : 12|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeEnabled : 11|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BFaultSignal : 10|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BEnableSignal : 9|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeStatus : 8|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncStatus : 7|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BReadConfigAndSettingsRequested : 6|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSwResetModuleRequested : 5|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeRequested : 4|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NModuleState : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147491714 BL6_IsoStatus: 6 DCDC
+ SG_ BStartupTimeout : 40|1@1- (1,0) [0|1] ""  ECU
+ SG_ BOtpBuckAux : 39|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BOtpSecError : 38|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BOtpPriError : 37|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BXcpBuckAuxError : 36|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BXcpDcdcError : 35|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSecOcpError : 34|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPriOcpError : 33|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSecUvpError : 32|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSecOvpError : 31|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPriUvpError : 30|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPriOvpError : 29|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BBuckOcpError : 28|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSuppAuxUvpError : 27|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSuppAuxOvpError : 26|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BBuckAuxHwError : 25|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BBuckVAuxDriverError : 24|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxSupplyError : 23|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BCanIntTimeoutError : 22|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BCanTimeoutError : 21|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BConfigSettingsError : 20|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPowerRequested : 19|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NAuxBuckState : 16|3@1+ (1,0) [0|7] ""  ECU
+ SG_ NChan2State : 13|3@1+ (1,0) [0|7] ""  ECU
+ SG_ NChan1State : 10|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BAuxIsoEnabled : 9|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BFaultSignal : 8|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BEnableSignal : 7|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncInputSignal : 6|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncStatus : 5|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSwResetModuleRequested : 4|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NState : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147491778 BL6_IsoGlobalValues: 8 DCDC
+ SG_ TSecCh2D m4 : 56|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TSecCh1D m3 : 56|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh2D m2 : 56|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh1D m1 : 56|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NReleaseMode m11 : 48|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NApplicationId m9 : 48|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NSettingsVersion m8 : 48|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NConfigCrc m7 : 48|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NXcpDcdcErrorFlags m6 : 48|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NOtpDcdcErrorFlags m5 : 48|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ TSecCh2C m4 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TSecCh1C m3 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh2C m2 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh1C m1 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ V1v65Aux m0 : 48|8@1+ (0.01,0) [0|2.55] "V"  ECU
+ SG_ VBuckAuxDriver m5 : 40|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TSecCh2B m4 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TSecCh1B m3 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh2B m2 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh1B m1 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ V3v3Aux m0 : 40|8@1+ (0.02,0) [0|5.1] "V"  ECU
+ SG_ NMissedSyncPulseCount m12 : 32|16@1- (1,0) [0|65535] ""  ECU
+ SG_ NChecksum m11 : 32|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NSerial m10 : 32|32@1+ (1,0) [0|4294967296] ""  ECU
+ SG_ NSettingsCrc m9 : 32|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NBootloaderId m8 : 32|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NConfigVersion m7 : 32|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NOcpDcdcErrorFlags m6 : 32|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ TBuckAux m5 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TSecCh2A m4 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TSecCh1A m3 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh2A m2 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh1A m1 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VHvAux m0 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NMultiplexer M : 24|4@1+ (1,0) [0|15] ""  ECU
+ SG_ VSuppAux : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ IBuckAux : 0|8@1+ (0.25,-30) [-30|33.75] "A"  ECU
+
+BO_ 2147490690 BL6_IsoPortInternalValue: 6 DCDC
+ SG_ IPortInternalAverage : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortInternalAverage : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortInternalMax : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortInternalMin : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147490754 BL6_IsoPortC1Value: 6 DCDC
+ SG_ IPortC1Average : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortC1Average : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortC1Max : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortC1Min : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147491395 BL7_Setpoints1Value: 7 DCDC
+ SG_ NPath1CurrentSideSelected m1 : 42|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1VoltageSideSelected m1 : 40|2@1+ (1,0) [0|3] ""  ECU
+ SG_ IPath1LimitLo m1 : 28|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ IPath1LimitHi m1 : 16|12@1+ (0.5,-1000) [-1000|1047.5] "A"  ECU
+ SG_ VPath1Setpoint m1 : 4|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ NMultiplexer M : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147491459 BL7_Setpoints2Value: 6 DCDC
+ SG_ PPath1LimitLo m1 : 24|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ PPath1LimitHi m1 : 8|16@1+ (100,-3000000) [-3000000|3553500] "W"  ECU
+ SG_ NMultiplexer M : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147490819 BL7_PortB1Value: 7 DCDC
+ SG_ NPortB1OverloadCount : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortB1Average : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortB1Average : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Max : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortB1Min : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147489923 BL7_PortA1Value: 8 DCDC
+ SG_ NMultiplexer M : 56|8@1+ (1,0) [0|255] ""  ECU
+ SG_ NPortA1OverloadCount m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ IPortA1Average m0 : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortA1Average m0 : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA1Max m0 : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortA1Min m0 : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147491523 BL7_ConfigAndSettingsValue: 4 DCDC
+ SG_ NParameterValue : 16|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NParameterIndex : 4|12@1+ (1,0) [0|4095] ""  ECU
+ SG_ NReadZoneSelect : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147489859 BL7_GlobalValue: 8 DCDC
+ SG_ BSetpointsApplied : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ VAuxCell6N1 m8 : 48|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TCell6N2 m2 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell3N2 m1 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NCellOtpErrorFlags m0 : 48|8@1+ (1,0) [0|255] ""  ECU
+ SG_ VAuxCell5N1 m8 : 40|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NApplicationId m5 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NBootloaderId m4 : 40|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TInternal m3 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell6N1 m2 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell3N1 m1 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NSyncNodeCount m0 : 39|5@1+ (1,0) [0|31] ""  ECU
+ SG_ NSyncNodeRank m0 : 34|5@1+ (1,0) [0|31] ""  ECU
+ SG_ VAuxCell4N1 m8 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NCellVAuxErrorFlags m7 : 32|8@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell8N2 m3 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell5N2 m2 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell2N2 m1 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NReleaseMode m0 : 32|2@1+ (1,0) [0|3] ""  ECU
+ SG_ VAuxCell3N1 m8 : 24|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NSerial m6 : 24|32@1+ (1,0) [0|4294967295] ""  ECU
+ SG_ NSettingsCrc m5 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NConfigCrc m4 : 24|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell8N1 m3 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell5N1 m2 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell2N1 m1 : 24|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux3Measured m0 : 24|8@1+ (0.01,0) [0|2.55] "V"  ECU
+ SG_ VAuxCell8N1 m9 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell2N1 m8 : 16|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NCellXcpErrorFlags m7 : 16|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell7N2 m3 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N2 m2 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell1N2 m1 : 16|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux2Measured m0 : 16|8@1+ (0.02,0) [0|5.1] "V"  ECU
+ SG_ VAuxCell7N1 m9 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ VAuxCell1N1 m8 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NCellSwOcpErrorFlags m7 : 8|8@1+ (1,0) [0|255] ""  ECU
+ SG_ NChecksum m6 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NSettingsVersion m5 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ NConfigVersion m4 : 8|16@1+ (1,0) [0|65535] ""  ECU
+ SG_ TCell7N1 m3 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell4N1 m2 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TCell1N1 m1 : 8|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VAux1Measured m0 : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NMultiplexer M : 0|8@1+ (1,0) [0|255] ""  ECU
+
+BO_ 2147489795 BL7_Status: 8 DCDC
+ SG_ BPath1AcModeActivated m0 : 63|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1ErrVAuxCell m0 : 56|1@1+ (1,0) [0|1] ""  ECU
+ SG_ IPath1Unbalance m0 : 48|8@1+ (0.25,0) [0|63.75] "A"  ECU
+ SG_ BPath1RcpWarning m0 : 47|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OcpError m0 : 46|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1OtpError m0 : 45|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBUvpError m0 : 44|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAUvpError m0 : 43|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideBOvpError m0 : 42|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1SideAOvpError m0 : 41|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPath1Requested m0 : 40|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NPath1CurrentSideSelected m0 : 38|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1VoltageSideSelected m0 : 36|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NPath1State m0 : 32|4@1+ (1,0) [0|15] ""  ECU
+ SG_ NMultiplexer M : 29|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BXcpError : 28|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NCellHwErrorFlags : 20|8@1+ (1,0) [0|255] ""  ECU
+ SG_ BIsoError : 19|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncInputSignal : 18|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncRequested : 17|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BInternalTemperatureError : 16|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BConfigSettingsError : 15|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxSupplyError : 14|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BCanTimeoutError : 13|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxIsoEnabled : 12|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeEnabled : 11|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BFaultSignal : 10|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BEnableSignal : 9|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeStatus : 8|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncStatus : 7|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BReadConfigAndSettingsRequested : 6|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSwResetModuleRequested : 5|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSafetyDischargeRequested : 4|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NModuleState : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147491715 BL7_IsoStatus: 6 DCDC
+ SG_ BStartupTimeout : 40|1@1- (1,0) [0|1] ""  ECU
+ SG_ BOtpBuckAux : 39|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BOtpSecError : 38|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BOtpPriError : 37|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BXcpBuckAuxError : 36|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BXcpDcdcError : 35|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSecOcpError : 34|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPriOcpError : 33|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSecUvpError : 32|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSecOvpError : 31|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPriUvpError : 30|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPriOvpError : 29|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BBuckOcpError : 28|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSuppAuxUvpError : 27|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSuppAuxOvpError : 26|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BBuckAuxHwError : 25|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BBuckVAuxDriverError : 24|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BAuxSupplyError : 23|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BCanIntTimeoutError : 22|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BCanTimeoutError : 21|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BConfigSettingsError : 20|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BPowerRequested : 19|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NAuxBuckState : 16|3@1+ (1,0) [0|7] ""  ECU
+ SG_ NChan2State : 13|3@1+ (1,0) [0|7] ""  ECU
+ SG_ NChan1State : 10|3@1+ (1,0) [0|7] ""  ECU
+ SG_ BAuxIsoEnabled : 9|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BFaultSignal : 8|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BEnableSignal : 7|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncInputSignal : 6|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSyncStatus : 5|1@1+ (1,0) [0|1] ""  ECU
+ SG_ BSwResetModuleRequested : 4|1@1+ (1,0) [0|1] ""  ECU
+ SG_ NState : 0|4@1+ (1,0) [0|15] ""  ECU
+
+BO_ 2147491779 BL7_IsoGlobalValues: 8 DCDC
+ SG_ TSecCh2D m4 : 56|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TSecCh1D m3 : 56|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh2D m2 : 56|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh1D m1 : 56|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ NReleaseMode m11 : 48|2@1+ (1,0) [0|3] ""  ECU
+ SG_ NApplicationId m9 : 48|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NSettingsVersion m8 : 48|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NConfigCrc m7 : 48|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NXcpDcdcErrorFlags m6 : 48|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NOtpDcdcErrorFlags m5 : 48|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ TSecCh2C m4 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TSecCh1C m3 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh2C m2 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh1C m1 : 48|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ V1v65Aux m0 : 48|8@1+ (0.01,0) [0|2.55] "V"  ECU
+ SG_ VBuckAuxDriver m5 : 40|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ TSecCh2B m4 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TSecCh1B m3 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh2B m2 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh1B m1 : 40|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ V3v3Aux m0 : 40|8@1+ (0.02,0) [0|5.1] "V"  ECU
+ SG_ NMissedSyncPulseCount m12 : 32|16@1- (1,0) [0|65535] ""  ECU
+ SG_ NChecksum m11 : 32|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NSerial m10 : 32|32@1+ (1,0) [0|4294967296] ""  ECU
+ SG_ NSettingsCrc m9 : 32|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NBootloaderId m8 : 32|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NConfigVersion m7 : 32|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ NOcpDcdcErrorFlags m6 : 32|16@1+ (1,0) [0|65536] ""  ECU
+ SG_ TBuckAux m5 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TSecCh2A m4 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TSecCh1A m3 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh2A m2 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ TPriCh1A m1 : 32|8@1+ (1,-40) [-40|215] "°C"  ECU
+ SG_ VHvAux m0 : 32|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ NMultiplexer M : 24|4@1+ (1,0) [0|15] ""  ECU
+ SG_ VSuppAux : 8|8@1+ (0.15,0) [0|38.25] "V"  ECU
+ SG_ IBuckAux : 0|8@1+ (0.25,-30) [-30|33.75] "A"  ECU
+
+BO_ 2147490691 BL7_IsoPortInternalValue: 6 DCDC
+ SG_ IPortInternalAverage : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortInternalAverage : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortInternalMax : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortInternalMin : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+BO_ 2147490755 BL7_IsoPortC1Value: 6 DCDC
+ SG_ IPortC1Average : 36|12@1+ (0.25,-500) [-500|523.75] "A"  ECU
+ SG_ VPortC1Average : 24|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortC1Max : 12|12@1+ (1,0) [0|4095] "V"  ECU
+ SG_ VPortC1Min : 0|12@1+ (1,0) [0|4095] "V"  ECU
+
+
+
+CM_ "The CAN baudrate can be set by the user according to the following choices: 125Kbps, 250Kbps, 500Kbps and 1Mbps.
+The default value of the CAN bus speed is 500Kbps.";
+CM_ BU_ Brightloop_Can_Loader "Brightloop Can Loader";
+CM_ BU_ ECU "Client Control Unit";
+CM_ BU_ HVHV "HVHV Unit";
+CM_ BO_ 2147487747 "Overal HVHV Status & Diagnostic";
+CM_ SG_ 2147487747 BPath1AcModeActivated "Indicates that the Power Path 1 is working in AC mode";
+CM_ SG_ 2147487747 BPath1AcUfpError "Power path 1 underfrequency fault";
+CM_ SG_ 2147487747 BPath1AcOfpError "Power path 1 overfrequency fault";
+CM_ SG_ 2147487747 NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147487747 BPath1FlgCapaError "Indicates a flying capa voltage error on power path 1";
+CM_ SG_ 2147487747 BPath2FlgCapaError "Indicates a flying capa voltage error on power path 2";
+CM_ SG_ 2147487747 BPath1ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 1";
+CM_ SG_ 2147487747 BPath2ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 2";
+CM_ SG_ 2147487747 IPath1Unbalance "Unbalanced current between cells on power path 1";
+CM_ SG_ 2147487747 IPath2Unbalance "Unbalanced current between cells on power path 2";
+CM_ SG_ 2147487747 BPath1RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147487747 BPath2RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147487747 BPath1OcpError "Power path 1 overcurrent fault";
+CM_ SG_ 2147487747 BPath2OcpError "Power path 2 overcurrent fault";
+CM_ SG_ 2147487747 BPath1OtpError "Power path 1 overtemperature fault";
+CM_ SG_ 2147487747 BPath2OtpError "Power path 2 overtemperature fault";
+CM_ SG_ 2147487747 BPath1SideBUvpError "Power path 1 side B undervoltage fault";
+CM_ SG_ 2147487747 BPath2SideBUvpError "Power path 2 side B undervoltage fault";
+CM_ SG_ 2147487747 BPath1SideAUvpError "Power path 1 side A undervoltage fault";
+CM_ SG_ 2147487747 BPath2SideAUvpError "Power path 2 side A undervoltage fault";
+CM_ SG_ 2147487747 BPath1SideBOvpError "Power path 1 side B overvoltage fault";
+CM_ SG_ 2147487747 BPath2SideBOvpError "Power path 2 side B overvoltage fault";
+CM_ SG_ 2147487747 BPath1SideAOvpError "Power path 1 side A overvoltage fault";
+CM_ SG_ 2147487747 BPath2SideAOvpError "Power path 2 side A overvoltage fault";
+CM_ SG_ 2147487747 BPath1Requested "Indicates that the power path 1 start command has been received";
+CM_ SG_ 2147487747 BPath2Requested "Indicates that the power path 2 start command has been received";
+CM_ SG_ 2147487747 NPath1CurrentSideSelected "Point of current limitation of Power path 1";
+CM_ SG_ 2147487747 NPath2CurrentSideSelected "Point of current limitation of Power path 2";
+CM_ SG_ 2147487747 NPath1VoltageSideSelected "Point of voltage regulation of Power path 1";
+CM_ SG_ 2147487747 NPath2VoltageSideSelected "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147487747 NPath1State "Indicates the power path 1 status";
+CM_ SG_ 2147487747 NPath2State "Indicates the power path 2 status";
+CM_ SG_ 2147487747 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487747 BXcpError "Indicates a power switches command?s integrity fault";
+CM_ SG_ 2147487747 NCellHwErrorFlags "Indicates HW errors triggered on CELL";
+CM_ SG_ 2147487747 BSyncInputSignal "Indicates if a correct synchronization signal is detected on the input synchronization pin";
+CM_ SG_ 2147487747 BSyncRequested "Indicates the synchronization command has been received";
+CM_ SG_ 2147487747 BInternalTemperatureError "Indicates an overtemperature error on the internal temperature";
+CM_ SG_ 2147487747 BConfigSettingsError "Indicates that the Config and/or Settings data is corrupted";
+CM_ SG_ 2147487747 BAuxSupplyError "Indicates a fault on one of the auxiliary power supplies";
+CM_ SG_ 2147487747 BCanTimeoutError "Indicates an error on the CAN bus";
+CM_ SG_ 2147487747 BAuxIsoEnabled "Indicates that isolated auxiliary supplies are activated";
+CM_ SG_ 2147487747 BSafetyDischargeEnabled "Indicates the safety discharge is activated";
+CM_ SG_ 2147487747 BFaultSignal "Indicates the signal Fault status";
+CM_ SG_ 2147487747 BEnableSignal "Indicates the external hardware ENABLE status";
+CM_ SG_ 2147487747 BSafetyDischargeStatus "Indicates the safety discharge status";
+CM_ SG_ 2147487747 BSyncStatus "Indicates the synchronization has been done successfully";
+CM_ SG_ 2147487747 BReadConfigAndSettingsRequested "Indicates that the Read config and settings command has been received";
+CM_ SG_ 2147487747 BSwResetModuleRequested "Indicates that the Software reset command has been received";
+CM_ SG_ 2147487747 BSafetyDischargeRequested "Indicates that the safety discharge command has been received";
+CM_ SG_ 2147487747 NModuleState "Indicates the overall module status";
+CM_ BO_ 2147489411 "Response message giving the present values of the setpoints ";
+CM_ SG_ 2147489411 IqPath1AcLimitLo "Power path 1 AC Iq lower limitation";
+CM_ SG_ 2147489411 IqPath1AcLimitHi "Power path 1 AC Iq upper limitation";
+CM_ SG_ 2147489411 PPath2LimitLo "Power path 2 power lower limitation";
+CM_ SG_ 2147489411 IqPath1AcSetpoint "Power path 1 AC Iq setpoint";
+CM_ SG_ 2147489411 IdPath1AcLimitLo "Power path 1 AC Id lower limitation";
+CM_ SG_ 2147489411 IdPath1AcSetpoint "Power path 1 AC Id setpoint";
+CM_ SG_ 2147489411 IdPath1AcLimitHi "Power path 1 AC Id upper limitation";
+CM_ SG_ 2147489411 PPath2LimitHi "Power path 2 power upper limitation";
+CM_ SG_ 2147489411 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147489347 "Response message giving the present values of the setpoints ";
+CM_ SG_ 2147489347 NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147489347 NPath2CurrentSideSelected "Point of current limitation of Power path 2";
+CM_ SG_ 2147489347 NPath2VoltageSideSelected "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147489347 NPath1AcFrequencySetpoint "Power path 1 AC frequency setpoint";
+CM_ SG_ 2147489347 IPath2LimitLo "Power path 2 current lower limitation";
+CM_ SG_ 2147489347 VqPath1AcSetpoint "Power path 1 AC Vq setpoint";
+CM_ SG_ 2147489347 VdPath1AcSetpoint "Power path 1 AC Vd setpoint";
+CM_ SG_ 2147489347 IPath2LimitHi "Power path 2 current upper limitation";
+CM_ SG_ 2147489347 VDcPath1AcSetpoint "Power path 1 AC Vdc setpoint";
+CM_ SG_ 2147489347 VPath2Setpoint "Power path 2 voltage setpoint";
+CM_ SG_ 2147489347 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147488771 "Values of port B1";
+CM_ SG_ 2147488771 NPortB1OverloadCount "Counter indicating the number of times an overload is detected on port B1";
+CM_ SG_ 2147488771 IPortB1Average "Average value of the port B1 current";
+CM_ SG_ 2147488771 VPortB1Average "Average value of the port B1 voltage";
+CM_ SG_ 2147488771 VPortB1Max "Maximum value of the  port B1 voltage seen since the last message sent";
+CM_ SG_ 2147488771 VPortB1Min "Minimum value of the port B1 voltage seen since the last message sent";
+CM_ BO_ 2147487875 "Values of port A1 ";
+CM_ SG_ 2147487875 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487875 IqPhAPortA1RMS "RMS value of the Iq on phase A";
+CM_ SG_ 2147487875 IqPortA1RMS "RMS value of the Iq on Port";
+CM_ SG_ 2147487875 NFrequencyPortA1 "Frequency of the AC network";
+CM_ SG_ 2147487875 IqPhCPortA1RMS "RMS value of the Iq on phase C";
+CM_ SG_ 2147487875 IdPhAPortA1RMS "RMS value of the Id on phase A";
+CM_ SG_ 2147487875 IdPortA1RMS "RMS value of the Id on Port";
+CM_ SG_ 2147487875 VphCPortA1Peak "Peak value of the voltage on phase C";
+CM_ SG_ 2147487875 IdPhCPortA1RMS "RMS value of the Id on phase C";
+CM_ SG_ 2147487875 IphCPortA1Peak "Peak value of the current on phase C";
+CM_ SG_ 2147487875 VqPortA1RMS "RMS value of the Vq";
+CM_ SG_ 2147487875 VphBPortA1Peak "Peak value of the voltage on phase B";
+CM_ SG_ 2147487875 IqPhBPortA1RMS "RMS value of the Iq on phase B";
+CM_ SG_ 2147487875 IphBPortA1Peak "Peak value of the current on phase B";
+CM_ SG_ 2147487875 VdPortA1RMS "RMS value of the Vd";
+CM_ SG_ 2147487875 VphAPortA1Peak "Peak value of the voltage on phase A";
+CM_ SG_ 2147487875 IphAPortA1Peak "Peak value of the current on phase A";
+CM_ SG_ 2147487875 IdPhBPortA1RMS "RMS value of the Id on phase B";
+CM_ BO_ 2147487939 "Values of port A2 ";
+CM_ SG_ 2147487939 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487939 NPortA2OverloadCount "Counter indicating the number of times an overload is detected on port A2";
+CM_ SG_ 2147487939 IPortA2Average "Average value of the port A2 current";
+CM_ SG_ 2147487939 VPortA2Average "Average value of the port A2 voltage";
+CM_ SG_ 2147487939 VPortA2Max "Maximum value of the  port A2 voltage seen since the last message sent";
+CM_ SG_ 2147487939 VPortA2Min "Minimum value of the port A2 voltage seen since the last message sent";
+CM_ BO_ 2147488387 "Values of internal parameters on PowerPath1";
+CM_ SG_ 2147488387 VPath1FlgCapaLvl2Max "Maximum value of the flying capa level 2 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488387 VPath1FlgCapaLvl2Min "Minimum value of the flying capa level 2 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488387 VPath1FlgCapaLvl1Max "Maximum value of the flying capa level 1 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488387 VPath1FlgCapaLvl1Min "Minimum value of the flying capa level 1 voltage of the power path 1 seen since the last message sent";
+CM_ BO_ 2147488451 "Values of internal parameters on PowerPath2";
+CM_ SG_ 2147488451 VPath2FlgCapaLvl2Max "Maximum value of the flying capa level 2 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488451 VPath2FlgCapaLvl2Min "Minimum value of the flying capa level 2 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488451 VPath2FlgCapaLvl1Max "Maximum value of the flying capa level 1 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488451 VPath2FlgCapaLvl1Min "Minimum value of the flying capa level 1 voltage of the power path 2 seen since the last message sent";
+CM_ BO_ 2147487811 "Global values";
+CM_ SG_ 2147487811 NCellOtpErrorFlags "Indicates overtemperature protection of cells";
+CM_ SG_ 2147487811 TCell3N2 "Temperature number 2 of cell 3";
+CM_ SG_ 2147487811 VAuxCell4N2 "Auxiliary voltage number 2 of cell 4";
+CM_ SG_ 2147487811 TCell3N1 "Temperature number 1 of cell 3";
+CM_ SG_ 2147487811 TInternal "Global product temperature";
+CM_ SG_ 2147487811 NBootloaderId "Version number of the bootloader program";
+CM_ SG_ 2147487811 NApplicationId "Version number of the application program";
+CM_ SG_ 2147487811 VAuxCell3N2 "Auxiliary voltage number 2 of cell 3";
+CM_ SG_ 2147487811 NSyncNodeCount "Number of node on the network";
+CM_ SG_ 2147487811 NSyncNodeRank "Rank of the node on the network";
+CM_ SG_ 2147487811 NReleaseMode "Reserved";
+CM_ SG_ 2147487811 TCell2N2 "Temperature number 2 of cell 2";
+CM_ SG_ 2147487811 NCellVAuxErrorFlags "Indicates Auxiliary voltage error on cells";
+CM_ SG_ 2147487811 VAuxCell4N1 "Auxiliary voltage number 1 of cell 4";
+CM_ SG_ 2147487811 VAuxCell2N2 "Auxiliary voltage number 2 of cell 2";
+CM_ SG_ 2147487811 VAuxCell4N3 "Auxiliary voltage number 3 of cell 4";
+CM_ SG_ 2147487811 TCell4N3 "Temperature number 3 of cell 4";
+CM_ SG_ 2147487811 VAux3Measured "Auxiliary voltage used for offset of current and voltage measurement";
+CM_ SG_ 2147487811 TCell2N1 "Temperature number 1 of cell 2";
+CM_ SG_ 2147487811 NConfigCrc "CRC of the CONFIG";
+CM_ SG_ 2147487811 NSettingsCrc "CRC of the SETTINGS";
+CM_ SG_ 2147487811 NSerial "Product Serial Number";
+CM_ SG_ 2147487811 VAuxCell3N1 "Auxiliary voltage number 1 of cell 3";
+CM_ SG_ 2147487811 VAuxCell1N2 "Auxiliary voltage number 2 of cell 1";
+CM_ SG_ 2147487811 VAuxCell3N3 "Auxiliary voltage number 3 of cell 3";
+CM_ SG_ 2147487811 TCell3N3 "Temperature number 3 of cell 3";
+CM_ SG_ 2147487811 VAux2Measured "Auxiliary voltage 3V3 value";
+CM_ SG_ 2147487811 TCell1N2 "Temperature number 2 of cell 1";
+CM_ SG_ 2147487811 TCell4N2 "Temperature number 2 of cell 4";
+CM_ SG_ 2147487811 NCellXcpErrorFlags "Indicates Xcp error on cells";
+CM_ SG_ 2147487811 VAuxCell2N1 "Auxiliary voltage number 1 of cell 2";
+CM_ SG_ 2147487811 VAuxCell2N3 "Auxiliary voltage number 3 of cell 2";
+CM_ SG_ 2147487811 TCell2N3 "Temperature number 3 of cell 2";
+CM_ SG_ 2147487811 VAux1Measured "Auxiliary voltage LV value";
+CM_ SG_ 2147487811 TCell1N1 "Temperature number 1 of cell 1";
+CM_ SG_ 2147487811 TCell4N1 "Temperature number 1 of cell 4";
+CM_ SG_ 2147487811 NConfigVersion "Version number of the CONFIG";
+CM_ SG_ 2147487811 NSettingsVersion "Version number of the SETTINGS";
+CM_ SG_ 2147487811 NChecksum "Checksum of the application program";
+CM_ SG_ 2147487811 NCellSwOcpErrorFlags "Indicates Sw overcurrent protection ";
+CM_ SG_ 2147487811 VAuxCell1N1 "Auxiliary voltage number 1 of cell 1";
+CM_ SG_ 2147487811 VAuxCell1N3 "Auxiliary voltage number 3 of cell 1";
+CM_ SG_ 2147487811 TCell1N3 "Temperature number 3 of cell 1";
+CM_ SG_ 2147487811 NMultiplexer "Multiplexer ID";
+CM_ BO_ 2147489475 "Value of all parameters of the configuration and settings";
+CM_ SG_ 2147489475 NParameterValue "Value of the 16bits word";
+CM_ SG_ 2147489475 NParameterIndex "Index at which the word is read in the selected zone";
+CM_ SG_ 2147489475 NReadZoneSelect "Zone in which to read the parameters";
+CM_ BO_ 2147489410 "Response message giving the present values of the setpoints ";
+CM_ SG_ 2147489410 PPath2LimitLo "Power path 2 power lower limitation";
+CM_ SG_ 2147489410 PPath2LimitHi "Power path 2 power upper limitation";
+CM_ SG_ 2147489410 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147489346 "Response message giving the present values of the setpoints ";
+CM_ SG_ 2147489346 NPath2CurrentSideSelected "Point of current limitation of Power path 2";
+CM_ SG_ 2147489346 NPath2VoltageSideSelected "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147489346 IPath2LimitLo "Power path 2 current lower limitation";
+CM_ SG_ 2147489346 IPath2LimitHi "Power path 2 current upper limitation";
+CM_ SG_ 2147489346 VPath2Setpoint "Power path 2 voltage setpoint";
+CM_ SG_ 2147489346 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147488450 "Values of internal parameters on PowerPath2";
+CM_ SG_ 2147488450 VPath2FlgCapaLvl2Max "Maximum value of the flying capa level 2 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488450 VPath2FlgCapaLvl2Min "Minimum value of the flying capa level 2 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488450 VPath2FlgCapaLvl1Max "Maximum value of the flying capa level 1 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488450 VPath2FlgCapaLvl1Min "Minimum value of the flying capa level 1 voltage of the power path 2 seen since the last message sent";
+CM_ BO_ 2147488770 "Values of port B1";
+CM_ SG_ 2147488770 NPortB1OverloadCount "Counter indicating the number of times an overload is detected on port B1";
+CM_ SG_ 2147488770 IPortB1Average "Average value of the port B1 current";
+CM_ SG_ 2147488770 VPortB1Average "Average value of the port B1 voltage";
+CM_ SG_ 2147488770 VPortB1Max "Maximum value of the  port B1 voltage seen since the last message sent";
+CM_ SG_ 2147488770 VPortB1Min "Minimum value of the port B1 voltage seen since the last message sent";
+CM_ BO_ 2147488127 "Command message to read the setpoints";
+CM_ SG_ 2147488127 NCrc "CRC of the message. The module accepts this message only when a correct CRC is verified";
+CM_ SG_ 2147488127 NPathSelect "The number of the power path to apply the setpoint read command to";
+CM_ SG_ 2147488127 BPathAcCurrentSetpointSelect "Indicate whether the current setpoint should be returned instead of the current limit for the AC power path. Set this parameter to 1 to ensure the current setpoint is returned in the HVHV_Setpoints2Value message";
+CM_ SG_ 2147488127 BReadSetpointRequest "Setpoint read command";
+CM_ BO_ 2147488063 "Control of error acknowledgement commands";
+CM_ SG_ 2147488063 NCrc "CRC of the message. The module accepts this message only when a correct CRC is verified";
+CM_ SG_ 2147488063 NModuleSelect "Module ID on which to apply error acknowledge : 1-32 for module 1 to module 32, 63 for all modules";
+CM_ SG_ 2147488063 BAckErrorsModuleRequest "Acknowledgement of all errors on module ";
+CM_ SG_ 2147488063 BAckErrorsPath2Request "Acknowledgement of errors on power path 2";
+CM_ SG_ 2147488063 BAckErrorsPath1Request "Acknowledgement of errors on power path 1";
+CM_ BO_ 2147487999 "Control  of Setpoints 2 DC";
+CM_ SG_ 2147487999 NCrc "CRC of the message. The module accepts this message only when a correct CRC is verified";
+CM_ SG_ 2147487999 NModuleSelect "Module ID on which to apply the setpoints";
+CM_ SG_ 2147487999 BL1_PPath2LimitLo "Power path 2 power lower limitation";
+CM_ SG_ 2147487999 BL2_PPath2LimitLo "Power path 2 power lower limitation";
+CM_ SG_ 2147487999 BL3_PPath2LimitLo "Power path 2 power lower limitation";
+CM_ SG_ 2147487999 BL4_PPath2LimitLo "Power path 2 power lower limitation";
+CM_ SG_ 2147487999 BL1_PPath2LimitHi "Power path 2 power upper limitation";
+CM_ SG_ 2147487999 BL2_PPath2LimitHi "Power path 2 power upper limitation";
+CM_ SG_ 2147487999 BL3_PPath2LimitHi "Power path 2 power upper limitation";
+CM_ SG_ 2147487999 BL4_PPath2LimitHi "Power path 2 power upper limitation";
+CM_ SG_ 2147487999 BL1_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ SG_ 2147487999 BL2_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ SG_ 2147487999 BL3_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ SG_ 2147487999 BL4_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ BO_ 2147488191 "Control  of Setpoints 1 AC";
+CM_ SG_ 2147488191 NCrc "CRC of the message. The module accepts this message only when a correct CRC is verified";
+CM_ SG_ 2147488191 NModuleSelect "Module ID on which to apply the setpoints";
+CM_ SG_ 2147488191 BL1_NPath1AcFrequencySetpoint "Power path 1 AC frequency setpoint";
+CM_ SG_ 2147488191 BL2_NPath1AcFrequencySetpoint "Power path 1 AC frequency setpoint";
+CM_ SG_ 2147488191 BL3_NPath1AcFrequencySetpoint "Power path 1 AC frequency setpoint";
+CM_ SG_ 2147488191 BL4_NPath1AcFrequencySetpoint "Power path 1 AC frequency setpoint";
+CM_ SG_ 2147488191 BL1_VqPath1AcSetpoint "Power path 1 AC Vq setpoint";
+CM_ SG_ 2147488191 BL2_VqPath1AcSetpoint "Power path 1 AC Vq setpoint";
+CM_ SG_ 2147488191 BL3_VqPath1AcSetpoint "Power path 1 AC Vq setpoint";
+CM_ SG_ 2147488191 BL4_VqPath1AcSetpoint "Power path 1 AC Vq setpoint";
+CM_ SG_ 2147488191 BL1_VdPath1AcSetpoint "Power path 1 AC Vd setpoint";
+CM_ SG_ 2147488191 BL2_VdPath1AcSetpoint "Power path 1 AC Vd setpoint";
+CM_ SG_ 2147488191 BL3_VdPath1AcSetpoint "Power path 1 AC Vd setpoint";
+CM_ SG_ 2147488191 BL4_VdPath1AcSetpoint "Power path 1 AC Vd setpoint";
+CM_ SG_ 2147488191 BL1_VDcPath1AcSetpoint "Power path 1 AC Vdc setpoint";
+CM_ SG_ 2147488191 BL2_VDcPath1AcSetpoint "Power path 1 AC Vdc setpoint";
+CM_ SG_ 2147488191 BL3_VDcPath1AcSetpoint "Power path 1 AC Vdc setpoint";
+CM_ SG_ 2147488191 BL4_VDcPath1AcSetpoint "Power path 1 AC Vdc setpoint";
+CM_ SG_ 2147488191 BL1_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ SG_ 2147488191 BL2_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ SG_ 2147488191 BL3_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ SG_ 2147488191 BL4_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ BO_ 2147488255 "Control  of Setpoints 2 AC";
+CM_ SG_ 2147488255 NCrc "CRC of the message. The module accepts this message only when a correct CRC is verified";
+CM_ SG_ 2147488255 NModuleSelect "Module ID on which to apply the setpoints";
+CM_ SG_ 2147488255 BL1_IqPath1AcLimitLo "Power path 1 AC Iq lower limitation";
+CM_ SG_ 2147488255 BL2_IqPath1AcLimitLo "Power path 1 AC Iq lower limitation";
+CM_ SG_ 2147488255 BL3_IqPath1AcLimitLo "Power path 1 AC Iq lower limitation";
+CM_ SG_ 2147488255 BL4_IqPath1AcLimitLo "Power path 1 AC Iq lower limitation";
+CM_ SG_ 2147488255 BL1_IqPath1AcLimitHi "Power path 1 AC Iq upper limitation";
+CM_ SG_ 2147488255 BL2_IqPath1AcLimitHi "Power path 1 AC Iq upper limitation";
+CM_ SG_ 2147488255 BL3_IqPath1AcLimitHi "Power path 1 AC Iq upper limitation";
+CM_ SG_ 2147488255 BL4_IqPath1AcLimitHi "Power path 1 AC Iq upper limitation";
+CM_ SG_ 2147488255 BL1_IqPath1AcSetpoint "Power path 1 AC Iq setpoint";
+CM_ SG_ 2147488255 BL1_IdPath1AcLimitLo "Power path 1 AC Id lower limitation";
+CM_ SG_ 2147488255 BL2_IdPath1AcLimitLo "Power path 1 AC Id lower limitation";
+CM_ SG_ 2147488255 BL2_IqPath1AcSetpoint "Power path 1 AC Iq setpoint";
+CM_ SG_ 2147488255 BL3_IqPath1AcSetpoint "Power path 1 AC Iq setpoint";
+CM_ SG_ 2147488255 BL3_IdPath1AcLimitLo "Power path 1 AC Id lower limitation";
+CM_ SG_ 2147488255 BL4_IqPath1AcSetpoint "Power path 1 AC Iq setpoint";
+CM_ SG_ 2147488255 BL4_IdPath1AcLimitLo "Power path 1 AC Id lower limitation";
+CM_ SG_ 2147488255 BL1_IdPath1AcSetpoint "Power path 1 AC Id setpoint";
+CM_ SG_ 2147488255 BL1_IdPath1AcLimitHi "Power path 1 AC Id upper limitation";
+CM_ SG_ 2147488255 BL2_IdPath1AcLimitHi "Power path 1 AC Id upper limitation";
+CM_ SG_ 2147488255 BL2_IdPath1AcSetpoint "Power path 1 AC Id setpoint";
+CM_ SG_ 2147488255 BL3_IdPath1AcSetpoint "Power path 1 AC Id setpoint";
+CM_ SG_ 2147488255 BL3_IdPath1AcLimitHi "Power path 1 AC Id upper limitation";
+CM_ SG_ 2147488255 BL4_IdPath1AcSetpoint "Power path 1 AC Id setpoint";
+CM_ SG_ 2147488255 BL4_IdPath1AcLimitHi "Power path 1 AC Id upper limitation";
+CM_ SG_ 2147488255 BL1_NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147488255 BL2_NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147488255 BL3_NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147488255 BL4_NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147488255 BL1_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ SG_ 2147488255 BL2_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ SG_ 2147488255 BL3_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ SG_ 2147488255 BL4_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ BO_ 2147487938 "Values of port A2 ";
+CM_ SG_ 2147487938 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487938 NPortA2OverloadCount "Counter indicating the number of times an overload is detected on port A2";
+CM_ SG_ 2147487938 IPortA2Average "Average value of the port A2 current";
+CM_ SG_ 2147487938 VPortA2Average "Average value of the port A2 voltage";
+CM_ SG_ 2147487938 VPortA2Max "Maximum value of the  port A2 voltage seen since the last message sent";
+CM_ SG_ 2147487938 VPortA2Min "Minimum value of the port A2 voltage seen since the last message sent";
+CM_ BO_ 2147489474 "Value of all parameters of the configuration and settings";
+CM_ SG_ 2147489474 NParameterValue "Value of the 16bits word";
+CM_ SG_ 2147489474 NParameterIndex "Index at which the word is read in the selected zone";
+CM_ SG_ 2147489474 NReadZoneSelect "Zone in which to read the parameters";
+CM_ BO_ 2147487810 "Global values";
+CM_ SG_ 2147487810 NCellOtpErrorFlags "Indicates overtemperature protection of cells";
+CM_ SG_ 2147487810 TCell3N2 "Temperature number 2 of cell 3";
+CM_ SG_ 2147487810 VAuxCell4N2 "Auxiliary voltage number 2 of cell 4";
+CM_ SG_ 2147487810 TCell3N1 "Temperature number 1 of cell 3";
+CM_ SG_ 2147487810 TInternal "Global product temperature";
+CM_ SG_ 2147487810 NBootloaderId "Version number of the bootloader program";
+CM_ SG_ 2147487810 NApplicationId "Version number of the application program";
+CM_ SG_ 2147487810 VAuxCell3N2 "Auxiliary voltage number 2 of cell 3";
+CM_ SG_ 2147487810 NSyncNodeCount "Number of node on the network";
+CM_ SG_ 2147487810 NSyncNodeRank "Rank of the node on the network";
+CM_ SG_ 2147487810 NReleaseMode "Reserved";
+CM_ SG_ 2147487810 TCell2N2 "Temperature number 2 of cell 2";
+CM_ SG_ 2147487810 NCellVAuxErrorFlags "Indicates Auxiliary voltage error on cells";
+CM_ SG_ 2147487810 VAuxCell4N1 "Auxiliary voltage number 1 of cell 4";
+CM_ SG_ 2147487810 VAuxCell2N2 "Auxiliary voltage number 2 of cell 2";
+CM_ SG_ 2147487810 VAuxCell4N3 "Auxiliary voltage number 3 of cell 4";
+CM_ SG_ 2147487810 TCell4N3 "Temperature number 3 of cell 4";
+CM_ SG_ 2147487810 VAux3Measured "Auxiliary voltage used for offset of current and voltage measurement";
+CM_ SG_ 2147487810 TCell2N1 "Temperature number 1 of cell 2";
+CM_ SG_ 2147487810 NConfigCrc "CRC of the CONFIG";
+CM_ SG_ 2147487810 NSettingsCrc "CRC of the SETTINGS";
+CM_ SG_ 2147487810 NSerial "Product Serial Number";
+CM_ SG_ 2147487810 VAuxCell3N1 "Auxiliary voltage number 1 of cell 3";
+CM_ SG_ 2147487810 VAuxCell1N2 "Auxiliary voltage number 2 of cell 1";
+CM_ SG_ 2147487810 VAuxCell3N3 "Auxiliary voltage number 3 of cell 3";
+CM_ SG_ 2147487810 TCell3N3 "Temperature number 3 of cell 3";
+CM_ SG_ 2147487810 VAux2Measured "Auxiliary voltage 3V3 value";
+CM_ SG_ 2147487810 TCell1N2 "Temperature number 2 of cell 1";
+CM_ SG_ 2147487810 TCell4N2 "Temperature number 2 of cell 4";
+CM_ SG_ 2147487810 NCellXcpErrorFlags "Indicates Xcp error on cells";
+CM_ SG_ 2147487810 VAuxCell2N1 "Auxiliary voltage number 1 of cell 2";
+CM_ SG_ 2147487810 VAuxCell2N3 "Auxiliary voltage number 3 of cell 2";
+CM_ SG_ 2147487810 TCell2N3 "Temperature number 3 of cell 2";
+CM_ SG_ 2147487810 VAux1Measured "Auxiliary voltage LV value";
+CM_ SG_ 2147487810 TCell1N1 "Temperature number 1 of cell 1";
+CM_ SG_ 2147487810 TCell4N1 "Temperature number 1 of cell 4";
+CM_ SG_ 2147487810 NConfigVersion "Version number of the CONFIG";
+CM_ SG_ 2147487810 NSettingsVersion "Version number of the SETTINGS";
+CM_ SG_ 2147487810 NChecksum "Checksum of the application program";
+CM_ SG_ 2147487810 NCellSwOcpErrorFlags "Indicates Sw overcurrent protection ";
+CM_ SG_ 2147487810 VAuxCell1N1 "Auxiliary voltage number 1 of cell 1";
+CM_ SG_ 2147487810 VAuxCell1N3 "Auxiliary voltage number 3 of cell 1";
+CM_ SG_ 2147487810 TCell1N3 "Temperature number 3 of cell 1";
+CM_ SG_ 2147487810 NMultiplexer "Multiplexer ID";
+CM_ BO_ 2147487746 "Overal HVHV Status & Diagnostic";
+CM_ SG_ 2147487746 BPath2FlgCapaError "Indicates a flying capa voltage error on power path 2";
+CM_ SG_ 2147487746 BPath2ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 2";
+CM_ SG_ 2147487746 IPath2Unbalance "Unbalanced current between cells on power path 2";
+CM_ SG_ 2147487746 BPath2RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147487746 BPath2OcpError "Power path 2 overcurrent fault";
+CM_ SG_ 2147487746 BPath2OtpError "Power path 2 overtemperature fault";
+CM_ SG_ 2147487746 BPath2SideBUvpError "Power path 2 side B undervoltage fault";
+CM_ SG_ 2147487746 BPath2SideAUvpError "Power path 2 side A undervoltage fault";
+CM_ SG_ 2147487746 BPath2SideBOvpError "Power path 2 side B overvoltage fault";
+CM_ SG_ 2147487746 BPath2SideAOvpError "Power path 2 side A overvoltage fault";
+CM_ SG_ 2147487746 BPath2Requested "Indicates that the power path 2 start command has been received";
+CM_ SG_ 2147487746 NPath2CurrentSideSelected "Point of current limitation of Power path 2";
+CM_ SG_ 2147487746 NPath2VoltageSideSelected "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147487746 NPath2State "Indicates the power path 2 status";
+CM_ SG_ 2147487746 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487746 BXcpError "Indicates a power switches command?s integrity fault";
+CM_ SG_ 2147487746 NCellHwErrorFlags "Indicates HW errors triggered on CELL";
+CM_ SG_ 2147487746 BSyncInputSignal "Indicates if a correct synchronization signal is detected on the input synchronization pin";
+CM_ SG_ 2147487746 BSyncRequested "Indicates the synchronization command has been received";
+CM_ SG_ 2147487746 BInternalTemperatureError "Indicates an overtemperature error on the internal temperature";
+CM_ SG_ 2147487746 BConfigSettingsError "Indicates that the Config and/or Settings data is corrupted";
+CM_ SG_ 2147487746 BAuxSupplyError "Indicates a fault on one of the auxiliary power supplies";
+CM_ SG_ 2147487746 BCanTimeoutError "Indicates an error on the CAN bus";
+CM_ SG_ 2147487746 BAuxIsoEnabled "Indicates that isolated auxiliary supplies are activated";
+CM_ SG_ 2147487746 BSafetyDischargeEnabled "Indicates the safety discharge is activated";
+CM_ SG_ 2147487746 BFaultSignal "Indicates the signal Fault status";
+CM_ SG_ 2147487746 BEnableSignal "Indicates the external hardware ENABLE status";
+CM_ SG_ 2147487746 BSafetyDischargeStatus "Indicates the safety discharge status";
+CM_ SG_ 2147487746 BSyncStatus "Indicates the synchronization has been done successfully";
+CM_ SG_ 2147487746 BReadConfigAndSettingsRequested "Indicates that the Read config and settings command has been received";
+CM_ SG_ 2147487746 BSwResetModuleRequested "Indicates that the Software reset command has been received";
+CM_ SG_ 2147487746 BSafetyDischargeRequested "Indicates that the safety discharge command has been received";
+CM_ SG_ 2147487746 NModuleState "Indicates the overall module status";
+CM_ BO_ 2147487935 "Control  of Setpoints 1 DC";
+CM_ SG_ 2147487935 NCrc "CRC of the message. The module accepts this message only when a correct CRC is verified";
+CM_ SG_ 2147487935 NModuleSelect "Module ID on which to apply the setpoints";
+CM_ SG_ 2147487935 BL1_NPath2CurrentSideSelect "Point of current limitation of Power path 2";
+CM_ SG_ 2147487935 BL2_NPath2CurrentSideSelect "Point of current limitation of Power path 2";
+CM_ SG_ 2147487935 BL3_NPath2CurrentSideSelect "Point of current limitation of Power path 2";
+CM_ SG_ 2147487935 BL4_NPath2CurrentSideSelect "Point of current limitation of Power path 2";
+CM_ SG_ 2147487935 BL1_NPath2VoltageSideSelect "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147487935 BL2_NPath2VoltageSideSelect "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147487935 BL3_NPath2VoltageSideSelect "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147487935 BL4_NPath2VoltageSideSelect "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147487935 BL1_IPath2LimitLo "Power path 2 current lower limitation";
+CM_ SG_ 2147487935 BL2_IPath2LimitLo "Power path 2 current lower limitation";
+CM_ SG_ 2147487935 BL3_IPath2LimitLo "Power path 2 current lower limitation";
+CM_ SG_ 2147487935 BL4_IPath2LimitLo "Power path 2 current lower limitation";
+CM_ SG_ 2147487935 BL1_IPath2LimitHi "Power path 2 current upper limitation";
+CM_ SG_ 2147487935 BL2_IPath2LimitHi "Power path 2 current upper limitation";
+CM_ SG_ 2147487935 BL3_IPath2LimitHi "Power path 2 current upper limitation";
+CM_ SG_ 2147487935 BL4_IPath2LimitHi "Power path 2 current upper limitation";
+CM_ SG_ 2147487935 BL1_VPath2Setpoint "Power path 2 voltage setpoint";
+CM_ SG_ 2147487935 BL2_VPath2Setpoint "Power path 2 voltage setpoint";
+CM_ SG_ 2147487935 BL3_VPath2Setpoint "Power path 2 voltage setpoint";
+CM_ SG_ 2147487935 BL4_VPath2Setpoint "Power path 2 voltage setpoint";
+CM_ SG_ 2147487935 BL1_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ SG_ 2147487935 BL2_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ SG_ 2147487935 BL3_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ SG_ 2147487935 BL4_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ BO_ 2147487807 "Control message from the ECU";
+CM_ SG_ 2147487807 NCrc "CRC of the message. The module accepts this message only when a correct CRC is verified";
+CM_ SG_ 2147487807 NModuleSelect "Module ID on which to apply software reset command and/or read config and settings command and/or discharge active command : 1-32 for module 1 to module 32, 63 for all modules";
+CM_ SG_ 2147487807 BSyncRequest "Activate synchronization command";
+CM_ SG_ 2147487807 BReadConfigAndSettingsRequest "Read config and settings of module command";
+CM_ SG_ 2147487807 BSwResetModuleRequest "Software reset module command";
+CM_ SG_ 2147487807 BSafetyDischargeRequest "Module safety discharge command";
+CM_ SG_ 2147487807 BPath2Request "Start/Stop power path 2 command";
+CM_ SG_ 2147487807 BPath1Request "Start/Stop power path 1 command";
+CM_ SG_ 2147487807 NCounter "Counter for reception of CAN messages. If it does not change for more than CanTimeOut parameter then an error is detected (CAN error)";
+CM_ BO_ 2147487749 "Overal HVHV Status & Diagnostic";
+CM_ SG_ 2147487749 BPath1AcModeActivated "Indicates that the Power Path 1 is working in AC mode";
+CM_ SG_ 2147487749 BPath1AcUfpError "Power path 1 underfrequency fault";
+CM_ SG_ 2147487749 BPath1AcOfpError "Power path 1 overfrequency fault";
+CM_ SG_ 2147487749 NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147487749 BPath2FlgCapaError "Indicates a flying capa voltage error on power path 2";
+CM_ SG_ 2147487749 BPath1FlgCapaError "Indicates a flying capa voltage error on power path 1";
+CM_ SG_ 2147487749 BPath2ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 2";
+CM_ SG_ 2147487749 BPath1ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 1";
+CM_ SG_ 2147487749 IPath2Unbalance "Unbalanced current between cells on power path 2";
+CM_ SG_ 2147487749 IPath1Unbalance "Unbalanced current between cells on power path 1";
+CM_ SG_ 2147487749 BPath2RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147487749 BPath1RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147487749 BPath2OcpError "Power path 2 overcurrent fault";
+CM_ SG_ 2147487749 BPath1OcpError "Power path 1 overcurrent fault";
+CM_ SG_ 2147487749 BPath2OtpError "Power path 2 overtemperature fault";
+CM_ SG_ 2147487749 BPath1OtpError "Power path 1 overtemperature fault";
+CM_ SG_ 2147487749 BPath2SideBUvpError "Power path 2 side B undervoltage fault";
+CM_ SG_ 2147487749 BPath1SideBUvpError "Power path 1 side B undervoltage fault";
+CM_ SG_ 2147487749 BPath2SideAUvpError "Power path 2 side A undervoltage fault";
+CM_ SG_ 2147487749 BPath1SideAUvpError "Power path 1 side A undervoltage fault";
+CM_ SG_ 2147487749 BPath2SideBOvpError "Power path 2 side B overvoltage fault";
+CM_ SG_ 2147487749 BPath1SideBOvpError "Power path 1 side B overvoltage fault";
+CM_ SG_ 2147487749 BPath2SideAOvpError "Power path 2 side A overvoltage fault";
+CM_ SG_ 2147487749 BPath1SideAOvpError "Power path 1 side A overvoltage fault";
+CM_ SG_ 2147487749 BPath2Requested "Indicates that the power path 2 start command has been received";
+CM_ SG_ 2147487749 BPath1Requested "Indicates that the power path 1 start command has been received";
+CM_ SG_ 2147487749 NPath2CurrentSideSelected "Point of current limitation of Power path 2";
+CM_ SG_ 2147487749 NPath1CurrentSideSelected "Point of current limitation of Power path 1";
+CM_ SG_ 2147487749 NPath2VoltageSideSelected "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147487749 NPath1VoltageSideSelected "Point of voltage regulation of Power path 1";
+CM_ SG_ 2147487749 NPath2State "Indicates the power path 2 status";
+CM_ SG_ 2147487749 NPath1State "Indicates the power path 1 status";
+CM_ SG_ 2147487749 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487749 BXcpError "Indicates a power switches command?s integrity fault";
+CM_ SG_ 2147487749 NCellHwErrorFlags "Indicates HW errors triggered on CELL";
+CM_ SG_ 2147487749 BSyncInputSignal "Indicates if a correct synchronization signal is detected on the input synchronization pin";
+CM_ SG_ 2147487749 BSyncRequested "Indicates the synchronization command has been received";
+CM_ SG_ 2147487749 BInternalTemperatureError "Indicates an overtemperature error on the internal temperature";
+CM_ SG_ 2147487749 BConfigSettingsError "Indicates that the Config and/or Settings data is corrupted";
+CM_ SG_ 2147487749 BAuxSupplyError "Indicates a fault on one of the auxiliary power supplies";
+CM_ SG_ 2147487749 BCanTimeoutError "Indicates an error on the CAN bus";
+CM_ SG_ 2147487749 BAuxIsoEnabled "Indicates that isolated auxiliary supplies are activated";
+CM_ SG_ 2147487749 BSafetyDischargeEnabled "Indicates the safety discharge is activated";
+CM_ SG_ 2147487749 BFaultSignal "Indicates the signal Fault status";
+CM_ SG_ 2147487749 BEnableSignal "Indicates the external hardware ENABLE status";
+CM_ SG_ 2147487749 BSafetyDischargeStatus "Indicates the safety discharge status";
+CM_ SG_ 2147487749 BSyncStatus "Indicates the synchronization has been done successfully";
+CM_ SG_ 2147487749 BReadConfigAndSettingsRequested "Indicates that the Read config and settings command has been received";
+CM_ SG_ 2147487749 BSwResetModuleRequested "Indicates that the Software reset command has been received";
+CM_ SG_ 2147487749 BSafetyDischargeRequested "Indicates that the safety discharge command has been received";
+CM_ SG_ 2147487749 NModuleState "Indicates the overall module status";
+CM_ BO_ 2147489413 "Response message giving the present values of the setpoints ";
+CM_ SG_ 2147489413 IqPath1AcLimitLo "Power path 1 AC Iq lower limitation";
+CM_ SG_ 2147489413 IqPath1AcLimitHi "Power path 1 AC Iq upper limitation";
+CM_ SG_ 2147489413 PPath2LimitLo "Power path 2 power lower limitation";
+CM_ SG_ 2147489413 IdPath1AcLimitLo "Power path 1 AC Id lower limitation";
+CM_ SG_ 2147489413 IqPath1AcSetpoint "Power path 1 AC Iq setpoint";
+CM_ SG_ 2147489413 PPath2LimitHi "Power path 2 power upper limitation";
+CM_ SG_ 2147489413 IdPath1AcLimitHi "Power path 1 AC Id upper limitation";
+CM_ SG_ 2147489413 IdPath1AcSetpoint "Power path 1 AC Id setpoint";
+CM_ SG_ 2147489413 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147489349 "Response message giving the present values of the setpoints ";
+CM_ SG_ 2147489349 NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147489349 NPath2CurrentSideSelected "Point of current limitation of Power path 2";
+CM_ SG_ 2147489349 NPath2VoltageSideSelected "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147489349 NPath1AcFrequencySetpoint "Power path 1 AC frequency setpoint";
+CM_ SG_ 2147489349 IPath2LimitLo "Power path 2 current lower limitation";
+CM_ SG_ 2147489349 VqPath1AcSetpoint "Power path 1 AC Vq setpoint";
+CM_ SG_ 2147489349 IPath2LimitHi "Power path 2 current upper limitation";
+CM_ SG_ 2147489349 VdPath1AcSetpoint "Power path 1 AC Vd setpoint";
+CM_ SG_ 2147489349 VPath2Setpoint "Power path 2 voltage setpoint";
+CM_ SG_ 2147489349 VDcPath1AcSetpoint "Power path 1 AC Vdc setpoint";
+CM_ SG_ 2147489349 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147488773 "Values of port B1";
+CM_ SG_ 2147488773 NPortB1OverloadCount "Counter indicating the number of times an overload is detected on port B1";
+CM_ SG_ 2147488773 IPortB1Average "Average value of the port B1 current";
+CM_ SG_ 2147488773 VPortB1Average "Average value of the port B1 voltage";
+CM_ SG_ 2147488773 VPortB1Max "Maximum value of the  port B1 voltage seen since the last message sent";
+CM_ SG_ 2147488773 VPortB1Min "Minimum value of the port B1 voltage seen since the last message sent";
+CM_ BO_ 2147487877 "Values of port A1 ";
+CM_ SG_ 2147487877 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487877 IqPhAPortA1RMS "RMS value of the Iq on phase A";
+CM_ SG_ 2147487877 IqPhCPortA1RMS "RMS value of the Iq on phase C";
+CM_ SG_ 2147487877 NFrequencyPortA1 "Frequency of the AC network";
+CM_ SG_ 2147487877 IqPortA1RMS "RMS value of the Iq on Port";
+CM_ SG_ 2147487877 IdPhAPortA1RMS "RMS value of the Id on phase A";
+CM_ SG_ 2147487877 IdPhCPortA1RMS "RMS value of the Id on phase C";
+CM_ SG_ 2147487877 VphCPortA1Peak "Peak value of the voltage on phase C";
+CM_ SG_ 2147487877 IdPortA1RMS "RMS value of the Id on Port";
+CM_ SG_ 2147487877 IphCPortA1Peak "Peak value of the current on phase C";
+CM_ SG_ 2147487877 IqPhBPortA1RMS "RMS value of the Iq on phase B";
+CM_ SG_ 2147487877 VphBPortA1Peak "Peak value of the voltage on phase B";
+CM_ SG_ 2147487877 VqPortA1RMS "RMS value of the Vq";
+CM_ SG_ 2147487877 IphBPortA1Peak "Peak value of the current on phase B";
+CM_ SG_ 2147487877 IdPhBPortA1RMS "RMS value of the Id on phase B";
+CM_ SG_ 2147487877 IphAPortA1Peak "Peak value of the current on phase A";
+CM_ SG_ 2147487877 VphAPortA1Peak "Peak value of the voltage on phase A";
+CM_ SG_ 2147487877 VdPortA1RMS "RMS value of the Vd";
+CM_ BO_ 2147487941 "Values of port A2 ";
+CM_ SG_ 2147487941 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487941 NPortA2OverloadCount "Counter indicating the number of times an overload is detected on port A2";
+CM_ SG_ 2147487941 IPortA2Average "Average value of the port A2 current";
+CM_ SG_ 2147487941 VPortA2Average "Average value of the port A2 voltage";
+CM_ SG_ 2147487941 VPortA2Max "Maximum value of the  port A2 voltage seen since the last message sent";
+CM_ SG_ 2147487941 VPortA2Min "Minimum value of the port A2 voltage seen since the last message sent";
+CM_ BO_ 2147488389 "Values of internal parameters on PowerPath1";
+CM_ SG_ 2147488389 VPath1FlgCapaLvl2Max "Maximum value of the flying capa level 2 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488389 VPath1FlgCapaLvl2Min "Minimum value of the flying capa level 2 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488389 VPath1FlgCapaLvl1Max "Maximum value of the flying capa level 1 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488389 VPath1FlgCapaLvl1Min "Minimum value of the flying capa level 1 voltage of the power path 1 seen since the last message sent";
+CM_ BO_ 2147488453 "Values of internal parameters on PowerPath2";
+CM_ SG_ 2147488453 VPath2FlgCapaLvl2Max "Maximum value of the flying capa level 2 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488453 VPath2FlgCapaLvl2Min "Minimum value of the flying capa level 2 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488453 VPath2FlgCapaLvl1Max "Maximum value of the flying capa level 1 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488453 VPath2FlgCapaLvl1Min "Minimum value of the flying capa level 1 voltage of the power path 2 seen since the last message sent";
+CM_ BO_ 2147487813 "Global values";
+CM_ SG_ 2147487813 VAuxCell4N2 "Auxiliary voltage number 2 of cell 4";
+CM_ SG_ 2147487813 TCell3N2 "Temperature number 2 of cell 3";
+CM_ SG_ 2147487813 NCellOtpErrorFlags "Indicates overtemperature protection of cells";
+CM_ SG_ 2147487813 VAuxCell3N2 "Auxiliary voltage number 2 of cell 3";
+CM_ SG_ 2147487813 NApplicationId "Version number of the application program";
+CM_ SG_ 2147487813 NBootloaderId "Version number of the bootloader program";
+CM_ SG_ 2147487813 TInternal "Global product temperature";
+CM_ SG_ 2147487813 TCell3N1 "Temperature number 1 of cell 3";
+CM_ SG_ 2147487813 NSyncNodeCount "Number of node on the network";
+CM_ SG_ 2147487813 NSyncNodeRank "Rank of the node on the network";
+CM_ SG_ 2147487813 TCell4N3 "Temperature number 3 of cell 4";
+CM_ SG_ 2147487813 VAuxCell4N3 "Auxiliary voltage number 3 of cell 4";
+CM_ SG_ 2147487813 VAuxCell2N2 "Auxiliary voltage number 2 of cell 2";
+CM_ SG_ 2147487813 VAuxCell4N1 "Auxiliary voltage number 1 of cell 4";
+CM_ SG_ 2147487813 NCellVAuxErrorFlags "Indicates Auxiliary voltage error on cells";
+CM_ SG_ 2147487813 TCell2N2 "Temperature number 2 of cell 2";
+CM_ SG_ 2147487813 NReleaseMode "Reserved";
+CM_ SG_ 2147487813 TCell3N3 "Temperature number 3 of cell 3";
+CM_ SG_ 2147487813 VAuxCell3N3 "Auxiliary voltage number 3 of cell 3";
+CM_ SG_ 2147487813 VAuxCell1N2 "Auxiliary voltage number 2 of cell 1";
+CM_ SG_ 2147487813 VAuxCell3N1 "Auxiliary voltage number 1 of cell 3";
+CM_ SG_ 2147487813 NSerial "Product Serial Number";
+CM_ SG_ 2147487813 NSettingsCrc "CRC of the SETTINGS";
+CM_ SG_ 2147487813 NConfigCrc "CRC of the CONFIG";
+CM_ SG_ 2147487813 TCell2N1 "Temperature number 1 of cell 2";
+CM_ SG_ 2147487813 VAux3Measured "Auxiliary voltage used for offset of current and voltage measurement";
+CM_ SG_ 2147487813 TCell2N3 "Temperature number 3 of cell 2";
+CM_ SG_ 2147487813 VAuxCell2N3 "Auxiliary voltage number 3 of cell 2";
+CM_ SG_ 2147487813 VAuxCell2N1 "Auxiliary voltage number 1 of cell 2";
+CM_ SG_ 2147487813 NCellXcpErrorFlags "Indicates Xcp error on cells";
+CM_ SG_ 2147487813 TCell4N2 "Temperature number 2 of cell 4";
+CM_ SG_ 2147487813 TCell1N2 "Temperature number 2 of cell 1";
+CM_ SG_ 2147487813 VAux2Measured "Auxiliary voltage 3V3 value";
+CM_ SG_ 2147487813 TCell1N3 "Temperature number 3 of cell 1";
+CM_ SG_ 2147487813 VAuxCell1N3 "Auxiliary voltage number 3 of cell 1";
+CM_ SG_ 2147487813 VAuxCell1N1 "Auxiliary voltage number 1 of cell 1";
+CM_ SG_ 2147487813 NCellSwOcpErrorFlags "Indicates Sw overcurrent protection ";
+CM_ SG_ 2147487813 NChecksum "Checksum of the application program";
+CM_ SG_ 2147487813 NSettingsVersion "Version number of the SETTINGS";
+CM_ SG_ 2147487813 NConfigVersion "Version number of the CONFIG";
+CM_ SG_ 2147487813 TCell4N1 "Temperature number 1 of cell 4";
+CM_ SG_ 2147487813 TCell1N1 "Temperature number 1 of cell 1";
+CM_ SG_ 2147487813 VAux1Measured "Auxiliary voltage LV value";
+CM_ SG_ 2147487813 NMultiplexer "Multiplexer ID";
+CM_ BO_ 2147489477 "Value of all parameters of the configuration and settings";
+CM_ SG_ 2147489477 NParameterValue "Value of the 16bits word";
+CM_ SG_ 2147489477 NParameterIndex "Index at which the word is read in the selected zone";
+CM_ SG_ 2147489477 NReadZoneSelect "Zone in which to read the parameters";
+CM_ BO_ 2147489412 "Response message giving the present values of the setpoints ";
+CM_ SG_ 2147489412 IqPath1AcLimitLo "Power path 1 AC Iq lower limitation";
+CM_ SG_ 2147489412 IqPath1AcLimitHi "Power path 1 AC Iq upper limitation";
+CM_ SG_ 2147489412 PPath2LimitLo "Power path 2 power lower limitation";
+CM_ SG_ 2147489412 IdPath1AcLimitLo "Power path 1 AC Id lower limitation";
+CM_ SG_ 2147489412 IqPath1AcSetpoint "Power path 1 AC Iq setpoint";
+CM_ SG_ 2147489412 PPath2LimitHi "Power path 2 power upper limitation";
+CM_ SG_ 2147489412 IdPath1AcLimitHi "Power path 1 AC Id upper limitation";
+CM_ SG_ 2147489412 IdPath1AcSetpoint "Power path 1 AC Id setpoint";
+CM_ SG_ 2147489412 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147489348 "Response message giving the present values of the setpoints ";
+CM_ SG_ 2147489348 NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147489348 NPath2CurrentSideSelected "Point of current limitation of Power path 2";
+CM_ SG_ 2147489348 NPath2VoltageSideSelected "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147489348 NPath1AcFrequencySetpoint "Power path 1 AC frequency setpoint";
+CM_ SG_ 2147489348 IPath2LimitLo "Power path 2 current lower limitation";
+CM_ SG_ 2147489348 VqPath1AcSetpoint "Power path 1 AC Vq setpoint";
+CM_ SG_ 2147489348 IPath2LimitHi "Power path 2 current upper limitation";
+CM_ SG_ 2147489348 VdPath1AcSetpoint "Power path 1 AC Vd setpoint";
+CM_ SG_ 2147489348 VPath2Setpoint "Power path 2 voltage setpoint";
+CM_ SG_ 2147489348 VDcPath1AcSetpoint "Power path 1 AC Vdc setpoint";
+CM_ SG_ 2147489348 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147488388 "Values of internal parameters on PowerPath1";
+CM_ SG_ 2147488388 VPath1FlgCapaLvl2Max "Maximum value of the flying capa level 2 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488388 VPath1FlgCapaLvl2Min "Minimum value of the flying capa level 2 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488388 VPath1FlgCapaLvl1Max "Maximum value of the flying capa level 1 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488388 VPath1FlgCapaLvl1Min "Minimum value of the flying capa level 1 voltage of the power path 1 seen since the last message sent";
+CM_ BO_ 2147488452 "Values of internal parameters on PowerPath2";
+CM_ SG_ 2147488452 VPath2FlgCapaLvl2Max "Maximum value of the flying capa level 2 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488452 VPath2FlgCapaLvl2Min "Minimum value of the flying capa level 2 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488452 VPath2FlgCapaLvl1Max "Maximum value of the flying capa level 1 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488452 VPath2FlgCapaLvl1Min "Minimum value of the flying capa level 1 voltage of the power path 2 seen since the last message sent";
+CM_ BO_ 2147488772 "Values of port B1";
+CM_ SG_ 2147488772 NPortB1OverloadCount "Counter indicating the number of times an overload is detected on port B1";
+CM_ SG_ 2147488772 IPortB1Average "Average value of the port B1 current";
+CM_ SG_ 2147488772 VPortB1Average "Average value of the port B1 voltage";
+CM_ SG_ 2147488772 VPortB1Max "Maximum value of the  port B1 voltage seen since the last message sent";
+CM_ SG_ 2147488772 VPortB1Min "Minimum value of the port B1 voltage seen since the last message sent";
+CM_ BO_ 2147487876 "Values of port A1 ";
+CM_ SG_ 2147487876 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487876 IqPhAPortA1RMS "RMS value of the Iq on phase A";
+CM_ SG_ 2147487876 IqPhCPortA1RMS "RMS value of the Iq on phase C";
+CM_ SG_ 2147487876 NFrequencyPortA1 "Frequency of the AC network";
+CM_ SG_ 2147487876 IqPortA1RMS "RMS value of the Iq on Port";
+CM_ SG_ 2147487876 IdPhAPortA1RMS "RMS value of the Id on phase A";
+CM_ SG_ 2147487876 IdPhCPortA1RMS "RMS value of the Id on phase C";
+CM_ SG_ 2147487876 VphCPortA1Peak "Peak value of the voltage on phase C";
+CM_ SG_ 2147487876 IdPortA1RMS "RMS value of the Id on Port";
+CM_ SG_ 2147487876 IphCPortA1Peak "Peak value of the current on phase C";
+CM_ SG_ 2147487876 IqPhBPortA1RMS "RMS value of the Iq on phase B";
+CM_ SG_ 2147487876 VphBPortA1Peak "Peak value of the voltage on phase B";
+CM_ SG_ 2147487876 VqPortA1RMS "RMS value of the Vq";
+CM_ SG_ 2147487876 IphBPortA1Peak "Peak value of the current on phase B";
+CM_ SG_ 2147487876 IdPhBPortA1RMS "RMS value of the Id on phase B";
+CM_ SG_ 2147487876 IphAPortA1Peak "Peak value of the current on phase A";
+CM_ SG_ 2147487876 VphAPortA1Peak "Peak value of the voltage on phase A";
+CM_ SG_ 2147487876 VdPortA1RMS "RMS value of the Vd";
+CM_ BO_ 2147487940 "Values of port A2 ";
+CM_ SG_ 2147487940 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487940 NPortA2OverloadCount "Counter indicating the number of times an overload is detected on port A2";
+CM_ SG_ 2147487940 IPortA2Average "Average value of the port A2 current";
+CM_ SG_ 2147487940 VPortA2Average "Average value of the port A2 voltage";
+CM_ SG_ 2147487940 VPortA2Max "Maximum value of the  port A2 voltage seen since the last message sent";
+CM_ SG_ 2147487940 VPortA2Min "Minimum value of the port A2 voltage seen since the last message sent";
+CM_ BO_ 2147489476 "Value of all parameters of the configuration and settings";
+CM_ SG_ 2147489476 NParameterValue "Value of the 16bits word";
+CM_ SG_ 2147489476 NParameterIndex "Index at which the word is read in the selected zone";
+CM_ SG_ 2147489476 NReadZoneSelect "Zone in which to read the parameters";
+CM_ BO_ 2147487812 "Global values";
+CM_ SG_ 2147487812 VAuxCell4N2 "Auxiliary voltage number 2 of cell 4";
+CM_ SG_ 2147487812 TCell3N2 "Temperature number 2 of cell 3";
+CM_ SG_ 2147487812 NCellOtpErrorFlags "Indicates overtemperature protection of cells";
+CM_ SG_ 2147487812 VAuxCell3N2 "Auxiliary voltage number 2 of cell 3";
+CM_ SG_ 2147487812 NApplicationId "Version number of the application program";
+CM_ SG_ 2147487812 NBootloaderId "Version number of the bootloader program";
+CM_ SG_ 2147487812 TInternal "Global product temperature";
+CM_ SG_ 2147487812 TCell3N1 "Temperature number 1 of cell 3";
+CM_ SG_ 2147487812 NSyncNodeCount "Number of node on the network";
+CM_ SG_ 2147487812 NSyncNodeRank "Rank of the node on the network";
+CM_ SG_ 2147487812 TCell4N3 "Temperature number 3 of cell 4";
+CM_ SG_ 2147487812 VAuxCell4N3 "Auxiliary voltage number 3 of cell 4";
+CM_ SG_ 2147487812 VAuxCell2N2 "Auxiliary voltage number 2 of cell 2";
+CM_ SG_ 2147487812 VAuxCell4N1 "Auxiliary voltage number 1 of cell 4";
+CM_ SG_ 2147487812 NCellVAuxErrorFlags "Indicates Auxiliary voltage error on cells";
+CM_ SG_ 2147487812 TCell2N2 "Temperature number 2 of cell 2";
+CM_ SG_ 2147487812 NReleaseMode "Reserved";
+CM_ SG_ 2147487812 TCell3N3 "Temperature number 3 of cell 3";
+CM_ SG_ 2147487812 VAuxCell3N3 "Auxiliary voltage number 3 of cell 3";
+CM_ SG_ 2147487812 VAuxCell1N2 "Auxiliary voltage number 2 of cell 1";
+CM_ SG_ 2147487812 VAuxCell3N1 "Auxiliary voltage number 1 of cell 3";
+CM_ SG_ 2147487812 NSerial "Product Serial Number";
+CM_ SG_ 2147487812 NSettingsCrc "CRC of the SETTINGS";
+CM_ SG_ 2147487812 NConfigCrc "CRC of the CONFIG";
+CM_ SG_ 2147487812 TCell2N1 "Temperature number 1 of cell 2";
+CM_ SG_ 2147487812 VAux3Measured "Auxiliary voltage used for offset of current and voltage measurement";
+CM_ SG_ 2147487812 TCell2N3 "Temperature number 3 of cell 2";
+CM_ SG_ 2147487812 VAuxCell2N3 "Auxiliary voltage number 3 of cell 2";
+CM_ SG_ 2147487812 VAuxCell2N1 "Auxiliary voltage number 1 of cell 2";
+CM_ SG_ 2147487812 NCellXcpErrorFlags "Indicates Xcp error on cells";
+CM_ SG_ 2147487812 TCell4N2 "Temperature number 2 of cell 4";
+CM_ SG_ 2147487812 TCell1N2 "Temperature number 2 of cell 1";
+CM_ SG_ 2147487812 VAux2Measured "Auxiliary voltage 3V3 value";
+CM_ SG_ 2147487812 TCell1N3 "Temperature number 3 of cell 1";
+CM_ SG_ 2147487812 VAuxCell1N3 "Auxiliary voltage number 3 of cell 1";
+CM_ SG_ 2147487812 VAuxCell1N1 "Auxiliary voltage number 1 of cell 1";
+CM_ SG_ 2147487812 NCellSwOcpErrorFlags "Indicates Sw overcurrent protection ";
+CM_ SG_ 2147487812 NChecksum "Checksum of the application program";
+CM_ SG_ 2147487812 NSettingsVersion "Version number of the SETTINGS";
+CM_ SG_ 2147487812 NConfigVersion "Version number of the CONFIG";
+CM_ SG_ 2147487812 TCell4N1 "Temperature number 1 of cell 4";
+CM_ SG_ 2147487812 TCell1N1 "Temperature number 1 of cell 1";
+CM_ SG_ 2147487812 VAux1Measured "Auxiliary voltage LV value";
+CM_ SG_ 2147487812 NMultiplexer "Multiplexer ID";
+CM_ BO_ 2147487748 "Overal HVHV Status & Diagnostic";
+CM_ SG_ 2147487748 BPath1AcModeActivated "Indicates that the Power Path 1 is working in AC mode";
+CM_ SG_ 2147487748 BPath1AcUfpError "Power path 1 underfrequency fault";
+CM_ SG_ 2147487748 BPath1AcOfpError "Power path 1 overfrequency fault";
+CM_ SG_ 2147487748 NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147487748 BPath2FlgCapaError "Indicates a flying capa voltage error on power path 2";
+CM_ SG_ 2147487748 BPath1FlgCapaError "Indicates a flying capa voltage error on power path 1";
+CM_ SG_ 2147487748 BPath2ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 2";
+CM_ SG_ 2147487748 BPath1ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 1";
+CM_ SG_ 2147487748 IPath2Unbalance "Unbalanced current between cells on power path 2";
+CM_ SG_ 2147487748 IPath1Unbalance "Unbalanced current between cells on power path 1";
+CM_ SG_ 2147487748 BPath2RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147487748 BPath1RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147487748 BPath2OcpError "Power path 2 overcurrent fault";
+CM_ SG_ 2147487748 BPath1OcpError "Power path 1 overcurrent fault";
+CM_ SG_ 2147487748 BPath2OtpError "Power path 2 overtemperature fault";
+CM_ SG_ 2147487748 BPath1OtpError "Power path 1 overtemperature fault";
+CM_ SG_ 2147487748 BPath2SideBUvpError "Power path 2 side B undervoltage fault";
+CM_ SG_ 2147487748 BPath1SideBUvpError "Power path 1 side B undervoltage fault";
+CM_ SG_ 2147487748 BPath2SideAUvpError "Power path 2 side A undervoltage fault";
+CM_ SG_ 2147487748 BPath1SideAUvpError "Power path 1 side A undervoltage fault";
+CM_ SG_ 2147487748 BPath2SideBOvpError "Power path 2 side B overvoltage fault";
+CM_ SG_ 2147487748 BPath1SideBOvpError "Power path 1 side B overvoltage fault";
+CM_ SG_ 2147487748 BPath2SideAOvpError "Power path 2 side A overvoltage fault";
+CM_ SG_ 2147487748 BPath1SideAOvpError "Power path 1 side A overvoltage fault";
+CM_ SG_ 2147487748 BPath2Requested "Indicates that the power path 2 start command has been received";
+CM_ SG_ 2147487748 BPath1Requested "Indicates that the power path 1 start command has been received";
+CM_ SG_ 2147487748 NPath2CurrentSideSelected "Point of current limitation of Power path 2";
+CM_ SG_ 2147487748 NPath1CurrentSideSelected "Point of current limitation of Power path 1";
+CM_ SG_ 2147487748 NPath2VoltageSideSelected "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147487748 NPath1VoltageSideSelected "Point of voltage regulation of Power path 1";
+CM_ SG_ 2147487748 NPath2State "Indicates the power path 2 status";
+CM_ SG_ 2147487748 NPath1State "Indicates the power path 1 status";
+CM_ SG_ 2147487748 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487748 BXcpError "Indicates a power switches command?s integrity fault";
+CM_ SG_ 2147487748 NCellHwErrorFlags "Indicates HW errors triggered on CELL";
+CM_ SG_ 2147487748 BSyncInputSignal "Indicates if a correct synchronization signal is detected on the input synchronization pin";
+CM_ SG_ 2147487748 BSyncRequested "Indicates the synchronization command has been received";
+CM_ SG_ 2147487748 BInternalTemperatureError "Indicates an overtemperature error on the internal temperature";
+CM_ SG_ 2147487748 BConfigSettingsError "Indicates that the Config and/or Settings data is corrupted";
+CM_ SG_ 2147487748 BAuxSupplyError "Indicates a fault on one of the auxiliary power supplies";
+CM_ SG_ 2147487748 BCanTimeoutError "Indicates an error on the CAN bus";
+CM_ SG_ 2147487748 BAuxIsoEnabled "Indicates that isolated auxiliary supplies are activated";
+CM_ SG_ 2147487748 BSafetyDischargeEnabled "Indicates the safety discharge is activated";
+CM_ SG_ 2147487748 BFaultSignal "Indicates the signal Fault status";
+CM_ SG_ 2147487748 BEnableSignal "Indicates the external hardware ENABLE status";
+CM_ SG_ 2147487748 BSafetyDischargeStatus "Indicates the safety discharge status";
+CM_ SG_ 2147487748 BSyncStatus "Indicates the synchronization has been done successfully";
+CM_ SG_ 2147487748 BReadConfigAndSettingsRequested "Indicates that the Read config and settings command has been received";
+CM_ SG_ 2147487748 BSwResetModuleRequested "Indicates that the Software reset command has been received";
+CM_ SG_ 2147487748 BSafetyDischargeRequested "Indicates that the safety discharge command has been received";
+CM_ SG_ 2147487748 NModuleState "Indicates the overall module status";
+CM_ BO_ 2147487751 "Overal HVHV Status & Diagnostic";
+CM_ SG_ 2147487751 BPath1AcModeActivated "Indicates that the Power Path 1 is working in AC mode";
+CM_ SG_ 2147487751 BPath1AcUfpError "Power path 1 underfrequency fault";
+CM_ SG_ 2147487751 BPath1AcOfpError "Power path 1 overfrequency fault";
+CM_ SG_ 2147487751 NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147487751 BPath1FlgCapaError "Indicates a flying capa voltage error on power path 1";
+CM_ SG_ 2147487751 BPath2FlgCapaError "Indicates a flying capa voltage error on power path 2";
+CM_ SG_ 2147487751 BPath1ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 1";
+CM_ SG_ 2147487751 BPath2ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 2";
+CM_ SG_ 2147487751 IPath1Unbalance "Unbalanced current between cells on power path 1";
+CM_ SG_ 2147487751 IPath2Unbalance "Unbalanced current between cells on power path 2";
+CM_ SG_ 2147487751 BPath1RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147487751 BPath2RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147487751 BPath1OcpError "Power path 1 overcurrent fault";
+CM_ SG_ 2147487751 BPath2OcpError "Power path 2 overcurrent fault";
+CM_ SG_ 2147487751 BPath1OtpError "Power path 1 overtemperature fault";
+CM_ SG_ 2147487751 BPath2OtpError "Power path 2 overtemperature fault";
+CM_ SG_ 2147487751 BPath1SideBUvpError "Power path 1 side B undervoltage fault";
+CM_ SG_ 2147487751 BPath2SideBUvpError "Power path 2 side B undervoltage fault";
+CM_ SG_ 2147487751 BPath1SideAUvpError "Power path 1 side A undervoltage fault";
+CM_ SG_ 2147487751 BPath2SideAUvpError "Power path 2 side A undervoltage fault";
+CM_ SG_ 2147487751 BPath1SideBOvpError "Power path 1 side B overvoltage fault";
+CM_ SG_ 2147487751 BPath2SideBOvpError "Power path 2 side B overvoltage fault";
+CM_ SG_ 2147487751 BPath1SideAOvpError "Power path 1 side A overvoltage fault";
+CM_ SG_ 2147487751 BPath2SideAOvpError "Power path 2 side A overvoltage fault";
+CM_ SG_ 2147487751 BPath1Requested "Indicates that the power path 1 start command has been received";
+CM_ SG_ 2147487751 BPath2Requested "Indicates that the power path 2 start command has been received";
+CM_ SG_ 2147487751 NPath1CurrentSideSelected "Point of current limitation of Power path 1";
+CM_ SG_ 2147487751 NPath2CurrentSideSelected "Point of current limitation of Power path 2";
+CM_ SG_ 2147487751 NPath1VoltageSideSelected "Point of voltage regulation of Power path 1";
+CM_ SG_ 2147487751 NPath2VoltageSideSelected "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147487751 NPath1State "Indicates the power path 1 status";
+CM_ SG_ 2147487751 NPath2State "Indicates the power path 2 status";
+CM_ SG_ 2147487751 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487751 BXcpError "Indicates a power switches command?s integrity fault";
+CM_ SG_ 2147487751 NCellHwErrorFlags "Indicates HW errors triggered on CELL";
+CM_ SG_ 2147487751 BSyncInputSignal "Indicates if a correct synchronization signal is detected on the input synchronization pin";
+CM_ SG_ 2147487751 BSyncRequested "Indicates the synchronization command has been received";
+CM_ SG_ 2147487751 BInternalTemperatureError "Indicates an overtemperature error on the internal temperature";
+CM_ SG_ 2147487751 BConfigSettingsError "Indicates that the Config and/or Settings data is corrupted";
+CM_ SG_ 2147487751 BAuxSupplyError "Indicates a fault on one of the auxiliary power supplies";
+CM_ SG_ 2147487751 BCanTimeoutError "Indicates an error on the CAN bus";
+CM_ SG_ 2147487751 BAuxIsoEnabled "Indicates that isolated auxiliary supplies are activated";
+CM_ SG_ 2147487751 BSafetyDischargeEnabled "Indicates the safety discharge is activated";
+CM_ SG_ 2147487751 BFaultSignal "Indicates the signal Fault status";
+CM_ SG_ 2147487751 BEnableSignal "Indicates the external hardware ENABLE status";
+CM_ SG_ 2147487751 BSafetyDischargeStatus "Indicates the safety discharge status";
+CM_ SG_ 2147487751 BSyncStatus "Indicates the synchronization has been done successfully";
+CM_ SG_ 2147487751 BReadConfigAndSettingsRequested "Indicates that the Read config and settings command has been received";
+CM_ SG_ 2147487751 BSwResetModuleRequested "Indicates that the Software reset command has been received";
+CM_ SG_ 2147487751 BSafetyDischargeRequested "Indicates that the safety discharge command has been received";
+CM_ SG_ 2147487751 NModuleState "Indicates the overall module status";
+CM_ BO_ 2147489415 "Response message giving the present values of the setpoints ";
+CM_ SG_ 2147489415 IqPath1AcLimitLo "Power path 1 AC Iq lower limitation";
+CM_ SG_ 2147489415 IqPath1AcLimitHi "Power path 1 AC Iq upper limitation";
+CM_ SG_ 2147489415 PPath2LimitLo "Power path 2 power lower limitation";
+CM_ SG_ 2147489415 IqPath1AcSetpoint "Power path 1 AC Iq setpoint";
+CM_ SG_ 2147489415 IdPath1AcLimitLo "Power path 1 AC Id lower limitation";
+CM_ SG_ 2147489415 IdPath1AcSetpoint "Power path 1 AC Id setpoint";
+CM_ SG_ 2147489415 IdPath1AcLimitHi "Power path 1 AC Id upper limitation";
+CM_ SG_ 2147489415 PPath2LimitHi "Power path 2 power upper limitation";
+CM_ SG_ 2147489415 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147489351 "Response message giving the present values of the setpoints ";
+CM_ SG_ 2147489351 NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147489351 NPath2CurrentSideSelected "Point of current limitation of Power path 2";
+CM_ SG_ 2147489351 NPath2VoltageSideSelected "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147489351 NPath1AcFrequencySetpoint "Power path 1 AC frequency setpoint";
+CM_ SG_ 2147489351 IPath2LimitLo "Power path 2 current lower limitation";
+CM_ SG_ 2147489351 VqPath1AcSetpoint "Power path 1 AC Vq setpoint";
+CM_ SG_ 2147489351 VdPath1AcSetpoint "Power path 1 AC Vd setpoint";
+CM_ SG_ 2147489351 IPath2LimitHi "Power path 2 current upper limitation";
+CM_ SG_ 2147489351 VDcPath1AcSetpoint "Power path 1 AC Vdc setpoint";
+CM_ SG_ 2147489351 VPath2Setpoint "Power path 2 voltage setpoint";
+CM_ SG_ 2147489351 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147488775 "Values of port B1";
+CM_ SG_ 2147488775 NPortB1OverloadCount "Counter indicating the number of times an overload is detected on port B1";
+CM_ SG_ 2147488775 IPortB1Average "Average value of the port B1 current";
+CM_ SG_ 2147488775 VPortB1Average "Average value of the port B1 voltage";
+CM_ SG_ 2147488775 VPortB1Max "Maximum value of the  port B1 voltage seen since the last message sent";
+CM_ SG_ 2147488775 VPortB1Min "Minimum value of the port B1 voltage seen since the last message sent";
+CM_ BO_ 2147487879 "Values of port A1 ";
+CM_ SG_ 2147487879 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487879 IqPhAPortA1RMS "RMS value of the Iq on phase A";
+CM_ SG_ 2147487879 IqPortA1RMS "RMS value of the Iq on Port";
+CM_ SG_ 2147487879 NFrequencyPortA1 "Frequency of the AC network";
+CM_ SG_ 2147487879 IqPhCPortA1RMS "RMS value of the Iq on phase C";
+CM_ SG_ 2147487879 IdPhAPortA1RMS "RMS value of the Id on phase A";
+CM_ SG_ 2147487879 IdPortA1RMS "RMS value of the Id on Port";
+CM_ SG_ 2147487879 VphCPortA1Peak "Peak value of the voltage on phase C";
+CM_ SG_ 2147487879 IdPhCPortA1RMS "RMS value of the Id on phase C";
+CM_ SG_ 2147487879 IphCPortA1Peak "Peak value of the current on phase C";
+CM_ SG_ 2147487879 VqPortA1RMS "RMS value of the Vq";
+CM_ SG_ 2147487879 VphBPortA1Peak "Peak value of the voltage on phase B";
+CM_ SG_ 2147487879 IqPhBPortA1RMS "RMS value of the Iq on phase B";
+CM_ SG_ 2147487879 IphBPortA1Peak "Peak value of the current on phase B";
+CM_ SG_ 2147487879 VdPortA1RMS "RMS value of the Vd";
+CM_ SG_ 2147487879 VphAPortA1Peak "Peak value of the voltage on phase A";
+CM_ SG_ 2147487879 IphAPortA1Peak "Peak value of the current on phase A";
+CM_ SG_ 2147487879 IdPhBPortA1RMS "RMS value of the Id on phase B";
+CM_ BO_ 2147487943 "Values of port A2 ";
+CM_ SG_ 2147487943 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487943 NPortA2OverloadCount "Counter indicating the number of times an overload is detected on port A2";
+CM_ SG_ 2147487943 IPortA2Average "Average value of the port A2 current";
+CM_ SG_ 2147487943 VPortA2Average "Average value of the port A2 voltage";
+CM_ SG_ 2147487943 VPortA2Max "Maximum value of the  port A2 voltage seen since the last message sent";
+CM_ SG_ 2147487943 VPortA2Min "Minimum value of the port A2 voltage seen since the last message sent";
+CM_ BO_ 2147488391 "Values of internal parameters on PowerPath1";
+CM_ SG_ 2147488391 VPath1FlgCapaLvl2Max "Maximum value of the flying capa level 2 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488391 VPath1FlgCapaLvl2Min "Minimum value of the flying capa level 2 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488391 VPath1FlgCapaLvl1Max "Maximum value of the flying capa level 1 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488391 VPath1FlgCapaLvl1Min "Minimum value of the flying capa level 1 voltage of the power path 1 seen since the last message sent";
+CM_ BO_ 2147488455 "Values of internal parameters on PowerPath2";
+CM_ SG_ 2147488455 VPath2FlgCapaLvl2Max "Maximum value of the flying capa level 2 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488455 VPath2FlgCapaLvl2Min "Minimum value of the flying capa level 2 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488455 VPath2FlgCapaLvl1Max "Maximum value of the flying capa level 1 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488455 VPath2FlgCapaLvl1Min "Minimum value of the flying capa level 1 voltage of the power path 2 seen since the last message sent";
+CM_ BO_ 2147487815 "Global values";
+CM_ SG_ 2147487815 NCellOtpErrorFlags "Indicates overtemperature protection of cells";
+CM_ SG_ 2147487815 TCell3N2 "Temperature number 2 of cell 3";
+CM_ SG_ 2147487815 VAuxCell4N2 "Auxiliary voltage number 2 of cell 4";
+CM_ SG_ 2147487815 TCell3N1 "Temperature number 1 of cell 3";
+CM_ SG_ 2147487815 TInternal "Global product temperature";
+CM_ SG_ 2147487815 NBootloaderId "Version number of the bootloader program";
+CM_ SG_ 2147487815 NApplicationId "Version number of the application program";
+CM_ SG_ 2147487815 VAuxCell3N2 "Auxiliary voltage number 2 of cell 3";
+CM_ SG_ 2147487815 NSyncNodeCount "Number of node on the network";
+CM_ SG_ 2147487815 NSyncNodeRank "Rank of the node on the network";
+CM_ SG_ 2147487815 NReleaseMode "Reserved";
+CM_ SG_ 2147487815 TCell2N2 "Temperature number 2 of cell 2";
+CM_ SG_ 2147487815 NCellVAuxErrorFlags "Indicates Auxiliary voltage error on cells";
+CM_ SG_ 2147487815 VAuxCell4N1 "Auxiliary voltage number 1 of cell 4";
+CM_ SG_ 2147487815 VAuxCell2N2 "Auxiliary voltage number 2 of cell 2";
+CM_ SG_ 2147487815 VAuxCell4N3 "Auxiliary voltage number 3 of cell 4";
+CM_ SG_ 2147487815 TCell4N3 "Temperature number 3 of cell 4";
+CM_ SG_ 2147487815 VAux3Measured "Auxiliary voltage used for offset of current and voltage measurement";
+CM_ SG_ 2147487815 TCell2N1 "Temperature number 1 of cell 2";
+CM_ SG_ 2147487815 NConfigCrc "CRC of the CONFIG";
+CM_ SG_ 2147487815 NSettingsCrc "CRC of the SETTINGS";
+CM_ SG_ 2147487815 NSerial "Product Serial Number";
+CM_ SG_ 2147487815 VAuxCell3N1 "Auxiliary voltage number 1 of cell 3";
+CM_ SG_ 2147487815 VAuxCell1N2 "Auxiliary voltage number 2 of cell 1";
+CM_ SG_ 2147487815 VAuxCell3N3 "Auxiliary voltage number 3 of cell 3";
+CM_ SG_ 2147487815 TCell3N3 "Temperature number 3 of cell 3";
+CM_ SG_ 2147487815 VAux2Measured "Auxiliary voltage 3V3 value";
+CM_ SG_ 2147487815 TCell1N2 "Temperature number 2 of cell 1";
+CM_ SG_ 2147487815 TCell4N2 "Temperature number 2 of cell 4";
+CM_ SG_ 2147487815 NCellXcpErrorFlags "Indicates Xcp error on cells";
+CM_ SG_ 2147487815 VAuxCell2N1 "Auxiliary voltage number 1 of cell 2";
+CM_ SG_ 2147487815 VAuxCell2N3 "Auxiliary voltage number 3 of cell 2";
+CM_ SG_ 2147487815 TCell2N3 "Temperature number 3 of cell 2";
+CM_ SG_ 2147487815 VAux1Measured "Auxiliary voltage LV value";
+CM_ SG_ 2147487815 TCell1N1 "Temperature number 1 of cell 1";
+CM_ SG_ 2147487815 TCell4N1 "Temperature number 1 of cell 4";
+CM_ SG_ 2147487815 NConfigVersion "Version number of the CONFIG";
+CM_ SG_ 2147487815 NSettingsVersion "Version number of the SETTINGS";
+CM_ SG_ 2147487815 NChecksum "Checksum of the application program";
+CM_ SG_ 2147487815 NCellSwOcpErrorFlags "Indicates Sw overcurrent protection ";
+CM_ SG_ 2147487815 VAuxCell1N1 "Auxiliary voltage number 1 of cell 1";
+CM_ SG_ 2147487815 VAuxCell1N3 "Auxiliary voltage number 3 of cell 1";
+CM_ SG_ 2147487815 TCell1N3 "Temperature number 3 of cell 1";
+CM_ SG_ 2147487815 NMultiplexer "Multiplexer ID";
+CM_ BO_ 2147489479 "Value of all parameters of the configuration and settings";
+CM_ SG_ 2147489479 NParameterValue "Value of the 16bits word";
+CM_ SG_ 2147489479 NParameterIndex "Index at which the word is read in the selected zone";
+CM_ SG_ 2147489479 NReadZoneSelect "Zone in which to read the parameters";
+CM_ BO_ 2147489414 "Response message giving the present values of the setpoints ";
+CM_ SG_ 2147489414 IqPath1AcLimitLo "Power path 1 AC Iq lower limitation";
+CM_ SG_ 2147489414 IqPath1AcLimitHi "Power path 1 AC Iq upper limitation";
+CM_ SG_ 2147489414 PPath2LimitLo "Power path 2 power lower limitation";
+CM_ SG_ 2147489414 IqPath1AcSetpoint "Power path 1 AC Iq setpoint";
+CM_ SG_ 2147489414 IdPath1AcLimitLo "Power path 1 AC Id lower limitation";
+CM_ SG_ 2147489414 IdPath1AcSetpoint "Power path 1 AC Id setpoint";
+CM_ SG_ 2147489414 IdPath1AcLimitHi "Power path 1 AC Id upper limitation";
+CM_ SG_ 2147489414 PPath2LimitHi "Power path 2 power upper limitation";
+CM_ SG_ 2147489414 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147489350 "Response message giving the present values of the setpoints ";
+CM_ SG_ 2147489350 NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147489350 NPath2CurrentSideSelected "Point of current limitation of Power path 2";
+CM_ SG_ 2147489350 NPath2VoltageSideSelected "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147489350 NPath1AcFrequencySetpoint "Power path 1 AC frequency setpoint";
+CM_ SG_ 2147489350 IPath2LimitLo "Power path 2 current lower limitation";
+CM_ SG_ 2147489350 VqPath1AcSetpoint "Power path 1 AC Vq setpoint";
+CM_ SG_ 2147489350 VdPath1AcSetpoint "Power path 1 AC Vd setpoint";
+CM_ SG_ 2147489350 IPath2LimitHi "Power path 2 current upper limitation";
+CM_ SG_ 2147489350 VDcPath1AcSetpoint "Power path 1 AC Vdc setpoint";
+CM_ SG_ 2147489350 VPath2Setpoint "Power path 2 voltage setpoint";
+CM_ SG_ 2147489350 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147488390 "Values of internal parameters on PowerPath1";
+CM_ SG_ 2147488390 VPath1FlgCapaLvl2Max "Maximum value of the flying capa level 2 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488390 VPath1FlgCapaLvl2Min "Minimum value of the flying capa level 2 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488390 VPath1FlgCapaLvl1Max "Maximum value of the flying capa level 1 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488390 VPath1FlgCapaLvl1Min "Minimum value of the flying capa level 1 voltage of the power path 1 seen since the last message sent";
+CM_ BO_ 2147488454 "Values of internal parameters on PowerPath2";
+CM_ SG_ 2147488454 VPath2FlgCapaLvl2Max "Maximum value of the flying capa level 2 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488454 VPath2FlgCapaLvl2Min "Minimum value of the flying capa level 2 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488454 VPath2FlgCapaLvl1Max "Maximum value of the flying capa level 1 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488454 VPath2FlgCapaLvl1Min "Minimum value of the flying capa level 1 voltage of the power path 2 seen since the last message sent";
+CM_ BO_ 2147488774 "Values of port B1";
+CM_ SG_ 2147488774 NPortB1OverloadCount "Counter indicating the number of times an overload is detected on port B1";
+CM_ SG_ 2147488774 IPortB1Average "Average value of the port B1 current";
+CM_ SG_ 2147488774 VPortB1Average "Average value of the port B1 voltage";
+CM_ SG_ 2147488774 VPortB1Max "Maximum value of the  port B1 voltage seen since the last message sent";
+CM_ SG_ 2147488774 VPortB1Min "Minimum value of the port B1 voltage seen since the last message sent";
+CM_ BO_ 2147487878 "Values of port A1 ";
+CM_ SG_ 2147487878 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487878 IqPhAPortA1RMS "RMS value of the Iq on phase A";
+CM_ SG_ 2147487878 IqPortA1RMS "RMS value of the Iq on Port";
+CM_ SG_ 2147487878 NFrequencyPortA1 "Frequency of the AC network";
+CM_ SG_ 2147487878 IqPhCPortA1RMS "RMS value of the Iq on phase C";
+CM_ SG_ 2147487878 IdPhAPortA1RMS "RMS value of the Id on phase A";
+CM_ SG_ 2147487878 IdPortA1RMS "RMS value of the Id on Port";
+CM_ SG_ 2147487878 VphCPortA1Peak "Peak value of the voltage on phase C";
+CM_ SG_ 2147487878 IdPhCPortA1RMS "RMS value of the Id on phase C";
+CM_ SG_ 2147487878 IphCPortA1Peak "Peak value of the current on phase C";
+CM_ SG_ 2147487878 VqPortA1RMS "RMS value of the Vq";
+CM_ SG_ 2147487878 VphBPortA1Peak "Peak value of the voltage on phase B";
+CM_ SG_ 2147487878 IqPhBPortA1RMS "RMS value of the Iq on phase B";
+CM_ SG_ 2147487878 IphBPortA1Peak "Peak value of the current on phase B";
+CM_ SG_ 2147487878 VdPortA1RMS "RMS value of the Vd";
+CM_ SG_ 2147487878 VphAPortA1Peak "Peak value of the voltage on phase A";
+CM_ SG_ 2147487878 IphAPortA1Peak "Peak value of the current on phase A";
+CM_ SG_ 2147487878 IdPhBPortA1RMS "RMS value of the Id on phase B";
+CM_ BO_ 2147487942 "Values of port A2 ";
+CM_ SG_ 2147487942 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487942 NPortA2OverloadCount "Counter indicating the number of times an overload is detected on port A2";
+CM_ SG_ 2147487942 IPortA2Average "Average value of the port A2 current";
+CM_ SG_ 2147487942 VPortA2Average "Average value of the port A2 voltage";
+CM_ SG_ 2147487942 VPortA2Max "Maximum value of the  port A2 voltage seen since the last message sent";
+CM_ SG_ 2147487942 VPortA2Min "Minimum value of the port A2 voltage seen since the last message sent";
+CM_ BO_ 2147489478 "Value of all parameters of the configuration and settings";
+CM_ SG_ 2147489478 NParameterValue "Value of the 16bits word";
+CM_ SG_ 2147489478 NParameterIndex "Index at which the word is read in the selected zone";
+CM_ SG_ 2147489478 NReadZoneSelect "Zone in which to read the parameters";
+CM_ BO_ 2147487814 "Global values";
+CM_ SG_ 2147487814 NCellOtpErrorFlags "Indicates overtemperature protection of cells";
+CM_ SG_ 2147487814 TCell3N2 "Temperature number 2 of cell 3";
+CM_ SG_ 2147487814 VAuxCell4N2 "Auxiliary voltage number 2 of cell 4";
+CM_ SG_ 2147487814 TCell3N1 "Temperature number 1 of cell 3";
+CM_ SG_ 2147487814 TInternal "Global product temperature";
+CM_ SG_ 2147487814 NBootloaderId "Version number of the bootloader program";
+CM_ SG_ 2147487814 NApplicationId "Version number of the application program";
+CM_ SG_ 2147487814 VAuxCell3N2 "Auxiliary voltage number 2 of cell 3";
+CM_ SG_ 2147487814 NSyncNodeCount "Number of node on the network";
+CM_ SG_ 2147487814 NSyncNodeRank "Rank of the node on the network";
+CM_ SG_ 2147487814 NReleaseMode "Reserved";
+CM_ SG_ 2147487814 TCell2N2 "Temperature number 2 of cell 2";
+CM_ SG_ 2147487814 NCellVAuxErrorFlags "Indicates Auxiliary voltage error on cells";
+CM_ SG_ 2147487814 VAuxCell4N1 "Auxiliary voltage number 1 of cell 4";
+CM_ SG_ 2147487814 VAuxCell2N2 "Auxiliary voltage number 2 of cell 2";
+CM_ SG_ 2147487814 VAuxCell4N3 "Auxiliary voltage number 3 of cell 4";
+CM_ SG_ 2147487814 TCell4N3 "Temperature number 3 of cell 4";
+CM_ SG_ 2147487814 VAux3Measured "Auxiliary voltage used for offset of current and voltage measurement";
+CM_ SG_ 2147487814 TCell2N1 "Temperature number 1 of cell 2";
+CM_ SG_ 2147487814 NConfigCrc "CRC of the CONFIG";
+CM_ SG_ 2147487814 NSettingsCrc "CRC of the SETTINGS";
+CM_ SG_ 2147487814 NSerial "Product Serial Number";
+CM_ SG_ 2147487814 VAuxCell3N1 "Auxiliary voltage number 1 of cell 3";
+CM_ SG_ 2147487814 VAuxCell1N2 "Auxiliary voltage number 2 of cell 1";
+CM_ SG_ 2147487814 VAuxCell3N3 "Auxiliary voltage number 3 of cell 3";
+CM_ SG_ 2147487814 TCell3N3 "Temperature number 3 of cell 3";
+CM_ SG_ 2147487814 VAux2Measured "Auxiliary voltage 3V3 value";
+CM_ SG_ 2147487814 TCell1N2 "Temperature number 2 of cell 1";
+CM_ SG_ 2147487814 TCell4N2 "Temperature number 2 of cell 4";
+CM_ SG_ 2147487814 NCellXcpErrorFlags "Indicates Xcp error on cells";
+CM_ SG_ 2147487814 VAuxCell2N1 "Auxiliary voltage number 1 of cell 2";
+CM_ SG_ 2147487814 VAuxCell2N3 "Auxiliary voltage number 3 of cell 2";
+CM_ SG_ 2147487814 TCell2N3 "Temperature number 3 of cell 2";
+CM_ SG_ 2147487814 VAux1Measured "Auxiliary voltage LV value";
+CM_ SG_ 2147487814 TCell1N1 "Temperature number 1 of cell 1";
+CM_ SG_ 2147487814 TCell4N1 "Temperature number 1 of cell 4";
+CM_ SG_ 2147487814 NConfigVersion "Version number of the CONFIG";
+CM_ SG_ 2147487814 NSettingsVersion "Version number of the SETTINGS";
+CM_ SG_ 2147487814 NChecksum "Checksum of the application program";
+CM_ SG_ 2147487814 NCellSwOcpErrorFlags "Indicates Sw overcurrent protection ";
+CM_ SG_ 2147487814 VAuxCell1N1 "Auxiliary voltage number 1 of cell 1";
+CM_ SG_ 2147487814 VAuxCell1N3 "Auxiliary voltage number 3 of cell 1";
+CM_ SG_ 2147487814 TCell1N3 "Temperature number 3 of cell 1";
+CM_ SG_ 2147487814 NMultiplexer "Multiplexer ID";
+CM_ BO_ 2147487750 "Overal HVHV Status & Diagnostic";
+CM_ SG_ 2147487750 BPath1AcModeActivated "Indicates that the Power Path 1 is working in AC mode";
+CM_ SG_ 2147487750 BPath1AcUfpError "Power path 1 underfrequency fault";
+CM_ SG_ 2147487750 BPath1AcOfpError "Power path 1 overfrequency fault";
+CM_ SG_ 2147487750 NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147487750 BPath1FlgCapaError "Indicates a flying capa voltage error on power path 1";
+CM_ SG_ 2147487750 BPath2FlgCapaError "Indicates a flying capa voltage error on power path 2";
+CM_ SG_ 2147487750 BPath1ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 1";
+CM_ SG_ 2147487750 BPath2ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 2";
+CM_ SG_ 2147487750 IPath1Unbalance "Unbalanced current between cells on power path 1";
+CM_ SG_ 2147487750 IPath2Unbalance "Unbalanced current between cells on power path 2";
+CM_ SG_ 2147487750 BPath1RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147487750 BPath2RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147487750 BPath1OcpError "Power path 1 overcurrent fault";
+CM_ SG_ 2147487750 BPath2OcpError "Power path 2 overcurrent fault";
+CM_ SG_ 2147487750 BPath1OtpError "Power path 1 overtemperature fault";
+CM_ SG_ 2147487750 BPath2OtpError "Power path 2 overtemperature fault";
+CM_ SG_ 2147487750 BPath1SideBUvpError "Power path 1 side B undervoltage fault";
+CM_ SG_ 2147487750 BPath2SideBUvpError "Power path 2 side B undervoltage fault";
+CM_ SG_ 2147487750 BPath1SideAUvpError "Power path 1 side A undervoltage fault";
+CM_ SG_ 2147487750 BPath2SideAUvpError "Power path 2 side A undervoltage fault";
+CM_ SG_ 2147487750 BPath1SideBOvpError "Power path 1 side B overvoltage fault";
+CM_ SG_ 2147487750 BPath2SideBOvpError "Power path 2 side B overvoltage fault";
+CM_ SG_ 2147487750 BPath1SideAOvpError "Power path 1 side A overvoltage fault";
+CM_ SG_ 2147487750 BPath2SideAOvpError "Power path 2 side A overvoltage fault";
+CM_ SG_ 2147487750 BPath1Requested "Indicates that the power path 1 start command has been received";
+CM_ SG_ 2147487750 BPath2Requested "Indicates that the power path 2 start command has been received";
+CM_ SG_ 2147487750 NPath1CurrentSideSelected "Point of current limitation of Power path 1";
+CM_ SG_ 2147487750 NPath2CurrentSideSelected "Point of current limitation of Power path 2";
+CM_ SG_ 2147487750 NPath1VoltageSideSelected "Point of voltage regulation of Power path 1";
+CM_ SG_ 2147487750 NPath2VoltageSideSelected "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147487750 NPath1State "Indicates the power path 1 status";
+CM_ SG_ 2147487750 NPath2State "Indicates the power path 2 status";
+CM_ SG_ 2147487750 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487750 BXcpError "Indicates a power switches command?s integrity fault";
+CM_ SG_ 2147487750 NCellHwErrorFlags "Indicates HW errors triggered on CELL";
+CM_ SG_ 2147487750 BSyncInputSignal "Indicates if a correct synchronization signal is detected on the input synchronization pin";
+CM_ SG_ 2147487750 BSyncRequested "Indicates the synchronization command has been received";
+CM_ SG_ 2147487750 BInternalTemperatureError "Indicates an overtemperature error on the internal temperature";
+CM_ SG_ 2147487750 BConfigSettingsError "Indicates that the Config and/or Settings data is corrupted";
+CM_ SG_ 2147487750 BAuxSupplyError "Indicates a fault on one of the auxiliary power supplies";
+CM_ SG_ 2147487750 BCanTimeoutError "Indicates an error on the CAN bus";
+CM_ SG_ 2147487750 BAuxIsoEnabled "Indicates that isolated auxiliary supplies are activated";
+CM_ SG_ 2147487750 BSafetyDischargeEnabled "Indicates the safety discharge is activated";
+CM_ SG_ 2147487750 BFaultSignal "Indicates the signal Fault status";
+CM_ SG_ 2147487750 BEnableSignal "Indicates the external hardware ENABLE status";
+CM_ SG_ 2147487750 BSafetyDischargeStatus "Indicates the safety discharge status";
+CM_ SG_ 2147487750 BSyncStatus "Indicates the synchronization has been done successfully";
+CM_ SG_ 2147487750 BReadConfigAndSettingsRequested "Indicates that the Read config and settings command has been received";
+CM_ SG_ 2147487750 BSwResetModuleRequested "Indicates that the Software reset command has been received";
+CM_ SG_ 2147487750 BSafetyDischargeRequested "Indicates that the safety discharge command has been received";
+CM_ SG_ 2147487750 NModuleState "Indicates the overall module status";
+CM_ BO_ 2147487753 "Overal HVHV Status & Diagnostic";
+CM_ SG_ 2147487753 BPath1AcModeActivated "Indicates that the Power Path 1 is working in AC mode";
+CM_ SG_ 2147487753 BPath1AcUfpError "Power path 1 underfrequency fault";
+CM_ SG_ 2147487753 BPath1AcOfpError "Power path 1 overfrequency fault";
+CM_ SG_ 2147487753 NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147487753 BPath1FlgCapaError "Indicates a flying capa voltage error on power path 1";
+CM_ SG_ 2147487753 BPath2FlgCapaError "Indicates a flying capa voltage error on power path 2";
+CM_ SG_ 2147487753 BPath1ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 1";
+CM_ SG_ 2147487753 BPath2ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 2";
+CM_ SG_ 2147487753 IPath1Unbalance "Unbalanced current between cells on power path 1";
+CM_ SG_ 2147487753 IPath2Unbalance "Unbalanced current between cells on power path 2";
+CM_ SG_ 2147487753 BPath1RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147487753 BPath2RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147487753 BPath1OcpError "Power path 1 overcurrent fault";
+CM_ SG_ 2147487753 BPath2OcpError "Power path 2 overcurrent fault";
+CM_ SG_ 2147487753 BPath1OtpError "Power path 1 overtemperature fault";
+CM_ SG_ 2147487753 BPath2OtpError "Power path 2 overtemperature fault";
+CM_ SG_ 2147487753 BPath1SideBUvpError "Power path 1 side B undervoltage fault";
+CM_ SG_ 2147487753 BPath2SideBUvpError "Power path 2 side B undervoltage fault";
+CM_ SG_ 2147487753 BPath1SideAUvpError "Power path 1 side A undervoltage fault";
+CM_ SG_ 2147487753 BPath2SideAUvpError "Power path 2 side A undervoltage fault";
+CM_ SG_ 2147487753 BPath1SideBOvpError "Power path 1 side B overvoltage fault";
+CM_ SG_ 2147487753 BPath2SideBOvpError "Power path 2 side B overvoltage fault";
+CM_ SG_ 2147487753 BPath1SideAOvpError "Power path 1 side A overvoltage fault";
+CM_ SG_ 2147487753 BPath2SideAOvpError "Power path 2 side A overvoltage fault";
+CM_ SG_ 2147487753 BPath1Requested "Indicates that the power path 1 start command has been received";
+CM_ SG_ 2147487753 BPath2Requested "Indicates that the power path 2 start command has been received";
+CM_ SG_ 2147487753 NPath1CurrentSideSelected "Point of current limitation of Power path 1";
+CM_ SG_ 2147487753 NPath2CurrentSideSelected "Point of current limitation of Power path 2";
+CM_ SG_ 2147487753 NPath1VoltageSideSelected "Point of voltage regulation of Power path 1";
+CM_ SG_ 2147487753 NPath2VoltageSideSelected "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147487753 NPath1State "Indicates the power path 1 status";
+CM_ SG_ 2147487753 NPath2State "Indicates the power path 2 status";
+CM_ SG_ 2147487753 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487753 BXcpError "Indicates a power switches command?s integrity fault";
+CM_ SG_ 2147487753 NCellHwErrorFlags "Indicates HW errors triggered on CELL";
+CM_ SG_ 2147487753 BSyncInputSignal "Indicates if a correct synchronization signal is detected on the input synchronization pin";
+CM_ SG_ 2147487753 BSyncRequested "Indicates the synchronization command has been received";
+CM_ SG_ 2147487753 BInternalTemperatureError "Indicates an overtemperature error on the internal temperature";
+CM_ SG_ 2147487753 BConfigSettingsError "Indicates that the Config and/or Settings data is corrupted";
+CM_ SG_ 2147487753 BAuxSupplyError "Indicates a fault on one of the auxiliary power supplies";
+CM_ SG_ 2147487753 BCanTimeoutError "Indicates an error on the CAN bus";
+CM_ SG_ 2147487753 BAuxIsoEnabled "Indicates that isolated auxiliary supplies are activated";
+CM_ SG_ 2147487753 BSafetyDischargeEnabled "Indicates the safety discharge is activated";
+CM_ SG_ 2147487753 BFaultSignal "Indicates the signal Fault status";
+CM_ SG_ 2147487753 BEnableSignal "Indicates the external hardware ENABLE status";
+CM_ SG_ 2147487753 BSafetyDischargeStatus "Indicates the safety discharge status";
+CM_ SG_ 2147487753 BSyncStatus "Indicates the synchronization has been done successfully";
+CM_ SG_ 2147487753 BReadConfigAndSettingsRequested "Indicates that the Read config and settings command has been received";
+CM_ SG_ 2147487753 BSwResetModuleRequested "Indicates that the Software reset command has been received";
+CM_ SG_ 2147487753 BSafetyDischargeRequested "Indicates that the safety discharge command has been received";
+CM_ SG_ 2147487753 NModuleState "Indicates the overall module status";
+CM_ BO_ 2147489417 "Response message giving the present values of the setpoints ";
+CM_ SG_ 2147489417 IqPath1AcLimitLo "Power path 1 AC Iq lower limitation";
+CM_ SG_ 2147489417 IqPath1AcLimitHi "Power path 1 AC Iq upper limitation";
+CM_ SG_ 2147489417 PPath2LimitLo "Power path 2 power lower limitation";
+CM_ SG_ 2147489417 IqPath1AcSetpoint "Power path 1 AC Iq setpoint";
+CM_ SG_ 2147489417 IdPath1AcLimitLo "Power path 1 AC Id lower limitation";
+CM_ SG_ 2147489417 IdPath1AcSetpoint "Power path 1 AC Id setpoint";
+CM_ SG_ 2147489417 IdPath1AcLimitHi "Power path 1 AC Id upper limitation";
+CM_ SG_ 2147489417 PPath2LimitHi "Power path 2 power upper limitation";
+CM_ SG_ 2147489417 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147489353 "Response message giving the present values of the setpoints ";
+CM_ SG_ 2147489353 NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147489353 NPath2CurrentSideSelected "Point of current limitation of Power path 2";
+CM_ SG_ 2147489353 NPath2VoltageSideSelected "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147489353 NPath1AcFrequencySetpoint "Power path 1 AC frequency setpoint";
+CM_ SG_ 2147489353 IPath2LimitLo "Power path 2 current lower limitation";
+CM_ SG_ 2147489353 VqPath1AcSetpoint "Power path 1 AC Vq setpoint";
+CM_ SG_ 2147489353 VdPath1AcSetpoint "Power path 1 AC Vd setpoint";
+CM_ SG_ 2147489353 IPath2LimitHi "Power path 2 current upper limitation";
+CM_ SG_ 2147489353 VDcPath1AcSetpoint "Power path 1 AC Vdc setpoint";
+CM_ SG_ 2147489353 VPath2Setpoint "Power path 2 voltage setpoint";
+CM_ SG_ 2147489353 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147488777 "Values of port B1";
+CM_ SG_ 2147488777 NPortB1OverloadCount "Counter indicating the number of times an overload is detected on port B1";
+CM_ SG_ 2147488777 IPortB1Average "Average value of the port B1 current";
+CM_ SG_ 2147488777 VPortB1Average "Average value of the port B1 voltage";
+CM_ SG_ 2147488777 VPortB1Max "Maximum value of the  port B1 voltage seen since the last message sent";
+CM_ SG_ 2147488777 VPortB1Min "Minimum value of the port B1 voltage seen since the last message sent";
+CM_ BO_ 2147487881 "Values of port A1 ";
+CM_ SG_ 2147487881 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487881 IqPhAPortA1RMS "RMS value of the Iq on phase A";
+CM_ SG_ 2147487881 IqPortA1RMS "RMS value of the Iq on Port";
+CM_ SG_ 2147487881 NFrequencyPortA1 "Frequency of the AC network";
+CM_ SG_ 2147487881 IqPhCPortA1RMS "RMS value of the Iq on phase C";
+CM_ SG_ 2147487881 IdPhAPortA1RMS "RMS value of the Id on phase A";
+CM_ SG_ 2147487881 IdPortA1RMS "RMS value of the Id on Port";
+CM_ SG_ 2147487881 VphCPortA1Peak "Peak value of the voltage on phase C";
+CM_ SG_ 2147487881 IdPhCPortA1RMS "RMS value of the Id on phase C";
+CM_ SG_ 2147487881 IphCPortA1Peak "Peak value of the current on phase C";
+CM_ SG_ 2147487881 VqPortA1RMS "RMS value of the Vq";
+CM_ SG_ 2147487881 VphBPortA1Peak "Peak value of the voltage on phase B";
+CM_ SG_ 2147487881 IqPhBPortA1RMS "RMS value of the Iq on phase B";
+CM_ SG_ 2147487881 IphBPortA1Peak "Peak value of the current on phase B";
+CM_ SG_ 2147487881 VdPortA1RMS "RMS value of the Vd";
+CM_ SG_ 2147487881 VphAPortA1Peak "Peak value of the voltage on phase A";
+CM_ SG_ 2147487881 IphAPortA1Peak "Peak value of the current on phase A";
+CM_ SG_ 2147487881 IdPhBPortA1RMS "RMS value of the Id on phase B";
+CM_ BO_ 2147487945 "Values of port A2 ";
+CM_ SG_ 2147487945 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487945 NPortA2OverloadCount "Counter indicating the number of times an overload is detected on port A2";
+CM_ SG_ 2147487945 IPortA2Average "Average value of the port A2 current";
+CM_ SG_ 2147487945 VPortA2Average "Average value of the port A2 voltage";
+CM_ SG_ 2147487945 VPortA2Max "Maximum value of the  port A2 voltage seen since the last message sent";
+CM_ SG_ 2147487945 VPortA2Min "Minimum value of the port A2 voltage seen since the last message sent";
+CM_ BO_ 2147488393 "Values of internal parameters on PowerPath1";
+CM_ SG_ 2147488393 VPath1FlgCapaLvl2Max "Maximum value of the flying capa level 2 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488393 VPath1FlgCapaLvl2Min "Minimum value of the flying capa level 2 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488393 VPath1FlgCapaLvl1Max "Maximum value of the flying capa level 1 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488393 VPath1FlgCapaLvl1Min "Minimum value of the flying capa level 1 voltage of the power path 1 seen since the last message sent";
+CM_ BO_ 2147488457 "Values of internal parameters on PowerPath2";
+CM_ SG_ 2147488457 VPath2FlgCapaLvl2Max "Maximum value of the flying capa level 2 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488457 VPath2FlgCapaLvl2Min "Minimum value of the flying capa level 2 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488457 VPath2FlgCapaLvl1Max "Maximum value of the flying capa level 1 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488457 VPath2FlgCapaLvl1Min "Minimum value of the flying capa level 1 voltage of the power path 2 seen since the last message sent";
+CM_ BO_ 2147487817 "Global values";
+CM_ SG_ 2147487817 NCellOtpErrorFlags "Indicates overtemperature protection of cells";
+CM_ SG_ 2147487817 TCell3N2 "Temperature number 2 of cell 3";
+CM_ SG_ 2147487817 VAuxCell4N2 "Auxiliary voltage number 2 of cell 4";
+CM_ SG_ 2147487817 TCell3N1 "Temperature number 1 of cell 3";
+CM_ SG_ 2147487817 TInternal "Global product temperature";
+CM_ SG_ 2147487817 NBootloaderId "Version number of the bootloader program";
+CM_ SG_ 2147487817 NApplicationId "Version number of the application program";
+CM_ SG_ 2147487817 VAuxCell3N2 "Auxiliary voltage number 2 of cell 3";
+CM_ SG_ 2147487817 NSyncNodeCount "Number of node on the network";
+CM_ SG_ 2147487817 NSyncNodeRank "Rank of the node on the network";
+CM_ SG_ 2147487817 NReleaseMode "Reserved";
+CM_ SG_ 2147487817 TCell2N2 "Temperature number 2 of cell 2";
+CM_ SG_ 2147487817 NCellVAuxErrorFlags "Indicates Auxiliary voltage error on cells";
+CM_ SG_ 2147487817 VAuxCell4N1 "Auxiliary voltage number 1 of cell 4";
+CM_ SG_ 2147487817 VAuxCell2N2 "Auxiliary voltage number 2 of cell 2";
+CM_ SG_ 2147487817 VAuxCell4N3 "Auxiliary voltage number 3 of cell 4";
+CM_ SG_ 2147487817 TCell4N3 "Temperature number 3 of cell 4";
+CM_ SG_ 2147487817 VAux3Measured "Auxiliary voltage used for offset of current and voltage measurement";
+CM_ SG_ 2147487817 TCell2N1 "Temperature number 1 of cell 2";
+CM_ SG_ 2147487817 NConfigCrc "CRC of the CONFIG";
+CM_ SG_ 2147487817 NSettingsCrc "CRC of the SETTINGS";
+CM_ SG_ 2147487817 NSerial "Product Serial Number";
+CM_ SG_ 2147487817 VAuxCell3N1 "Auxiliary voltage number 1 of cell 3";
+CM_ SG_ 2147487817 VAuxCell1N2 "Auxiliary voltage number 2 of cell 1";
+CM_ SG_ 2147487817 VAuxCell3N3 "Auxiliary voltage number 3 of cell 3";
+CM_ SG_ 2147487817 TCell3N3 "Temperature number 3 of cell 3";
+CM_ SG_ 2147487817 VAux2Measured "Auxiliary voltage 3V3 value";
+CM_ SG_ 2147487817 TCell1N2 "Temperature number 2 of cell 1";
+CM_ SG_ 2147487817 TCell4N2 "Temperature number 2 of cell 4";
+CM_ SG_ 2147487817 NCellXcpErrorFlags "Indicates Xcp error on cells";
+CM_ SG_ 2147487817 VAuxCell2N1 "Auxiliary voltage number 1 of cell 2";
+CM_ SG_ 2147487817 VAuxCell2N3 "Auxiliary voltage number 3 of cell 2";
+CM_ SG_ 2147487817 TCell2N3 "Temperature number 3 of cell 2";
+CM_ SG_ 2147487817 VAux1Measured "Auxiliary voltage LV value";
+CM_ SG_ 2147487817 TCell1N1 "Temperature number 1 of cell 1";
+CM_ SG_ 2147487817 TCell4N1 "Temperature number 1 of cell 4";
+CM_ SG_ 2147487817 NConfigVersion "Version number of the CONFIG";
+CM_ SG_ 2147487817 NSettingsVersion "Version number of the SETTINGS";
+CM_ SG_ 2147487817 NChecksum "Checksum of the application program";
+CM_ SG_ 2147487817 NCellSwOcpErrorFlags "Indicates Sw overcurrent protection ";
+CM_ SG_ 2147487817 VAuxCell1N1 "Auxiliary voltage number 1 of cell 1";
+CM_ SG_ 2147487817 VAuxCell1N3 "Auxiliary voltage number 3 of cell 1";
+CM_ SG_ 2147487817 TCell1N3 "Temperature number 3 of cell 1";
+CM_ SG_ 2147487817 NMultiplexer "Multiplexer ID";
+CM_ BO_ 2147489481 "Value of all parameters of the configuration and settings";
+CM_ SG_ 2147489481 NParameterValue "Value of the 16bits word";
+CM_ SG_ 2147489481 NParameterIndex "Index at which the word is read in the selected zone";
+CM_ SG_ 2147489481 NReadZoneSelect "Zone in which to read the parameters";
+CM_ BO_ 2147489416 "Response message giving the present values of the setpoints ";
+CM_ SG_ 2147489416 IqPath1AcLimitLo "Power path 1 AC Iq lower limitation";
+CM_ SG_ 2147489416 IqPath1AcLimitHi "Power path 1 AC Iq upper limitation";
+CM_ SG_ 2147489416 PPath2LimitLo "Power path 2 power lower limitation";
+CM_ SG_ 2147489416 IqPath1AcSetpoint "Power path 1 AC Iq setpoint";
+CM_ SG_ 2147489416 IdPath1AcLimitLo "Power path 1 AC Id lower limitation";
+CM_ SG_ 2147489416 IdPath1AcSetpoint "Power path 1 AC Id setpoint";
+CM_ SG_ 2147489416 IdPath1AcLimitHi "Power path 1 AC Id upper limitation";
+CM_ SG_ 2147489416 PPath2LimitHi "Power path 2 power upper limitation";
+CM_ SG_ 2147489416 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147489352 "Response message giving the present values of the setpoints ";
+CM_ SG_ 2147489352 NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147489352 NPath2CurrentSideSelected "Point of current limitation of Power path 2";
+CM_ SG_ 2147489352 NPath2VoltageSideSelected "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147489352 NPath1AcFrequencySetpoint "Power path 1 AC frequency setpoint";
+CM_ SG_ 2147489352 IPath2LimitLo "Power path 2 current lower limitation";
+CM_ SG_ 2147489352 VqPath1AcSetpoint "Power path 1 AC Vq setpoint";
+CM_ SG_ 2147489352 VdPath1AcSetpoint "Power path 1 AC Vd setpoint";
+CM_ SG_ 2147489352 IPath2LimitHi "Power path 2 current upper limitation";
+CM_ SG_ 2147489352 VDcPath1AcSetpoint "Power path 1 AC Vdc setpoint";
+CM_ SG_ 2147489352 VPath2Setpoint "Power path 2 voltage setpoint";
+CM_ SG_ 2147489352 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147488392 "Values of internal parameters on PowerPath1";
+CM_ SG_ 2147488392 VPath1FlgCapaLvl2Max "Maximum value of the flying capa level 2 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488392 VPath1FlgCapaLvl2Min "Minimum value of the flying capa level 2 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488392 VPath1FlgCapaLvl1Max "Maximum value of the flying capa level 1 voltage of the power path 1 seen since the last message sent";
+CM_ SG_ 2147488392 VPath1FlgCapaLvl1Min "Minimum value of the flying capa level 1 voltage of the power path 1 seen since the last message sent";
+CM_ BO_ 2147488456 "Values of internal parameters on PowerPath2";
+CM_ SG_ 2147488456 VPath2FlgCapaLvl2Max "Maximum value of the flying capa level 2 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488456 VPath2FlgCapaLvl2Min "Minimum value of the flying capa level 2 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488456 VPath2FlgCapaLvl1Max "Maximum value of the flying capa level 1 voltage of the power path 2 seen since the last message sent";
+CM_ SG_ 2147488456 VPath2FlgCapaLvl1Min "Minimum value of the flying capa level 1 voltage of the power path 2 seen since the last message sent";
+CM_ BO_ 2147488776 "Values of port B1";
+CM_ SG_ 2147488776 NPortB1OverloadCount "Counter indicating the number of times an overload is detected on port B1";
+CM_ SG_ 2147488776 IPortB1Average "Average value of the port B1 current";
+CM_ SG_ 2147488776 VPortB1Average "Average value of the port B1 voltage";
+CM_ SG_ 2147488776 VPortB1Max "Maximum value of the  port B1 voltage seen since the last message sent";
+CM_ SG_ 2147488776 VPortB1Min "Minimum value of the port B1 voltage seen since the last message sent";
+CM_ BO_ 2147487880 "Values of port A1 ";
+CM_ SG_ 2147487880 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487880 IqPhAPortA1RMS "RMS value of the Iq on phase A";
+CM_ SG_ 2147487880 IqPortA1RMS "RMS value of the Iq on Port";
+CM_ SG_ 2147487880 NFrequencyPortA1 "Frequency of the AC network";
+CM_ SG_ 2147487880 IqPhCPortA1RMS "RMS value of the Iq on phase C";
+CM_ SG_ 2147487880 IdPhAPortA1RMS "RMS value of the Id on phase A";
+CM_ SG_ 2147487880 IdPortA1RMS "RMS value of the Id on Port";
+CM_ SG_ 2147487880 VphCPortA1Peak "Peak value of the voltage on phase C";
+CM_ SG_ 2147487880 IdPhCPortA1RMS "RMS value of the Id on phase C";
+CM_ SG_ 2147487880 IphCPortA1Peak "Peak value of the current on phase C";
+CM_ SG_ 2147487880 VqPortA1RMS "RMS value of the Vq";
+CM_ SG_ 2147487880 VphBPortA1Peak "Peak value of the voltage on phase B";
+CM_ SG_ 2147487880 IqPhBPortA1RMS "RMS value of the Iq on phase B";
+CM_ SG_ 2147487880 IphBPortA1Peak "Peak value of the current on phase B";
+CM_ SG_ 2147487880 VdPortA1RMS "RMS value of the Vd";
+CM_ SG_ 2147487880 VphAPortA1Peak "Peak value of the voltage on phase A";
+CM_ SG_ 2147487880 IphAPortA1Peak "Peak value of the current on phase A";
+CM_ SG_ 2147487880 IdPhBPortA1RMS "RMS value of the Id on phase B";
+CM_ BO_ 2147487944 "Values of port A2 ";
+CM_ SG_ 2147487944 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487944 NPortA2OverloadCount "Counter indicating the number of times an overload is detected on port A2";
+CM_ SG_ 2147487944 IPortA2Average "Average value of the port A2 current";
+CM_ SG_ 2147487944 VPortA2Average "Average value of the port A2 voltage";
+CM_ SG_ 2147487944 VPortA2Max "Maximum value of the  port A2 voltage seen since the last message sent";
+CM_ SG_ 2147487944 VPortA2Min "Minimum value of the port A2 voltage seen since the last message sent";
+CM_ BO_ 2147489480 "Value of all parameters of the configuration and settings";
+CM_ SG_ 2147489480 NParameterValue "Value of the 16bits word";
+CM_ SG_ 2147489480 NParameterIndex "Index at which the word is read in the selected zone";
+CM_ SG_ 2147489480 NReadZoneSelect "Zone in which to read the parameters";
+CM_ BO_ 2147487816 "Global values";
+CM_ SG_ 2147487816 NCellOtpErrorFlags "Indicates overtemperature protection of cells";
+CM_ SG_ 2147487816 TCell3N2 "Temperature number 2 of cell 3";
+CM_ SG_ 2147487816 VAuxCell4N2 "Auxiliary voltage number 2 of cell 4";
+CM_ SG_ 2147487816 TCell3N1 "Temperature number 1 of cell 3";
+CM_ SG_ 2147487816 TInternal "Global product temperature";
+CM_ SG_ 2147487816 NBootloaderId "Version number of the bootloader program";
+CM_ SG_ 2147487816 NApplicationId "Version number of the application program";
+CM_ SG_ 2147487816 VAuxCell3N2 "Auxiliary voltage number 2 of cell 3";
+CM_ SG_ 2147487816 NSyncNodeCount "Number of node on the network";
+CM_ SG_ 2147487816 NSyncNodeRank "Rank of the node on the network";
+CM_ SG_ 2147487816 NReleaseMode "Reserved";
+CM_ SG_ 2147487816 TCell2N2 "Temperature number 2 of cell 2";
+CM_ SG_ 2147487816 NCellVAuxErrorFlags "Indicates Auxiliary voltage error on cells";
+CM_ SG_ 2147487816 VAuxCell4N1 "Auxiliary voltage number 1 of cell 4";
+CM_ SG_ 2147487816 VAuxCell2N2 "Auxiliary voltage number 2 of cell 2";
+CM_ SG_ 2147487816 VAuxCell4N3 "Auxiliary voltage number 3 of cell 4";
+CM_ SG_ 2147487816 TCell4N3 "Temperature number 3 of cell 4";
+CM_ SG_ 2147487816 VAux3Measured "Auxiliary voltage used for offset of current and voltage measurement";
+CM_ SG_ 2147487816 TCell2N1 "Temperature number 1 of cell 2";
+CM_ SG_ 2147487816 NConfigCrc "CRC of the CONFIG";
+CM_ SG_ 2147487816 NSettingsCrc "CRC of the SETTINGS";
+CM_ SG_ 2147487816 NSerial "Product Serial Number";
+CM_ SG_ 2147487816 VAuxCell3N1 "Auxiliary voltage number 1 of cell 3";
+CM_ SG_ 2147487816 VAuxCell1N2 "Auxiliary voltage number 2 of cell 1";
+CM_ SG_ 2147487816 VAuxCell3N3 "Auxiliary voltage number 3 of cell 3";
+CM_ SG_ 2147487816 TCell3N3 "Temperature number 3 of cell 3";
+CM_ SG_ 2147487816 VAux2Measured "Auxiliary voltage 3V3 value";
+CM_ SG_ 2147487816 TCell1N2 "Temperature number 2 of cell 1";
+CM_ SG_ 2147487816 TCell4N2 "Temperature number 2 of cell 4";
+CM_ SG_ 2147487816 NCellXcpErrorFlags "Indicates Xcp error on cells";
+CM_ SG_ 2147487816 VAuxCell2N1 "Auxiliary voltage number 1 of cell 2";
+CM_ SG_ 2147487816 VAuxCell2N3 "Auxiliary voltage number 3 of cell 2";
+CM_ SG_ 2147487816 TCell2N3 "Temperature number 3 of cell 2";
+CM_ SG_ 2147487816 VAux1Measured "Auxiliary voltage LV value";
+CM_ SG_ 2147487816 TCell1N1 "Temperature number 1 of cell 1";
+CM_ SG_ 2147487816 TCell4N1 "Temperature number 1 of cell 4";
+CM_ SG_ 2147487816 NConfigVersion "Version number of the CONFIG";
+CM_ SG_ 2147487816 NSettingsVersion "Version number of the SETTINGS";
+CM_ SG_ 2147487816 NChecksum "Checksum of the application program";
+CM_ SG_ 2147487816 NCellSwOcpErrorFlags "Indicates Sw overcurrent protection ";
+CM_ SG_ 2147487816 VAuxCell1N1 "Auxiliary voltage number 1 of cell 1";
+CM_ SG_ 2147487816 VAuxCell1N3 "Auxiliary voltage number 3 of cell 1";
+CM_ SG_ 2147487816 TCell1N3 "Temperature number 3 of cell 1";
+CM_ SG_ 2147487816 NMultiplexer "Multiplexer ID";
+CM_ BO_ 2147487752 "Overal HVHV Status & Diagnostic";
+CM_ SG_ 2147487752 BPath1AcModeActivated "Indicates that the Power Path 1 is working in AC mode";
+CM_ SG_ 2147487752 BPath1AcUfpError "Power path 1 underfrequency fault";
+CM_ SG_ 2147487752 BPath1AcOfpError "Power path 1 overfrequency fault";
+CM_ SG_ 2147487752 NPath1AcFunctionMode "Power path 1 AC Function mode select";
+CM_ SG_ 2147487752 BPath1FlgCapaError "Indicates a flying capa voltage error on power path 1";
+CM_ SG_ 2147487752 BPath2FlgCapaError "Indicates a flying capa voltage error on power path 2";
+CM_ SG_ 2147487752 BPath1ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 1";
+CM_ SG_ 2147487752 BPath2ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 2";
+CM_ SG_ 2147487752 IPath1Unbalance "Unbalanced current between cells on power path 1";
+CM_ SG_ 2147487752 IPath2Unbalance "Unbalanced current between cells on power path 2";
+CM_ SG_ 2147487752 BPath1RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147487752 BPath2RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147487752 BPath1OcpError "Power path 1 overcurrent fault";
+CM_ SG_ 2147487752 BPath2OcpError "Power path 2 overcurrent fault";
+CM_ SG_ 2147487752 BPath1OtpError "Power path 1 overtemperature fault";
+CM_ SG_ 2147487752 BPath2OtpError "Power path 2 overtemperature fault";
+CM_ SG_ 2147487752 BPath1SideBUvpError "Power path 1 side B undervoltage fault";
+CM_ SG_ 2147487752 BPath2SideBUvpError "Power path 2 side B undervoltage fault";
+CM_ SG_ 2147487752 BPath1SideAUvpError "Power path 1 side A undervoltage fault";
+CM_ SG_ 2147487752 BPath2SideAUvpError "Power path 2 side A undervoltage fault";
+CM_ SG_ 2147487752 BPath1SideBOvpError "Power path 1 side B overvoltage fault";
+CM_ SG_ 2147487752 BPath2SideBOvpError "Power path 2 side B overvoltage fault";
+CM_ SG_ 2147487752 BPath1SideAOvpError "Power path 1 side A overvoltage fault";
+CM_ SG_ 2147487752 BPath2SideAOvpError "Power path 2 side A overvoltage fault";
+CM_ SG_ 2147487752 BPath1Requested "Indicates that the power path 1 start command has been received";
+CM_ SG_ 2147487752 BPath2Requested "Indicates that the power path 2 start command has been received";
+CM_ SG_ 2147487752 NPath1CurrentSideSelected "Point of current limitation of Power path 1";
+CM_ SG_ 2147487752 NPath2CurrentSideSelected "Point of current limitation of Power path 2";
+CM_ SG_ 2147487752 NPath1VoltageSideSelected "Point of voltage regulation of Power path 1";
+CM_ SG_ 2147487752 NPath2VoltageSideSelected "Point of voltage regulation of Power path 2";
+CM_ SG_ 2147487752 NPath1State "Indicates the power path 1 status";
+CM_ SG_ 2147487752 NPath2State "Indicates the power path 2 status";
+CM_ SG_ 2147487752 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147487752 BXcpError "Indicates a power switches command?s integrity fault";
+CM_ SG_ 2147487752 NCellHwErrorFlags "Indicates HW errors triggered on CELL";
+CM_ SG_ 2147487752 BSyncInputSignal "Indicates if a correct synchronization signal is detected on the input synchronization pin";
+CM_ SG_ 2147487752 BSyncRequested "Indicates the synchronization command has been received";
+CM_ SG_ 2147487752 BInternalTemperatureError "Indicates an overtemperature error on the internal temperature";
+CM_ SG_ 2147487752 BConfigSettingsError "Indicates that the Config and/or Settings data is corrupted";
+CM_ SG_ 2147487752 BAuxSupplyError "Indicates a fault on one of the auxiliary power supplies";
+CM_ SG_ 2147487752 BCanTimeoutError "Indicates an error on the CAN bus";
+CM_ SG_ 2147487752 BAuxIsoEnabled "Indicates that isolated auxiliary supplies are activated";
+CM_ SG_ 2147487752 BSafetyDischargeEnabled "Indicates the safety discharge is activated";
+CM_ SG_ 2147487752 BFaultSignal "Indicates the signal Fault status";
+CM_ SG_ 2147487752 BEnableSignal "Indicates the external hardware ENABLE status";
+CM_ SG_ 2147487752 BSafetyDischargeStatus "Indicates the safety discharge status";
+CM_ SG_ 2147487752 BSyncStatus "Indicates the synchronization has been done successfully";
+CM_ SG_ 2147487752 BReadConfigAndSettingsRequested "Indicates that the Read config and settings command has been received";
+CM_ SG_ 2147487752 BSwResetModuleRequested "Indicates that the Software reset command has been received";
+CM_ SG_ 2147487752 BSafetyDischargeRequested "Indicates that the safety discharge command has been received";
+CM_ SG_ 2147487752 NModuleState "Indicates the overall module status";
+CM_ BO_ 2147491393 "Response message giving the present values of the setpoints";
+CM_ SG_ 2147491393 NPath1CurrentSideSelected "Point of current limitation of Power path 1";
+CM_ SG_ 2147491393 NPath1VoltageSideSelected "Point of voltage regulation of Power path 1";
+CM_ SG_ 2147491393 IPath1LimitLo "Power path 1 current lower limitation";
+CM_ SG_ 2147491393 IPath1LimitHi "Power path 1 current upper limitation";
+CM_ SG_ 2147491393 VPath1Setpoint "Power path 1 voltage setpoint";
+CM_ SG_ 2147491393 NMultiplexer "Multiplexer ID: the power path's number of the setpoints";
+CM_ BO_ 2147491457 "Response message giving the present values of the setpoints";
+CM_ SG_ 2147491457 PPath1LimitLo "Power path 1 power lower limitation";
+CM_ SG_ 2147491457 PPath1LimitHi "Power path 1 power upper limitation";
+CM_ SG_ 2147491457 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147490817 "Values of port B1";
+CM_ SG_ 2147490817 NPortB1OverloadCount "Counter indicating the number of times an overload is detected on port B1";
+CM_ SG_ 2147490817 IPortB1Average "Average value of the port B1 current";
+CM_ SG_ 2147490817 VPortB1Average "Average value of the port B1 voltage";
+CM_ SG_ 2147490817 VPortB1Max "Maximum value of the  port B1 voltage seen since the last message sent";
+CM_ SG_ 2147490817 VPortB1Min "Minimum value of the port B1 voltage seen since the last message sent";
+CM_ BO_ 2147490175 "Command message to read the setpoints";
+CM_ SG_ 2147490175 NCRC "CRC of the message. The module accepts this message only when a correct CRC is verified";
+CM_ SG_ 2147490175 NPathSelect "The number of the power path to apply the setpoint read command to";
+CM_ SG_ 2147490175 BReadSetpointRequest "Setpoint read command";
+CM_ BO_ 2147490111 "Control of error acknowledgement commands";
+CM_ SG_ 2147490111 NCRC "CRC of the message. The module accepts this message only when a correct CRC is verified";
+CM_ SG_ 2147490111 NModuleSelect "Module ID on which to apply error acknowledge : 1-32 for module 1 to module 32, 63 for all modules";
+CM_ SG_ 2147490111 BAckErrorsModuleRequest "Acknowledgement of all errors on module";
+CM_ SG_ 2147490111 BAckErrorsPath1Request "Acknowledgement of errors on power path 1";
+CM_ BO_ 2147490047 "Control  of Setpoints 2";
+CM_ SG_ 2147490047 NCRC "CRC of the message. The module accepts this message only when a correct CRC is verified";
+CM_ SG_ 2147490047 NModuleSelect "Module ID on which to apply the setpoints";
+CM_ SG_ 2147490047 BL5_PPath1LimitLo "Power path 1 power lower limitation";
+CM_ SG_ 2147490047 BL6_PPath1LimitLo "Power path 1 power lower limitation";
+CM_ SG_ 2147490047 BL7_PPath1LimitLo "Power path 1 power lower limitation";
+CM_ SG_ 2147490047 BL5_PPath1LimitHi "Power path 1 power upper limitation";
+CM_ SG_ 2147490047 BL6_PPath1LimitHi "Power path 1 power upper limitation";
+CM_ SG_ 2147490047 BL7_PPath1LimitHi "Power path 1 power upper limitation";
+CM_ SG_ 2147490047 BL5_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ SG_ 2147490047 BL6_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ SG_ 2147490047 BL7_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ BO_ 2147489921 "Values of port A1";
+CM_ SG_ 2147489921 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147489921 NPortA1OverloadCount "Counter indicating the number of times an overload is detected on port A1";
+CM_ SG_ 2147489921 IPortA1Average "Average value of the port A1 current";
+CM_ SG_ 2147489921 VPortA1Average "Average value of the port A1 voltage";
+CM_ SG_ 2147489921 VPortA1Max "Maximum value of the port A1 voltage seen since the last message sent";
+CM_ SG_ 2147489921 VPortA1Min "Minimum value of the port A1 voltage seen since the last message sent";
+CM_ BO_ 2147491521 "Value of all parameters of the configuration and settings";
+CM_ SG_ 2147491521 NParameterValue "Value of the parameter";
+CM_ SG_ 2147491521 NParameterIndex "Index at which the word is read in the selected zone";
+CM_ SG_ 2147491521 NReadZoneSelect "Zone in which to read the parameters";
+CM_ BO_ 2147489857 "Global values";
+CM_ SG_ 2147489857 BSetpointsApplied "Indicates the power path setpoints have been applied";
+CM_ SG_ 2147489857 VAuxCell6N1 "Auxiliary voltage number 1 of cell 6";
+CM_ SG_ 2147489857 TCell6N2 "Temperature number 2 of cell 6";
+CM_ SG_ 2147489857 TCell3N2 "Temperature number 2 of cell 3";
+CM_ SG_ 2147489857 NCellOtpErrorFlags "Indicates overtemperature protection of cells";
+CM_ SG_ 2147489857 VAuxCell5N1 "Auxiliary voltage number 1 of cell 5";
+CM_ SG_ 2147489857 NApplicationId "Version number of the application program";
+CM_ SG_ 2147489857 NBootloaderId "Version number of the bootloader program";
+CM_ SG_ 2147489857 TInternal "Global product temperature";
+CM_ SG_ 2147489857 TCell6N1 "Temperature number 1 of cell 6";
+CM_ SG_ 2147489857 TCell3N1 "Temperature number 1 of cell 3";
+CM_ SG_ 2147489857 NSyncNodeCount "Count of nodes in the array";
+CM_ SG_ 2147489857 NSyncNodeRank "Rank of the node in the array";
+CM_ SG_ 2147489857 VAuxCell4N1 "Auxiliary voltage number 1 of cell 4";
+CM_ SG_ 2147489857 NCellVAuxErrorFlags "Indicates Auxiliary voltage error on cells";
+CM_ SG_ 2147489857 TCell8N2 "Temperature number 2 of cell 8";
+CM_ SG_ 2147489857 TCell5N2 "Temperature number 2 of cell 5";
+CM_ SG_ 2147489857 TCell2N2 "Temperature number 2 of cell 2";
+CM_ SG_ 2147489857 NReleaseMode "Reserved";
+CM_ SG_ 2147489857 VAuxCell3N1 "Auxiliary voltage number 1 of cell 3";
+CM_ SG_ 2147489857 NSerial "Product Serial Number";
+CM_ SG_ 2147489857 NSettingsCrc "CRC of the SETTINGS";
+CM_ SG_ 2147489857 NConfigCrc "CRC of the CONFIG";
+CM_ SG_ 2147489857 TCell8N1 "Temperature number 1 of cell 8";
+CM_ SG_ 2147489857 TCell5N1 "Temperature number 1 of cell 5";
+CM_ SG_ 2147489857 TCell2N1 "Temperature number 1 of cell 2";
+CM_ SG_ 2147489857 VAux3Measured "Auxiliary voltage used for offset of current and voltage measurement";
+CM_ SG_ 2147489857 VAuxCell8N1 "Auxiliary voltage number 1 of cell 8";
+CM_ SG_ 2147489857 VAuxCell2N1 "Auxiliary voltage number 1 of cell 2";
+CM_ SG_ 2147489857 NCellXcpErrorFlags "Indicates Xcp error on cells";
+CM_ SG_ 2147489857 TCell7N2 "Temperature number 2 of cell 7";
+CM_ SG_ 2147489857 TCell4N2 "Temperature number 2 of cell 4";
+CM_ SG_ 2147489857 TCell1N2 "Temperature number 2 of cell 1";
+CM_ SG_ 2147489857 VAux2Measured "Auxiliary voltage 3V3 value";
+CM_ SG_ 2147489857 VAuxCell7N1 "Auxiliary voltage number 1 of cell 7";
+CM_ SG_ 2147489857 VAuxCell1N1 "Auxiliary voltage number 1 of cell 1";
+CM_ SG_ 2147489857 NCellSwOcpErrorFlags "Indicates Sw overcurrent protection ";
+CM_ SG_ 2147489857 NChecksum "Checksum of the application program";
+CM_ SG_ 2147489857 NSettingsVersion "Version number of the SETTINGS";
+CM_ SG_ 2147489857 NConfigVersion "Version number of the CONFIG";
+CM_ SG_ 2147489857 TCell7N1 "Temperature number 1 of cell 7";
+CM_ SG_ 2147489857 TCell4N1 "Temperature number 1 of cell 4";
+CM_ SG_ 2147489857 TCell1N1 "Temperature number 1 of cell 1";
+CM_ SG_ 2147489857 VAux1Measured "Auxiliary voltage LV value";
+CM_ SG_ 2147489857 NMultiplexer "Multiplexer ID";
+CM_ BO_ 2147489793 "Overal DCDC Status & Diagnostic";
+CM_ SG_ 2147489793 BPath1AcModeActivated "Indicates that the Power Path 1 is working in AC mode";
+CM_ SG_ 2147489793 BPath1ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 1";
+CM_ SG_ 2147489793 IPath1Unbalance "Unbalanced current between cells on power path 1";
+CM_ SG_ 2147489793 BPath1RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147489793 BPath1OcpError "Power path 1 overcurrent fault";
+CM_ SG_ 2147489793 BPath1OtpError "Power path 1 overtemperature fault";
+CM_ SG_ 2147489793 BPath1SideBUvpError "Power path 1 side B undervoltage fault";
+CM_ SG_ 2147489793 BPath1SideAUvpError "Power path 1 side A undervoltage fault";
+CM_ SG_ 2147489793 BPath1SideBOvpError "Power path 1 side B overvoltage fault";
+CM_ SG_ 2147489793 BPath1SideAOvpError "Power path 1 side A overvoltage fault";
+CM_ SG_ 2147489793 BPath1Requested "Indicates that the power path 1 start command has been received";
+CM_ SG_ 2147489793 NPath1CurrentSideSelected "Point of current limitation of Power path 1";
+CM_ SG_ 2147489793 NPath1VoltageSideSelected "Point of voltage regulation of Power path 1";
+CM_ SG_ 2147489793 NPath1State "Indicates the path 1 status";
+CM_ SG_ 2147489793 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147489793 BXcpError "Indicates a power switches command?s integrity fault";
+CM_ SG_ 2147489793 NCellHwErrorFlags "Indicates HW errors triggered on CELL";
+CM_ SG_ 2147489793 BIsoError "Indicates if an error occured on the isolated stage";
+CM_ SG_ 2147489793 BSyncInputSignal "Indicates if a correct synchronization signal is detected on the input synchronization pin";
+CM_ SG_ 2147489793 BSyncRequested "Indicates the synchronization command has been received";
+CM_ SG_ 2147489793 BInternalTemperatureError "Indicates an overtemperature error on the internal temperature";
+CM_ SG_ 2147489793 BConfigSettingsError "Indicates that the Config and/or Settings data is corrupted";
+CM_ SG_ 2147489793 BAuxSupplyError "Indicates a fault on one of the auxiliary power supplies";
+CM_ SG_ 2147489793 BCanTimeoutError "Indicates an error on the CAN bus";
+CM_ SG_ 2147489793 BAuxIsoEnabled "Indicates that isolated auxiliary supplies are activated";
+CM_ SG_ 2147489793 BSafetyDischargeEnabled "Indicates the safety discharge is activated";
+CM_ SG_ 2147489793 BFaultSignal "Indicates the signal Fault status";
+CM_ SG_ 2147489793 BEnableSignal "Indicates the external hardware ENABLE status";
+CM_ SG_ 2147489793 BSafetyDischargeStatus "Indicates the safety discharge status";
+CM_ SG_ 2147489793 BSyncStatus "Indicates the synchronization has been done successfully";
+CM_ SG_ 2147489793 BReadConfigAndSettingsRequested "Indicates that the Read config and settings command has been received";
+CM_ SG_ 2147489793 BSwResetModuleRequested "Indicates that the Software reset command has been received";
+CM_ SG_ 2147489793 BSafetyDischargeRequested "Indicates that the safety discharge command has been received";
+CM_ SG_ 2147489793 NModuleState "Indicates the overall module status";
+CM_ BO_ 2147489983 "Control  of Setpoints 1 DC";
+CM_ SG_ 2147489983 NCRC "CRC of the message. The module accepts this message only when a correct CRC is verified";
+CM_ SG_ 2147489983 NModuleSelect "Module ID on which to apply the setpoints";
+CM_ SG_ 2147489983 BL5_NPath1CurrentSideSelect "Point of current limitation of Power path 1";
+CM_ SG_ 2147489983 BL6_NPath1CurrentSideSelect "Point of current limitation of Power path 1";
+CM_ SG_ 2147489983 BL7_NPath1CurrentSideSelect "Point of current limitation of Power path 1";
+CM_ SG_ 2147489983 BL5_NPath1VoltageSideSelect "Point of voltage regulation of Power path 1";
+CM_ SG_ 2147489983 BL6_NPath1VoltageSideSelect "Point of voltage regulation of Power path 1";
+CM_ SG_ 2147489983 BL7_NPath1VoltageSideSelect "Point of voltage regulation of Power path 1";
+CM_ SG_ 2147489983 BL5_IPath1LimitLo "Power path 1 current lower limitation";
+CM_ SG_ 2147489983 BL6_IPath1LimitLo "Power path 1 current lower limitation";
+CM_ SG_ 2147489983 BL7_IPath1LimitLo "Power path 1 current lower limitation";
+CM_ SG_ 2147489983 BL5_IPath1LimitHi "Power path 1 current upper limitation";
+CM_ SG_ 2147489983 BL6_IPath1LimitHi "Power path 1 current upper limitation";
+CM_ SG_ 2147489983 BL7_IPath1LimitHi "Power path 1 current upper limitation";
+CM_ SG_ 2147489983 BL5_VPath1Setpoint "Power path 1 voltage setpoint";
+CM_ SG_ 2147489983 BL6_VPath1Setpoint "Power path 1 voltage setpoint";
+CM_ SG_ 2147489983 BL7_VPath1Setpoint "Power path 1 voltage setpoint";
+CM_ SG_ 2147489983 BL5_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ SG_ 2147489983 BL6_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ SG_ 2147489983 BL7_NMultiplexer "Multiplexer ID: allows to select the power path to apply the setpoints";
+CM_ BO_ 2147489855 "Control message from the ECU";
+CM_ SG_ 2147489855 BIsoStandaloneRequest "IsoStandalone command";
+CM_ SG_ 2147489855 NCRC "CRC of the message. The module accepts this message only when a correct CRC is verified";
+CM_ SG_ 2147489855 NModuleSelect "Module ID on which to apply software reset command and/or read config and settings command and/or discharge active command : 1-32 for module 1 to module 32, 63 for all modules";
+CM_ SG_ 2147489855 BSyncRequest "Activate synchronization command";
+CM_ SG_ 2147489855 BReadConfigAndSettingsRequest "Read config and settings of module command";
+CM_ SG_ 2147489855 BSwResetModuleRequest "Software reset module command";
+CM_ SG_ 2147489855 BSafetyDischargeRequest "Module safety discharge command";
+CM_ SG_ 2147489855 BPath1Request "Start/Stop power path 1 command";
+CM_ SG_ 2147489855 NCounter "Counter for reception of CAN messages. If it does not change for more than CanTimeOut parameter then an error is detected (CAN error)";
+CM_ BO_ 2147491713 "Overal Isolation stage Status & Diagnostic";
+CM_ SG_ 2147491713 BStartupTimeout "Indicates the start up sequence timed out";
+CM_ SG_ 2147491713 BOtpBuckAux "Indicates on over temperature error on the auxiliary buck";
+CM_ SG_ 2147491713 BOtpSecError "Indicates an over temperature error on the secondary side of the isolation transformer (side C)";
+CM_ SG_ 2147491713 BOtpPriError "Indicates an over temperature error on the primary side of the isolation transformer (side internal)";
+CM_ SG_ 2147491713 BXcpBuckAuxError "Indicates an internal fault on the auxiliary buck stage";
+CM_ SG_ 2147491713 BXcpDcdcError "Indicates an internal fault on the Dcdc stage";
+CM_ SG_ 2147491713 BSecOcpError "Indicates an over current error on the secondary side of the isolation transformer (side C)";
+CM_ SG_ 2147491713 BPriOcpError "Indicates an over current error on the primary side of the isolation transformer (side internal)";
+CM_ SG_ 2147491713 BSecUvpError "Indicates an undervoltage on the secondary side of the isolation transfomer (side C)";
+CM_ SG_ 2147491713 BSecOvpError "Indicates an overvoltage on the secondary side of the isolation transformer (side C)";
+CM_ SG_ 2147491713 BPriUvpError "Indicates an undervoltage on the primary side of the isolation transformer (side internal)";
+CM_ SG_ 2147491713 BPriOvpError "Indicates an overvoltage on the primary side of the isolation transformer (side internal)";
+CM_ SG_ 2147491713 BBuckOcpError "Indicates an error on the current measured in the auxiliary buck";
+CM_ SG_ 2147491713 BSuppAuxUvpError "Indicates an undervoltage on the output of the auxiliairy buck";
+CM_ SG_ 2147491713 BSuppAuxOvpError "Indicates an overvoltage on the output voltage of the auxiliary buck";
+CM_ SG_ 2147491713 BBuckAuxHwError "Indicates an overvoltage on the output voltage of the auxiliary buck";
+CM_ SG_ 2147491713 BBuckVAuxDriverError "Indicates an hardware error on the auxiliary buck";
+CM_ SG_ 2147491713 BAuxSupplyError "Indicates an error on the auxiliary supply";
+CM_ SG_ 2147491713 BCanIntTimeoutError "Indicates an error on the internal CAN bus";
+CM_ SG_ 2147491713 BCanTimeoutError "Indicates an error on the CAN bus";
+CM_ SG_ 2147491713 BConfigSettingsError "Indicates the Config and or the Settings data are corrupted";
+CM_ SG_ 2147491713 BPowerRequested "Indicates a start request has been received from the power board";
+CM_ SG_ 2147491713 NAuxBuckState "Indicates the auxiliary buck state";
+CM_ SG_ 2147491713 NChan2State "Indicates the isolation transformer channel 2 state";
+CM_ SG_ 2147491713 NChan1State "Indicates the isolation transformer channel 1 state";
+CM_ SG_ 2147491713 BAuxIsoEnabled "Indicates if the isolated auxiliary supplies are activated";
+CM_ SG_ 2147491713 BFaultSignal "Indicates the signal Fault status";
+CM_ SG_ 2147491713 BEnableSignal "Indicates the external hardware ENABLE status";
+CM_ SG_ 2147491713 BSyncInputSignal "Indicates if a correct synchronization signal is detected on the input synchronization pin";
+CM_ SG_ 2147491713 BSyncStatus "Indicates if the synchronization has been done successfully";
+CM_ SG_ 2147491713 BSwResetModuleRequested "Indicates the software reset command has been received";
+CM_ SG_ 2147491713 NState "Indicates the isolation stage state";
+CM_ BO_ 2147491777 "Isolation stage global values";
+CM_ SG_ 2147491777 TSecCh2D "Temperature of the secondary bridge D of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491777 TSecCh1D "Temperature of the secondary bridge D of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491777 TPriCh2D "Temperature of the primary bridge D of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491777 TPriCh1D "Temperature of the primary bridge D of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491777 NReleaseMode "Reserved";
+CM_ SG_ 2147491777 NApplicationId "Module Serial Number";
+CM_ SG_ 2147491777 NSettingsVersion "Version number of the settings";
+CM_ SG_ 2147491777 NConfigCrc "Crc of the configuration";
+CM_ SG_ 2147491777 NXcpDcdcErrorFlags "Details on internal fault for the dcdc stage";
+CM_ SG_ 2147491777 NOtpDcdcErrorFlags "Details on over temperature protection";
+CM_ SG_ 2147491777 TSecCh2C "Temperature of the secondary bridge C of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491777 TSecCh1C "Temperature of the secondary bridge C of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491777 TPriCh2C "Temperature of the primary bridge C of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491777 TPriCh1C "Temperature of the primary bridge C of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491777 V1v65Aux "Auxiliary voltage 1V65 value";
+CM_ SG_ 2147491777 VBuckAuxDriver "Auxiliary voltage supply for the auxiliary buck drivers";
+CM_ SG_ 2147491777 TSecCh2B "Temperature of the secondary bridge B of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491777 TSecCh1B "Temperature of the secondary bridge B of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491777 TPriCh2B "Temperature of the primary bridge B of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491777 TPriCh1B "Temperature of the primary bridge B of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491777 V3v3Aux "Auxiliary voltage 3v3 value";
+CM_ SG_ 2147491777 NMissedSyncPulseCount "reserved";
+CM_ SG_ 2147491777 NChecksum "Checksum of the application program";
+CM_ SG_ 2147491777 NSerial "Module serial number";
+CM_ SG_ 2147491777 NSettingsCrc "Crc of the settings";
+CM_ SG_ 2147491777 NBootloaderId "Version number of the bootloader program";
+CM_ SG_ 2147491777 NConfigVersion "Version number of the configuration";
+CM_ SG_ 2147491777 NOcpDcdcErrorFlags "Detail on over current protection";
+CM_ SG_ 2147491777 TBuckAux "Temperature of the auxiliary buck";
+CM_ SG_ 2147491777 TSecCh2A "Temperature of the secondary bridge A of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491777 TSecCh1A "Temperature of the secondary bridge A of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491777 TPriCh2A "Temperature of the primary bridge A of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491777 TPriCh1A "Temperature of the primary bridge A of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491777 VHvAux "Main auxiliary voltage";
+CM_ SG_ 2147491777 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147491777 VSuppAux "Auxiliary voltage supply for the dcdc isolation stage";
+CM_ SG_ 2147491777 IBuckAux "Auxiliary buck current value";
+CM_ BO_ 2147490689 "Values of port Internal";
+CM_ SG_ 2147490689 IPortInternalAverage "Average value of the internal port current";
+CM_ SG_ 2147490689 VPortInternalAverage "Average value of the internal port voltage";
+CM_ SG_ 2147490689 VPortInternalMax "Maximum value of the internal port voltage measured since the last message sent";
+CM_ SG_ 2147490689 VPortInternalMin "Minimum value of the internal port voltage measured since the last message sent";
+CM_ BO_ 2147490753 "Values of port C1";
+CM_ SG_ 2147490753 IPortC1Average "Average value of the port C1 current";
+CM_ SG_ 2147490753 VPortC1Average "Average value of the port C1 voltage";
+CM_ SG_ 2147490753 VPortC1Max "Maximum value of the  port C1 voltage seen since the last message sent";
+CM_ SG_ 2147490753 VPortC1Min "Minimum value of the port C1 voltage seen since the last message sent";
+CM_ BO_ 2147491394 "Response message giving the present values of the setpoints";
+CM_ SG_ 2147491394 NPath1CurrentSideSelected "Point of current limitation of Power path 1";
+CM_ SG_ 2147491394 NPath1VoltageSideSelected "Point of voltage regulation of Power path 1";
+CM_ SG_ 2147491394 IPath1LimitLo "Power path 1 current lower limitation";
+CM_ SG_ 2147491394 IPath1LimitHi "Power path 1 current upper limitation";
+CM_ SG_ 2147491394 VPath1Setpoint "Power path 1 voltage setpoint";
+CM_ SG_ 2147491394 NMultiplexer "Multiplexer ID: the power path's number of the setpoints";
+CM_ BO_ 2147491458 "Response message giving the present values of the setpoints";
+CM_ SG_ 2147491458 PPath1LimitLo "Power path 1 power lower limitation";
+CM_ SG_ 2147491458 PPath1LimitHi "Power path 1 power upper limitation";
+CM_ SG_ 2147491458 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147490818 "Values of port B1";
+CM_ SG_ 2147490818 NPortB1OverloadCount "Counter indicating the number of times an overload is detected on port B1";
+CM_ SG_ 2147490818 IPortB1Average "Average value of the port B1 current";
+CM_ SG_ 2147490818 VPortB1Average "Average value of the port B1 voltage";
+CM_ SG_ 2147490818 VPortB1Max "Maximum value of the  port B1 voltage seen since the last message sent";
+CM_ SG_ 2147490818 VPortB1Min "Minimum value of the port B1 voltage seen since the last message sent";
+CM_ BO_ 2147489922 "Values of port A1";
+CM_ SG_ 2147489922 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147489922 NPortA1OverloadCount "Counter indicating the number of times an overload is detected on port A1";
+CM_ SG_ 2147489922 IPortA1Average "Average value of the port A1 current";
+CM_ SG_ 2147489922 VPortA1Average "Average value of the port A1 voltage";
+CM_ SG_ 2147489922 VPortA1Max "Maximum value of the port A1 voltage seen since the last message sent";
+CM_ SG_ 2147489922 VPortA1Min "Minimum value of the port A1 voltage seen since the last message sent";
+CM_ BO_ 2147491522 "Value of all parameters of the configuration and settings";
+CM_ SG_ 2147491522 NParameterValue "Value of the parameter";
+CM_ SG_ 2147491522 NParameterIndex "Index at which the word is read in the selected zone";
+CM_ SG_ 2147491522 NReadZoneSelect "Zone in which to read the parameters";
+CM_ BO_ 2147489858 "Global values";
+CM_ SG_ 2147489858 BSetpointsApplied "Indicates the power path setpoints have been applied";
+CM_ SG_ 2147489858 VAuxCell6N1 "Auxiliary voltage number 1 of cell 6";
+CM_ SG_ 2147489858 TCell6N2 "Temperature number 2 of cell 6";
+CM_ SG_ 2147489858 TCell3N2 "Temperature number 2 of cell 3";
+CM_ SG_ 2147489858 NCellOtpErrorFlags "Indicates overtemperature protection of cells";
+CM_ SG_ 2147489858 VAuxCell5N1 "Auxiliary voltage number 1 of cell 5";
+CM_ SG_ 2147489858 NApplicationId "Version number of the application program";
+CM_ SG_ 2147489858 NBootloaderId "Version number of the bootloader program";
+CM_ SG_ 2147489858 TInternal "Global product temperature";
+CM_ SG_ 2147489858 TCell6N1 "Temperature number 1 of cell 6";
+CM_ SG_ 2147489858 TCell3N1 "Temperature number 1 of cell 3";
+CM_ SG_ 2147489858 NSyncNodeCount "Count of nodes in the array";
+CM_ SG_ 2147489858 NSyncNodeRank "Rank of the node in the array";
+CM_ SG_ 2147489858 VAuxCell4N1 "Auxiliary voltage number 1 of cell 4";
+CM_ SG_ 2147489858 NCellVAuxErrorFlags "Indicates Auxiliary voltage error on cells";
+CM_ SG_ 2147489858 TCell8N2 "Temperature number 2 of cell 8";
+CM_ SG_ 2147489858 TCell5N2 "Temperature number 2 of cell 5";
+CM_ SG_ 2147489858 TCell2N2 "Temperature number 2 of cell 2";
+CM_ SG_ 2147489858 NReleaseMode "Reserved";
+CM_ SG_ 2147489858 VAuxCell3N1 "Auxiliary voltage number 1 of cell 3";
+CM_ SG_ 2147489858 NSerial "Product Serial Number";
+CM_ SG_ 2147489858 NSettingsCrc "CRC of the SETTINGS";
+CM_ SG_ 2147489858 NConfigCrc "CRC of the CONFIG";
+CM_ SG_ 2147489858 TCell8N1 "Temperature number 1 of cell 8";
+CM_ SG_ 2147489858 TCell5N1 "Temperature number 1 of cell 5";
+CM_ SG_ 2147489858 TCell2N1 "Temperature number 1 of cell 2";
+CM_ SG_ 2147489858 VAux3Measured "Auxiliary voltage used for offset of current and voltage measurement";
+CM_ SG_ 2147489858 VAuxCell8N1 "Auxiliary voltage number 1 of cell 8";
+CM_ SG_ 2147489858 VAuxCell2N1 "Auxiliary voltage number 1 of cell 2";
+CM_ SG_ 2147489858 NCellXcpErrorFlags "Indicates Xcp error on cells";
+CM_ SG_ 2147489858 TCell7N2 "Temperature number 2 of cell 7";
+CM_ SG_ 2147489858 TCell4N2 "Temperature number 2 of cell 4";
+CM_ SG_ 2147489858 TCell1N2 "Temperature number 2 of cell 1";
+CM_ SG_ 2147489858 VAux2Measured "Auxiliary voltage 3V3 value";
+CM_ SG_ 2147489858 VAuxCell7N1 "Auxiliary voltage number 1 of cell 7";
+CM_ SG_ 2147489858 VAuxCell1N1 "Auxiliary voltage number 1 of cell 1";
+CM_ SG_ 2147489858 NCellSwOcpErrorFlags "Indicates Sw overcurrent protection ";
+CM_ SG_ 2147489858 NChecksum "Checksum of the application program";
+CM_ SG_ 2147489858 NSettingsVersion "Version number of the SETTINGS";
+CM_ SG_ 2147489858 NConfigVersion "Version number of the CONFIG";
+CM_ SG_ 2147489858 TCell7N1 "Temperature number 1 of cell 7";
+CM_ SG_ 2147489858 TCell4N1 "Temperature number 1 of cell 4";
+CM_ SG_ 2147489858 TCell1N1 "Temperature number 1 of cell 1";
+CM_ SG_ 2147489858 VAux1Measured "Auxiliary voltage LV value";
+CM_ SG_ 2147489858 NMultiplexer "Multiplexer ID";
+CM_ BO_ 2147489794 "Overal DCDC Status & Diagnostic";
+CM_ SG_ 2147489794 BPath1AcModeActivated "Indicates that the Power Path 1 is working in AC mode";
+CM_ SG_ 2147489794 BPath1ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 1";
+CM_ SG_ 2147489794 IPath1Unbalance "Unbalanced current between cells on power path 1";
+CM_ SG_ 2147489794 BPath1RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147489794 BPath1OcpError "Power path 1 overcurrent fault";
+CM_ SG_ 2147489794 BPath1OtpError "Power path 1 overtemperature fault";
+CM_ SG_ 2147489794 BPath1SideBUvpError "Power path 1 side B undervoltage fault";
+CM_ SG_ 2147489794 BPath1SideAUvpError "Power path 1 side A undervoltage fault";
+CM_ SG_ 2147489794 BPath1SideBOvpError "Power path 1 side B overvoltage fault";
+CM_ SG_ 2147489794 BPath1SideAOvpError "Power path 1 side A overvoltage fault";
+CM_ SG_ 2147489794 BPath1Requested "Indicates that the power path 1 start command has been received";
+CM_ SG_ 2147489794 NPath1CurrentSideSelected "Point of current limitation of Power path 1";
+CM_ SG_ 2147489794 NPath1VoltageSideSelected "Point of voltage regulation of Power path 1";
+CM_ SG_ 2147489794 NPath1State "Indicates the path 1 status";
+CM_ SG_ 2147489794 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147489794 BXcpError "Indicates a power switches command?s integrity fault";
+CM_ SG_ 2147489794 NCellHwErrorFlags "Indicates HW errors triggered on CELL";
+CM_ SG_ 2147489794 BIsoError "Indicates if an error occured on the isolated stage";
+CM_ SG_ 2147489794 BSyncInputSignal "Indicates if a correct synchronization signal is detected on the input synchronization pin";
+CM_ SG_ 2147489794 BSyncRequested "Indicates the synchronization command has been received";
+CM_ SG_ 2147489794 BInternalTemperatureError "Indicates an overtemperature error on the internal temperature";
+CM_ SG_ 2147489794 BConfigSettingsError "Indicates that the Config and/or Settings data is corrupted";
+CM_ SG_ 2147489794 BAuxSupplyError "Indicates a fault on one of the auxiliary power supplies";
+CM_ SG_ 2147489794 BCanTimeoutError "Indicates an error on the CAN bus";
+CM_ SG_ 2147489794 BAuxIsoEnabled "Indicates that isolated auxiliary supplies are activated";
+CM_ SG_ 2147489794 BSafetyDischargeEnabled "Indicates the safety discharge is activated";
+CM_ SG_ 2147489794 BFaultSignal "Indicates the signal Fault status";
+CM_ SG_ 2147489794 BEnableSignal "Indicates the external hardware ENABLE status";
+CM_ SG_ 2147489794 BSafetyDischargeStatus "Indicates the safety discharge status";
+CM_ SG_ 2147489794 BSyncStatus "Indicates the synchronization has been done successfully";
+CM_ SG_ 2147489794 BReadConfigAndSettingsRequested "Indicates that the Read config and settings command has been received";
+CM_ SG_ 2147489794 BSwResetModuleRequested "Indicates that the Software reset command has been received";
+CM_ SG_ 2147489794 BSafetyDischargeRequested "Indicates that the safety discharge command has been received";
+CM_ SG_ 2147489794 NModuleState "Indicates the overall module status";
+CM_ BO_ 2147491714 "Overal Isolation stage Status & Diagnostic";
+CM_ SG_ 2147491714 BStartupTimeout "Indicates the start up sequence timed out";
+CM_ SG_ 2147491714 BOtpBuckAux "Indicates on over temperature error on the auxiliary buck";
+CM_ SG_ 2147491714 BOtpSecError "Indicates an over temperature error on the secondary side of the isolation transformer (side C)";
+CM_ SG_ 2147491714 BOtpPriError "Indicates an over temperature error on the primary side of the isolation transformer (side internal)";
+CM_ SG_ 2147491714 BXcpBuckAuxError "Indicates an internal fault on the auxiliary buck stage";
+CM_ SG_ 2147491714 BXcpDcdcError "Indicates an internal fault on the Dcdc stage";
+CM_ SG_ 2147491714 BSecOcpError "Indicates an over current error on the secondary side of the isolation transformer (side C)";
+CM_ SG_ 2147491714 BPriOcpError "Indicates an over current error on the primary side of the isolation transformer (side internal)";
+CM_ SG_ 2147491714 BSecUvpError "Indicates an undervoltage on the secondary side of the isolation transfomer (side C)";
+CM_ SG_ 2147491714 BSecOvpError "Indicates an overvoltage on the secondary side of the isolation transformer (side C)";
+CM_ SG_ 2147491714 BPriUvpError "Indicates an undervoltage on the primary side of the isolation transformer (side internal)";
+CM_ SG_ 2147491714 BPriOvpError "Indicates an overvoltage on the primary side of the isolation transformer (side internal)";
+CM_ SG_ 2147491714 BBuckOcpError "Indicates an error on the current measured in the auxiliary buck";
+CM_ SG_ 2147491714 BSuppAuxUvpError "Indicates an undervoltage on the output of the auxiliairy buck";
+CM_ SG_ 2147491714 BSuppAuxOvpError "Indicates an overvoltage on the output voltage of the auxiliary buck";
+CM_ SG_ 2147491714 BBuckAuxHwError "Indicates an overvoltage on the output voltage of the auxiliary buck";
+CM_ SG_ 2147491714 BBuckVAuxDriverError "Indicates an hardware error on the auxiliary buck";
+CM_ SG_ 2147491714 BAuxSupplyError "Indicates an error on the auxiliary supply";
+CM_ SG_ 2147491714 BCanIntTimeoutError "Indicates an error on the internal CAN bus";
+CM_ SG_ 2147491714 BCanTimeoutError "Indicates an error on the CAN bus";
+CM_ SG_ 2147491714 BConfigSettingsError "Indicates the Config and or the Settings data are corrupted";
+CM_ SG_ 2147491714 BPowerRequested "Indicates a start request has been received from the power board";
+CM_ SG_ 2147491714 NAuxBuckState "Indicates the auxiliary buck state";
+CM_ SG_ 2147491714 NChan2State "Indicates the isolation transformer channel 2 state";
+CM_ SG_ 2147491714 NChan1State "Indicates the isolation transformer channel 1 state";
+CM_ SG_ 2147491714 BAuxIsoEnabled "Indicates if the isolated auxiliary supplies are activated";
+CM_ SG_ 2147491714 BFaultSignal "Indicates the signal Fault status";
+CM_ SG_ 2147491714 BEnableSignal "Indicates the external hardware ENABLE status";
+CM_ SG_ 2147491714 BSyncInputSignal "Indicates if a correct synchronization signal is detected on the input synchronization pin";
+CM_ SG_ 2147491714 BSyncStatus "Indicates if the synchronization has been done successfully";
+CM_ SG_ 2147491714 BSwResetModuleRequested "Indicates the software reset command has been received";
+CM_ SG_ 2147491714 NState "Indicates the isolation stage state";
+CM_ BO_ 2147491778 "Isolation stage global values";
+CM_ SG_ 2147491778 TSecCh2D "Temperature of the secondary bridge D of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491778 TSecCh1D "Temperature of the secondary bridge D of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491778 TPriCh2D "Temperature of the primary bridge D of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491778 TPriCh1D "Temperature of the primary bridge D of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491778 NReleaseMode "Reserved";
+CM_ SG_ 2147491778 NApplicationId "Module Serial Number";
+CM_ SG_ 2147491778 NSettingsVersion "Version number of the settings";
+CM_ SG_ 2147491778 NConfigCrc "Crc of the configuration";
+CM_ SG_ 2147491778 NXcpDcdcErrorFlags "Details on internal fault for the dcdc stage";
+CM_ SG_ 2147491778 NOtpDcdcErrorFlags "Details on over temperature protection";
+CM_ SG_ 2147491778 TSecCh2C "Temperature of the secondary bridge C of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491778 TSecCh1C "Temperature of the secondary bridge C of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491778 TPriCh2C "Temperature of the primary bridge C of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491778 TPriCh1C "Temperature of the primary bridge C of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491778 V1v65Aux "Auxiliary voltage 1V65 value";
+CM_ SG_ 2147491778 VBuckAuxDriver "Auxiliary voltage supply for the auxiliary buck drivers";
+CM_ SG_ 2147491778 TSecCh2B "Temperature of the secondary bridge B of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491778 TSecCh1B "Temperature of the secondary bridge B of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491778 TPriCh2B "Temperature of the primary bridge B of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491778 TPriCh1B "Temperature of the primary bridge B of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491778 V3v3Aux "Auxiliary voltage 3v3 value";
+CM_ SG_ 2147491778 NMissedSyncPulseCount "reserved";
+CM_ SG_ 2147491778 NChecksum "Checksum of the application program";
+CM_ SG_ 2147491778 NSerial "Module serial number";
+CM_ SG_ 2147491778 NSettingsCrc "Crc of the settings";
+CM_ SG_ 2147491778 NBootloaderId "Version number of the bootloader program";
+CM_ SG_ 2147491778 NConfigVersion "Version number of the configuration";
+CM_ SG_ 2147491778 NOcpDcdcErrorFlags "Detail on over current protection";
+CM_ SG_ 2147491778 TBuckAux "Temperature of the auxiliary buck";
+CM_ SG_ 2147491778 TSecCh2A "Temperature of the secondary bridge A of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491778 TSecCh1A "Temperature of the secondary bridge A of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491778 TPriCh2A "Temperature of the primary bridge A of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491778 TPriCh1A "Temperature of the primary bridge A of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491778 VHvAux "Main auxiliary voltage";
+CM_ SG_ 2147491778 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147491778 VSuppAux "Auxiliary voltage supply for the dcdc isolation stage";
+CM_ SG_ 2147491778 IBuckAux "Auxiliary buck current value";
+CM_ BO_ 2147490690 "Values of port Internal";
+CM_ SG_ 2147490690 IPortInternalAverage "Average value of the internal port current";
+CM_ SG_ 2147490690 VPortInternalAverage "Average value of the internal port voltage";
+CM_ SG_ 2147490690 VPortInternalMax "Maximum value of the internal port voltage measured since the last message sent";
+CM_ SG_ 2147490690 VPortInternalMin "Minimum value of the internal port voltage measured since the last message sent";
+CM_ BO_ 2147490754 "Values of port C1";
+CM_ SG_ 2147490754 IPortC1Average "Average value of the port C1 current";
+CM_ SG_ 2147490754 VPortC1Average "Average value of the port C1 voltage";
+CM_ SG_ 2147490754 VPortC1Max "Maximum value of the  port C1 voltage seen since the last message sent";
+CM_ SG_ 2147490754 VPortC1Min "Minimum value of the port C1 voltage seen since the last message sent";
+CM_ BO_ 2147491395 "Response message giving the present values of the setpoints";
+CM_ SG_ 2147491395 NPath1CurrentSideSelected "Point of current limitation of Power path 1";
+CM_ SG_ 2147491395 NPath1VoltageSideSelected "Point of voltage regulation of Power path 1";
+CM_ SG_ 2147491395 IPath1LimitLo "Power path 1 current lower limitation";
+CM_ SG_ 2147491395 IPath1LimitHi "Power path 1 current upper limitation";
+CM_ SG_ 2147491395 VPath1Setpoint "Power path 1 voltage setpoint";
+CM_ SG_ 2147491395 NMultiplexer "Multiplexer ID: the power path's number of the setpoints";
+CM_ BO_ 2147491459 "Response message giving the present values of the setpoints";
+CM_ SG_ 2147491459 PPath1LimitLo "Power path 1 power lower limitation";
+CM_ SG_ 2147491459 PPath1LimitHi "Power path 1 power upper limitation";
+CM_ SG_ 2147491459 NMultiplexer "Multiplexer ID:  the power path's number of the setpoints";
+CM_ BO_ 2147490819 "Values of port B1";
+CM_ SG_ 2147490819 NPortB1OverloadCount "Counter indicating the number of times an overload is detected on port B1";
+CM_ SG_ 2147490819 IPortB1Average "Average value of the port B1 current";
+CM_ SG_ 2147490819 VPortB1Average "Average value of the port B1 voltage";
+CM_ SG_ 2147490819 VPortB1Max "Maximum value of the  port B1 voltage seen since the last message sent";
+CM_ SG_ 2147490819 VPortB1Min "Minimum value of the port B1 voltage seen since the last message sent";
+CM_ BO_ 2147489923 "Values of port A1";
+CM_ SG_ 2147489923 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147489923 NPortA1OverloadCount "Counter indicating the number of times an overload is detected on port A1";
+CM_ SG_ 2147489923 IPortA1Average "Average value of the port A1 current";
+CM_ SG_ 2147489923 VPortA1Average "Average value of the port A1 voltage";
+CM_ SG_ 2147489923 VPortA1Max "Maximum value of the port A1 voltage seen since the last message sent";
+CM_ SG_ 2147489923 VPortA1Min "Minimum value of the port A1 voltage seen since the last message sent";
+CM_ BO_ 2147491523 "Value of all parameters of the configuration and settings";
+CM_ SG_ 2147491523 NParameterValue "Value of the parameter";
+CM_ SG_ 2147491523 NParameterIndex "Index at which the word is read in the selected zone";
+CM_ SG_ 2147491523 NReadZoneSelect "Zone in which to read the parameters";
+CM_ BO_ 2147489859 "Global values";
+CM_ SG_ 2147489859 BSetpointsApplied "Indicates the power path setpoints have been applied";
+CM_ SG_ 2147489859 VAuxCell6N1 "Auxiliary voltage number 1 of cell 6";
+CM_ SG_ 2147489859 TCell6N2 "Temperature number 2 of cell 6";
+CM_ SG_ 2147489859 TCell3N2 "Temperature number 2 of cell 3";
+CM_ SG_ 2147489859 NCellOtpErrorFlags "Indicates overtemperature protection of cells";
+CM_ SG_ 2147489859 VAuxCell5N1 "Auxiliary voltage number 1 of cell 5";
+CM_ SG_ 2147489859 NApplicationId "Version number of the application program";
+CM_ SG_ 2147489859 NBootloaderId "Version number of the bootloader program";
+CM_ SG_ 2147489859 TInternal "Global product temperature";
+CM_ SG_ 2147489859 TCell6N1 "Temperature number 1 of cell 6";
+CM_ SG_ 2147489859 TCell3N1 "Temperature number 1 of cell 3";
+CM_ SG_ 2147489859 NSyncNodeCount "Count of nodes in the array";
+CM_ SG_ 2147489859 NSyncNodeRank "Rank of the node in the array";
+CM_ SG_ 2147489859 VAuxCell4N1 "Auxiliary voltage number 1 of cell 4";
+CM_ SG_ 2147489859 NCellVAuxErrorFlags "Indicates Auxiliary voltage error on cells";
+CM_ SG_ 2147489859 TCell8N2 "Temperature number 2 of cell 8";
+CM_ SG_ 2147489859 TCell5N2 "Temperature number 2 of cell 5";
+CM_ SG_ 2147489859 TCell2N2 "Temperature number 2 of cell 2";
+CM_ SG_ 2147489859 NReleaseMode "Reserved";
+CM_ SG_ 2147489859 VAuxCell3N1 "Auxiliary voltage number 1 of cell 3";
+CM_ SG_ 2147489859 NSerial "Product Serial Number";
+CM_ SG_ 2147489859 NSettingsCrc "CRC of the SETTINGS";
+CM_ SG_ 2147489859 NConfigCrc "CRC of the CONFIG";
+CM_ SG_ 2147489859 TCell8N1 "Temperature number 1 of cell 8";
+CM_ SG_ 2147489859 TCell5N1 "Temperature number 1 of cell 5";
+CM_ SG_ 2147489859 TCell2N1 "Temperature number 1 of cell 2";
+CM_ SG_ 2147489859 VAux3Measured "Auxiliary voltage used for offset of current and voltage measurement";
+CM_ SG_ 2147489859 VAuxCell8N1 "Auxiliary voltage number 1 of cell 8";
+CM_ SG_ 2147489859 VAuxCell2N1 "Auxiliary voltage number 1 of cell 2";
+CM_ SG_ 2147489859 NCellXcpErrorFlags "Indicates Xcp error on cells";
+CM_ SG_ 2147489859 TCell7N2 "Temperature number 2 of cell 7";
+CM_ SG_ 2147489859 TCell4N2 "Temperature number 2 of cell 4";
+CM_ SG_ 2147489859 TCell1N2 "Temperature number 2 of cell 1";
+CM_ SG_ 2147489859 VAux2Measured "Auxiliary voltage 3V3 value";
+CM_ SG_ 2147489859 VAuxCell7N1 "Auxiliary voltage number 1 of cell 7";
+CM_ SG_ 2147489859 VAuxCell1N1 "Auxiliary voltage number 1 of cell 1";
+CM_ SG_ 2147489859 NCellSwOcpErrorFlags "Indicates Sw overcurrent protection ";
+CM_ SG_ 2147489859 NChecksum "Checksum of the application program";
+CM_ SG_ 2147489859 NSettingsVersion "Version number of the SETTINGS";
+CM_ SG_ 2147489859 NConfigVersion "Version number of the CONFIG";
+CM_ SG_ 2147489859 TCell7N1 "Temperature number 1 of cell 7";
+CM_ SG_ 2147489859 TCell4N1 "Temperature number 1 of cell 4";
+CM_ SG_ 2147489859 TCell1N1 "Temperature number 1 of cell 1";
+CM_ SG_ 2147489859 VAux1Measured "Auxiliary voltage LV value";
+CM_ SG_ 2147489859 NMultiplexer "Multiplexer ID";
+CM_ BO_ 2147489795 "Overal DCDC Status & Diagnostic";
+CM_ SG_ 2147489795 BPath1AcModeActivated "Indicates that the Power Path 1 is working in AC mode";
+CM_ SG_ 2147489795 BPath1ErrVAuxCell "Indicates a driver auxiliary voltage error on power path 1";
+CM_ SG_ 2147489795 IPath1Unbalance "Unbalanced current between cells on power path 1";
+CM_ SG_ 2147489795 BPath1RcpWarning "Warns the user of a potential reverse current problem";
+CM_ SG_ 2147489795 BPath1OcpError "Power path 1 overcurrent fault";
+CM_ SG_ 2147489795 BPath1OtpError "Power path 1 overtemperature fault";
+CM_ SG_ 2147489795 BPath1SideBUvpError "Power path 1 side B undervoltage fault";
+CM_ SG_ 2147489795 BPath1SideAUvpError "Power path 1 side A undervoltage fault";
+CM_ SG_ 2147489795 BPath1SideBOvpError "Power path 1 side B overvoltage fault";
+CM_ SG_ 2147489795 BPath1SideAOvpError "Power path 1 side A overvoltage fault";
+CM_ SG_ 2147489795 BPath1Requested "Indicates that the power path 1 start command has been received";
+CM_ SG_ 2147489795 NPath1CurrentSideSelected "Point of current limitation of Power path 1";
+CM_ SG_ 2147489795 NPath1VoltageSideSelected "Point of voltage regulation of Power path 1";
+CM_ SG_ 2147489795 NPath1State "Indicates the path 1 status";
+CM_ SG_ 2147489795 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147489795 BXcpError "Indicates a power switches command?s integrity fault";
+CM_ SG_ 2147489795 NCellHwErrorFlags "Indicates HW errors triggered on CELL";
+CM_ SG_ 2147489795 BIsoError "Indicates if an error occured on the isolated stage";
+CM_ SG_ 2147489795 BSyncInputSignal "Indicates if a correct synchronization signal is detected on the input synchronization pin";
+CM_ SG_ 2147489795 BSyncRequested "Indicates the synchronization command has been received";
+CM_ SG_ 2147489795 BInternalTemperatureError "Indicates an overtemperature error on the internal temperature";
+CM_ SG_ 2147489795 BConfigSettingsError "Indicates that the Config and/or Settings data is corrupted";
+CM_ SG_ 2147489795 BAuxSupplyError "Indicates a fault on one of the auxiliary power supplies";
+CM_ SG_ 2147489795 BCanTimeoutError "Indicates an error on the CAN bus";
+CM_ SG_ 2147489795 BAuxIsoEnabled "Indicates that isolated auxiliary supplies are activated";
+CM_ SG_ 2147489795 BSafetyDischargeEnabled "Indicates the safety discharge is activated";
+CM_ SG_ 2147489795 BFaultSignal "Indicates the signal Fault status";
+CM_ SG_ 2147489795 BEnableSignal "Indicates the external hardware ENABLE status";
+CM_ SG_ 2147489795 BSafetyDischargeStatus "Indicates the safety discharge status";
+CM_ SG_ 2147489795 BSyncStatus "Indicates the synchronization has been done successfully";
+CM_ SG_ 2147489795 BReadConfigAndSettingsRequested "Indicates that the Read config and settings command has been received";
+CM_ SG_ 2147489795 BSwResetModuleRequested "Indicates that the Software reset command has been received";
+CM_ SG_ 2147489795 BSafetyDischargeRequested "Indicates that the safety discharge command has been received";
+CM_ SG_ 2147489795 NModuleState "Indicates the overall module status";
+CM_ BO_ 2147491715 "Overal Isolation stage Status & Diagnostic";
+CM_ SG_ 2147491715 BStartupTimeout "Indicates the start up sequence timed out";
+CM_ SG_ 2147491715 BOtpBuckAux "Indicates on over temperature error on the auxiliary buck";
+CM_ SG_ 2147491715 BOtpSecError "Indicates an over temperature error on the secondary side of the isolation transformer (side C)";
+CM_ SG_ 2147491715 BOtpPriError "Indicates an over temperature error on the primary side of the isolation transformer (side internal)";
+CM_ SG_ 2147491715 BXcpBuckAuxError "Indicates an internal fault on the auxiliary buck stage";
+CM_ SG_ 2147491715 BXcpDcdcError "Indicates an internal fault on the Dcdc stage";
+CM_ SG_ 2147491715 BSecOcpError "Indicates an over current error on the secondary side of the isolation transformer (side C)";
+CM_ SG_ 2147491715 BPriOcpError "Indicates an over current error on the primary side of the isolation transformer (side internal)";
+CM_ SG_ 2147491715 BSecUvpError "Indicates an undervoltage on the secondary side of the isolation transfomer (side C)";
+CM_ SG_ 2147491715 BSecOvpError "Indicates an overvoltage on the secondary side of the isolation transformer (side C)";
+CM_ SG_ 2147491715 BPriUvpError "Indicates an undervoltage on the primary side of the isolation transformer (side internal)";
+CM_ SG_ 2147491715 BPriOvpError "Indicates an overvoltage on the primary side of the isolation transformer (side internal)";
+CM_ SG_ 2147491715 BBuckOcpError "Indicates an error on the current measured in the auxiliary buck";
+CM_ SG_ 2147491715 BSuppAuxUvpError "Indicates an undervoltage on the output of the auxiliairy buck";
+CM_ SG_ 2147491715 BSuppAuxOvpError "Indicates an overvoltage on the output voltage of the auxiliary buck";
+CM_ SG_ 2147491715 BBuckAuxHwError "Indicates an overvoltage on the output voltage of the auxiliary buck";
+CM_ SG_ 2147491715 BBuckVAuxDriverError "Indicates an hardware error on the auxiliary buck";
+CM_ SG_ 2147491715 BAuxSupplyError "Indicates an error on the auxiliary supply";
+CM_ SG_ 2147491715 BCanIntTimeoutError "Indicates an error on the internal CAN bus";
+CM_ SG_ 2147491715 BCanTimeoutError "Indicates an error on the CAN bus";
+CM_ SG_ 2147491715 BConfigSettingsError "Indicates the Config and or the Settings data are corrupted";
+CM_ SG_ 2147491715 BPowerRequested "Indicates a start request has been received from the power board";
+CM_ SG_ 2147491715 NAuxBuckState "Indicates the auxiliary buck state";
+CM_ SG_ 2147491715 NChan2State "Indicates the isolation transformer channel 2 state";
+CM_ SG_ 2147491715 NChan1State "Indicates the isolation transformer channel 1 state";
+CM_ SG_ 2147491715 BAuxIsoEnabled "Indicates if the isolated auxiliary supplies are activated";
+CM_ SG_ 2147491715 BFaultSignal "Indicates the signal Fault status";
+CM_ SG_ 2147491715 BEnableSignal "Indicates the external hardware ENABLE status";
+CM_ SG_ 2147491715 BSyncInputSignal "Indicates if a correct synchronization signal is detected on the input synchronization pin";
+CM_ SG_ 2147491715 BSyncStatus "Indicates if the synchronization has been done successfully";
+CM_ SG_ 2147491715 BSwResetModuleRequested "Indicates the software reset command has been received";
+CM_ SG_ 2147491715 NState "Indicates the isolation stage state";
+CM_ BO_ 2147491779 "Isolation stage global values";
+CM_ SG_ 2147491779 TSecCh2D "Temperature of the secondary bridge D of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491779 TSecCh1D "Temperature of the secondary bridge D of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491779 TPriCh2D "Temperature of the primary bridge D of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491779 TPriCh1D "Temperature of the primary bridge D of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491779 NReleaseMode "Reserved";
+CM_ SG_ 2147491779 NApplicationId "Module Serial Number";
+CM_ SG_ 2147491779 NSettingsVersion "Version number of the settings";
+CM_ SG_ 2147491779 NConfigCrc "Crc of the configuration";
+CM_ SG_ 2147491779 NXcpDcdcErrorFlags "Details on internal fault for the dcdc stage";
+CM_ SG_ 2147491779 NOtpDcdcErrorFlags "Details on over temperature protection";
+CM_ SG_ 2147491779 TSecCh2C "Temperature of the secondary bridge C of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491779 TSecCh1C "Temperature of the secondary bridge C of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491779 TPriCh2C "Temperature of the primary bridge C of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491779 TPriCh1C "Temperature of the primary bridge C of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491779 V1v65Aux "Auxiliary voltage 1V65 value";
+CM_ SG_ 2147491779 VBuckAuxDriver "Auxiliary voltage supply for the auxiliary buck drivers";
+CM_ SG_ 2147491779 TSecCh2B "Temperature of the secondary bridge B of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491779 TSecCh1B "Temperature of the secondary bridge B of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491779 TPriCh2B "Temperature of the primary bridge B of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491779 TPriCh1B "Temperature of the primary bridge B of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491779 V3v3Aux "Auxiliary voltage 3v3 value";
+CM_ SG_ 2147491779 NMissedSyncPulseCount "reserved";
+CM_ SG_ 2147491779 NChecksum "Checksum of the application program";
+CM_ SG_ 2147491779 NSerial "Module serial number";
+CM_ SG_ 2147491779 NSettingsCrc "Crc of the settings";
+CM_ SG_ 2147491779 NBootloaderId "Version number of the bootloader program";
+CM_ SG_ 2147491779 NConfigVersion "Version number of the configuration";
+CM_ SG_ 2147491779 NOcpDcdcErrorFlags "Detail on over current protection";
+CM_ SG_ 2147491779 TBuckAux "Temperature of the auxiliary buck";
+CM_ SG_ 2147491779 TSecCh2A "Temperature of the secondary bridge A of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491779 TSecCh1A "Temperature of the secondary bridge A of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491779 TPriCh2A "Temperature of the primary bridge A of the channel 2 of the dcdc isolated stage";
+CM_ SG_ 2147491779 TPriCh1A "Temperature of the primary bridge A of the channel 1 of the dcdc isolated stage";
+CM_ SG_ 2147491779 VHvAux "Main auxiliary voltage";
+CM_ SG_ 2147491779 NMultiplexer "Multiplexer ID";
+CM_ SG_ 2147491779 VSuppAux "Auxiliary voltage supply for the dcdc isolation stage";
+CM_ SG_ 2147491779 IBuckAux "Auxiliary buck current value";
+CM_ BO_ 2147490691 "Values of port Internal";
+CM_ SG_ 2147490691 IPortInternalAverage "Average value of the internal port current";
+CM_ SG_ 2147490691 VPortInternalAverage "Average value of the internal port voltage";
+CM_ SG_ 2147490691 VPortInternalMax "Maximum value of the internal port voltage measured since the last message sent";
+CM_ SG_ 2147490691 VPortInternalMin "Minimum value of the internal port voltage measured since the last message sent";
+CM_ BO_ 2147490755 "Values of port C1";
+CM_ SG_ 2147490755 IPortC1Average "Average value of the port C1 current";
+CM_ SG_ 2147490755 VPortC1Average "Average value of the port C1 voltage";
+CM_ SG_ 2147490755 VPortC1Max "Maximum value of the  port C1 voltage seen since the last message sent";
+CM_ SG_ 2147490755 VPortC1Min "Minimum value of the port C1 voltage seen since the last message sent";
+BA_DEF_  "Baudrate" INT 0 1000000;
+BA_DEF_  "Bootloader Range Address" STRING ;
+BA_DEF_  "Application Range Address" STRING ;
+BA_DEF_ BO_  "CanDootDecode" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootDecodeBus" INT 0 6;
+BA_DEF_ BO_  "CanDootPaused" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulate" ENUM  "No","Yes";
+BA_DEF_ BO_  "CanDootSimulateBus" INT 0 6;
+BA_DEF_ BO_  "CanDootSimulateCycleTime" INT 0 50000;
+BA_DEF_ BO_  "CG_MessageInstName" STRING ;
+BA_DEF_ BO_  "CG_RX_TX" ENUM  "RX","TX","NONE";
+BA_DEF_ SG_  "CanDootGroup" ENUM  "None","g1","g2","g3","g4","g5","g6","g7","g8","g9","gA","gB","gC","gD","gE","gF";
+BA_DEF_ SG_  "CanDootHidden" ENUM  "No","Yes";
+BA_DEF_ SG_  "CanDootBroadcast" ENUM  "No","Yes";
+BA_DEF_ SG_  "CG_VarType" ENUM  "bool","uint8_t","int8_t","uint16_t","int16_t","uint32_t","int32_t","uin64_t","int64_t","float","double";
+BA_DEF_  "MultiplexExtEnabled" ENUM  "No","Yes";
+BA_DEF_DEF_  "Baudrate" 500000;
+BA_DEF_DEF_  "Bootloader Range Address" "";
+BA_DEF_DEF_  "Application Range Address" "";
+BA_DEF_DEF_  "CanDootDecode" "Yes";
+BA_DEF_DEF_  "CanDootDecodeBus" 1;
+BA_DEF_DEF_  "CanDootPaused" "Yes";
+BA_DEF_DEF_  "CanDootSimulate" "No";
+BA_DEF_DEF_  "CanDootSimulateBus" 0;
+BA_DEF_DEF_  "CanDootSimulateCycleTime" 100;
+BA_DEF_DEF_  "CG_MessageInstName" "";
+BA_DEF_DEF_  "CG_RX_TX" "RX";
+BA_DEF_DEF_  "CanDootGroup" "None";
+BA_DEF_DEF_  "CanDootHidden" "No";
+BA_DEF_DEF_  "CanDootBroadcast" "No";
+BA_DEF_DEF_  "CG_VarType" "uint8_t";
+BA_DEF_DEF_  "MultiplexExtEnabled" "Yes";
+BA_ "Bootloader Range Address" "0x0FFFF000";
+BA_ "Application Range Address" "0x00001000";
+BA_ "CanDootDecode" BO_ 2147487747 0;
+BA_ "CanDootPaused" BO_ 2147487747 0;
+BA_ "CanDootDecode" BO_ 2147489411 0;
+BA_ "CanDootPaused" BO_ 2147489411 0;
+BA_ "CanDootDecode" BO_ 2147489347 0;
+BA_ "CanDootPaused" BO_ 2147489347 0;
+BA_ "CanDootDecode" BO_ 2147488771 0;
+BA_ "CanDootPaused" BO_ 2147488771 0;
+BA_ "CanDootDecode" BO_ 2147487875 0;
+BA_ "CanDootPaused" BO_ 2147487875 0;
+BA_ "CanDootDecode" BO_ 2147487939 0;
+BA_ "CanDootPaused" BO_ 2147487939 0;
+BA_ "CanDootDecode" BO_ 2147488387 0;
+BA_ "CanDootDecode" BO_ 2147488451 0;
+BA_ "CanDootDecode" BO_ 2147487811 0;
+BA_ "CanDootDecode" BO_ 2147489475 0;
+BA_ "CanDootDecode" BO_ 2147489410 0;
+BA_ "CanDootPaused" BO_ 2147489410 0;
+BA_ "CanDootDecode" BO_ 2147489346 0;
+BA_ "CanDootPaused" BO_ 2147489346 0;
+BA_ "CanDootDecode" BO_ 2147488450 0;
+BA_ "CanDootDecode" BO_ 2147488770 0;
+BA_ "CanDootPaused" BO_ 2147488770 0;
+BA_ "CanDootPaused" BO_ 2147488127 0;
+BA_ "CanDootPaused" BO_ 2147488063 0;
+BA_ "CanDootPaused" BO_ 2147487999 0;
+BA_ "CanDootPaused" BO_ 2147488191 0;
+BA_ "CanDootPaused" BO_ 2147488255 0;
+BA_ "CanDootDecode" BO_ 2147487938 0;
+BA_ "CanDootPaused" BO_ 2147487938 0;
+BA_ "CanDootDecode" BO_ 2147489474 0;
+BA_ "CanDootDecode" BO_ 2147487810 0;
+BA_ "CanDootDecode" BO_ 2147487746 0;
+BA_ "CanDootPaused" BO_ 2147487746 0;
+BA_ "CanDootPaused" BO_ 2147487935 0;
+BA_ "CanDootPaused" BO_ 2147487749 0;
+BA_ "CanDootPaused" BO_ 2147489413 0;
+BA_ "CanDootPaused" BO_ 2147489349 0;
+BA_ "CanDootPaused" BO_ 2147488773 0;
+BA_ "CanDootPaused" BO_ 2147487877 0;
+BA_ "CanDootPaused" BO_ 2147487941 0;
+BA_ "CanDootPaused" BO_ 2147489412 0;
+BA_ "CanDootPaused" BO_ 2147489348 0;
+BA_ "CanDootPaused" BO_ 2147488772 0;
+BA_ "CanDootPaused" BO_ 2147487876 0;
+BA_ "CanDootPaused" BO_ 2147487940 0;
+BA_ "CanDootPaused" BO_ 2147487748 0;
+BA_ "CanDootPaused" BO_ 2147487751 0;
+BA_ "CanDootPaused" BO_ 2147489415 0;
+BA_ "CanDootPaused" BO_ 2147489351 0;
+BA_ "CanDootPaused" BO_ 2147488775 0;
+BA_ "CanDootPaused" BO_ 2147487879 0;
+BA_ "CanDootPaused" BO_ 2147487943 0;
+BA_ "CanDootPaused" BO_ 2147489414 0;
+BA_ "CanDootPaused" BO_ 2147489350 0;
+BA_ "CanDootPaused" BO_ 2147488774 0;
+BA_ "CanDootPaused" BO_ 2147487878 0;
+BA_ "CanDootPaused" BO_ 2147487942 0;
+BA_ "CanDootPaused" BO_ 2147487750 0;
+BA_ "CanDootPaused" BO_ 2147487753 0;
+BA_ "CanDootPaused" BO_ 2147489417 0;
+BA_ "CanDootPaused" BO_ 2147489353 0;
+BA_ "CanDootPaused" BO_ 2147488777 0;
+BA_ "CanDootPaused" BO_ 2147487881 0;
+BA_ "CanDootPaused" BO_ 2147487945 0;
+BA_ "CanDootPaused" BO_ 2147489416 0;
+BA_ "CanDootPaused" BO_ 2147489352 0;
+BA_ "CanDootPaused" BO_ 2147488776 0;
+BA_ "CanDootPaused" BO_ 2147487880 0;
+BA_ "CanDootPaused" BO_ 2147487944 0;
+BA_ "CanDootPaused" BO_ 2147487752 0;
+BA_ "CanDootPaused" BO_ 2147491393 0;
+BA_ "CanDootPaused" BO_ 2147491457 0;
+BA_ "CanDootPaused" BO_ 2147490817 0;
+BA_ "CanDootPaused" BO_ 2147490175 0;
+BA_ "CanDootPaused" BO_ 2147490111 0;
+BA_ "CanDootPaused" BO_ 2147490047 0;
+BA_ "CanDootPaused" BO_ 2147489921 0;
+BA_ "CanDootPaused" BO_ 2147489793 0;
+BA_ "CanDootPaused" BO_ 2147489983 0;
+BA_ "CanDootPaused" BO_ 2147491713 0;
+BA_ "CanDootPaused" BO_ 2147490689 0;
+BA_ "CanDootPaused" BO_ 2147490753 0;
+BA_ "CanDootPaused" BO_ 2147491394 0;
+BA_ "CanDootPaused" BO_ 2147491458 0;
+BA_ "CanDootPaused" BO_ 2147490818 0;
+BA_ "CanDootPaused" BO_ 2147489922 0;
+BA_ "CanDootPaused" BO_ 2147489794 0;
+BA_ "CanDootPaused" BO_ 2147491714 0;
+BA_ "CanDootPaused" BO_ 2147490690 0;
+BA_ "CanDootPaused" BO_ 2147490754 0;
+BA_ "CanDootDecode" BO_ 2147491395 0;
+BA_ "CanDootPaused" BO_ 2147491395 0;
+BA_ "CanDootDecode" BO_ 2147491459 0;
+BA_ "CanDootPaused" BO_ 2147491459 0;
+BA_ "CanDootDecode" BO_ 2147490819 0;
+BA_ "CanDootPaused" BO_ 2147490819 0;
+BA_ "CanDootDecode" BO_ 2147489923 0;
+BA_ "CanDootPaused" BO_ 2147489923 0;
+BA_ "CanDootDecode" BO_ 2147491523 0;
+BA_ "CanDootDecode" BO_ 2147489859 0;
+BA_ "CanDootDecode" BO_ 2147489795 0;
+BA_ "CanDootPaused" BO_ 2147489795 0;
+BA_ "CanDootDecode" BO_ 2147491715 0;
+BA_ "CanDootPaused" BO_ 2147491715 0;
+BA_ "CanDootDecode" BO_ 2147491779 0;
+BA_ "CanDootDecode" BO_ 2147490691 0;
+BA_ "CanDootPaused" BO_ 2147490691 0;
+BA_ "CanDootDecode" BO_ 2147490755 0;
+BA_ "CanDootPaused" BO_ 2147490755 0;
+BA_ "CanDootHidden" SG_ 2147487747 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489411 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489347 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487875 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487939 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487811 NConfigCrc 1;
+BA_ "CanDootHidden" SG_ 2147487811 NSettingsCrc 1;
+BA_ "CanDootHidden" SG_ 2147487811 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489410 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489346 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147488127 NCrc 1;
+BA_ "CanDootHidden" SG_ 2147488063 NCrc 1;
+BA_ "CanDootHidden" SG_ 2147488063 NModuleSelect 1;
+BA_ "CanDootHidden" SG_ 2147487999 NCrc 1;
+BA_ "CanDootHidden" SG_ 2147487999 NModuleSelect 1;
+BA_ "CanDootHidden" SG_ 2147487999 BL1_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487999 BL2_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487999 BL3_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487999 BL4_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147488191 NCrc 1;
+BA_ "CanDootHidden" SG_ 2147488191 NModuleSelect 1;
+BA_ "CanDootHidden" SG_ 2147488191 BL1_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147488191 BL2_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147488191 BL3_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147488191 BL4_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147488255 NCrc 1;
+BA_ "CanDootHidden" SG_ 2147488255 NModuleSelect 1;
+BA_ "CanDootHidden" SG_ 2147488255 BL1_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147488255 BL2_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147488255 BL3_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147488255 BL4_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487938 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487810 NConfigCrc 1;
+BA_ "CanDootHidden" SG_ 2147487810 NSettingsCrc 1;
+BA_ "CanDootHidden" SG_ 2147487810 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487746 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487935 NCrc 1;
+BA_ "CanDootHidden" SG_ 2147487935 NModuleSelect 1;
+BA_ "CanDootHidden" SG_ 2147487935 BL1_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487935 BL2_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487935 BL3_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487935 BL4_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487807 NCrc 1;
+BA_ "CanDootHidden" SG_ 2147487807 NModuleSelect 1;
+BA_ "CanDootHidden" SG_ 2147487749 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489413 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489349 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487877 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487941 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487813 NSettingsCrc 1;
+BA_ "CanDootHidden" SG_ 2147487813 NConfigCrc 1;
+BA_ "CanDootHidden" SG_ 2147487813 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489412 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489348 NMultiplexer 1;
+BA_ "CanDootBroadcast" SG_ 2147488772 NPortB1OverloadCount 1;
+BA_ "CanDootBroadcast" SG_ 2147488772 IPortB1Average 1;
+BA_ "CanDootBroadcast" SG_ 2147488772 VPortB1Average 1;
+BA_ "CanDootBroadcast" SG_ 2147488772 VPortB1Max 1;
+BA_ "CanDootBroadcast" SG_ 2147488772 VPortB1Min 1;
+BA_ "CanDootHidden" SG_ 2147487876 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487940 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487812 NSettingsCrc 1;
+BA_ "CanDootHidden" SG_ 2147487812 NConfigCrc 1;
+BA_ "CanDootHidden" SG_ 2147487812 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487748 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487751 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489415 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489351 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487879 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487943 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487815 NConfigCrc 1;
+BA_ "CanDootHidden" SG_ 2147487815 NSettingsCrc 1;
+BA_ "CanDootBroadcast" SG_ 2147487815 TCell1N1 1;
+BA_ "CanDootHidden" SG_ 2147487815 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489414 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489350 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487878 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487942 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487814 NConfigCrc 1;
+BA_ "CanDootHidden" SG_ 2147487814 NSettingsCrc 1;
+BA_ "CanDootBroadcast" SG_ 2147487814 TCell1N2 1;
+BA_ "CanDootHidden" SG_ 2147487814 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487750 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487753 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489417 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489353 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487881 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487945 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487817 NConfigCrc 1;
+BA_ "CanDootHidden" SG_ 2147487817 NSettingsCrc 1;
+BA_ "CanDootHidden" SG_ 2147487817 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489416 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489352 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487880 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487944 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487816 NConfigCrc 1;
+BA_ "CanDootHidden" SG_ 2147487816 NSettingsCrc 1;
+BA_ "CanDootHidden" SG_ 2147487816 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147487752 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147491393 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147491457 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147490111 NModuleSelect 1;
+BA_ "CanDootHidden" SG_ 2147490047 NModuleSelect 1;
+BA_ "CanDootHidden" SG_ 2147490047 BL5_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147490047 BL6_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147490047 BL7_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489921 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489857 NSettingsCrc 1;
+BA_ "CanDootHidden" SG_ 2147489857 NConfigCrc 1;
+BA_ "CanDootHidden" SG_ 2147489857 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489793 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489983 NModuleSelect 1;
+BA_ "CanDootHidden" SG_ 2147489983 BL5_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489983 BL6_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489983 BL7_NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489855 NModuleSelect 1;
+BA_ "CanDootHidden" SG_ 2147491777 NConfigCrc 1;
+BA_ "CanDootHidden" SG_ 2147491777 NSettingsCrc 1;
+BA_ "CanDootHidden" SG_ 2147491777 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147491394 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147491458 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489922 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489858 NSettingsCrc 1;
+BA_ "CanDootHidden" SG_ 2147489858 NConfigCrc 1;
+BA_ "CanDootHidden" SG_ 2147489858 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489794 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147491778 NConfigCrc 1;
+BA_ "CanDootHidden" SG_ 2147491778 NSettingsCrc 1;
+BA_ "CanDootHidden" SG_ 2147491778 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147491395 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147491459 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489923 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489859 NSettingsCrc 1;
+BA_ "CanDootHidden" SG_ 2147489859 NConfigCrc 1;
+BA_ "CanDootHidden" SG_ 2147489859 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147489795 NMultiplexer 1;
+BA_ "CanDootHidden" SG_ 2147491779 NConfigCrc 1;
+BA_ "CanDootHidden" SG_ 2147491779 NSettingsCrc 1;
+BA_ "CanDootHidden" SG_ 2147491779 NMultiplexer 1;
+SIG_GROUP_ 2147487999 DcSetpoints2Write 1 : BL1_PPath2LimitHi BL1_PPath2LimitLo;
+SIG_GROUP_ 2147487999 ACUHV_DcSetpoints2Write 1 : BL1_PPath2LimitHi BL1_PPath2LimitLo;
+SIG_GROUP_ 2147488191 AcSetpoints1Write 1 : BL1_VDcPath1AcSetpoint BL1_VdPath1AcSetpoint BL1_VqPath1AcSetpoint BL1_NPath1AcFrequencySetpoint;
+SIG_GROUP_ 2147488191 ACUHV_AcSetpoints1Write 1 : BL1_VDcPath1AcSetpoint BL1_VdPath1AcSetpoint BL1_VqPath1AcSetpoint BL1_NPath1AcFrequencySetpoint;
+SIG_GROUP_ 2147488255 AcSetpoints2Write 1 : BL1_NPath1AcFunctionMode BL1_IdPath1AcLimitHi BL1_IdPath1AcSetpoint BL1_IdPath1AcLimitLo BL1_IqPath1AcSetpoint BL1_IqPath1AcLimitHi BL1_IqPath1AcLimitLo;
+SIG_GROUP_ 2147488255 ACUHV_AcSetpoints2Write 1 : BL1_NPath1AcFunctionMode BL1_IdPath1AcLimitHi BL1_IdPath1AcSetpoint BL1_IdPath1AcLimitLo BL1_IqPath1AcSetpoint BL1_IqPath1AcLimitHi BL1_IqPath1AcLimitLo;
+SIG_GROUP_ 2147487935 DcSetpoints1Write 1 : BL1_VPath2Setpoint BL1_IPath2LimitHi BL1_IPath2LimitLo BL1_NPath2VoltageSideSelect BL1_NPath2CurrentSideSelect;
+SIG_GROUP_ 2147487935 ACUHV_DcSetpoints1Write 1 : BL1_VPath2Setpoint BL1_IPath2LimitHi BL1_IPath2LimitLo BL1_NPath2VoltageSideSelect BL1_NPath2CurrentSideSelect;
+SIG_GROUP_ 2147487749 BL2_Node5Status_Global 1 : BXcpError NCellHwErrorFlags BSyncInputSignal BSyncRequested BInternalTemperatureError BConfigSettingsError BAuxSupplyError BCanTimeoutError BAuxIsoEnabled BSafetyDischargeEnabled BFaultSignal BEnableSignal BSafetyDischargeStatus BSyncStatus BReadConfigAndSettingsRequested BSwResetModuleRequested BSafetyDischargeRequested NModuleState;
+SIG_GROUP_ 2147487749 BL2_Node5Status_Path2 1 : BPath2FlgCapaError BPath2ErrVAuxCell IPath2Unbalance BPath2RcpWarning BPath2OcpError BPath2OtpError BPath2SideBUvpError BPath2SideAUvpError BPath2SideBOvpError BPath2SideAOvpError BPath2Requested NPath2CurrentSideSelected NPath2VoltageSideSelected NPath2State;
+SIG_GROUP_ 2147487749 BL2_Node5Status_Path1 1 : BPath1AcModeActivated BPath1AcUfpError BPath1AcOfpError NPath1AcFunctionMode BPath1FlgCapaError BPath1ErrVAuxCell IPath1Unbalance BPath1RcpWarning BPath1OcpError BPath1OtpError BPath1SideBUvpError BPath1SideAUvpError BPath1SideBOvpError BPath1SideAOvpError BPath1Requested NPath1CurrentSideSelected NPath1VoltageSideSelected NPath1State;
+SIG_GROUP_ 2147487748 BL2_Node4Status_Global 1 : BXcpError NCellHwErrorFlags BSyncInputSignal BSyncRequested BInternalTemperatureError BConfigSettingsError BAuxSupplyError BCanTimeoutError BAuxIsoEnabled BSafetyDischargeEnabled BFaultSignal BEnableSignal BSafetyDischargeStatus BSyncStatus BReadConfigAndSettingsRequested BSwResetModuleRequested BSafetyDischargeRequested NModuleState;
+SIG_GROUP_ 2147487748 BL2_Node4Status_Path2 1 : BPath2FlgCapaError BPath2ErrVAuxCell IPath2Unbalance BPath2RcpWarning BPath2OcpError BPath2OtpError BPath2SideBUvpError BPath2SideAUvpError BPath2SideBOvpError BPath2SideAOvpError BPath2Requested NPath2CurrentSideSelected NPath2VoltageSideSelected NPath2State;
+SIG_GROUP_ 2147487748 BL2_Node4Status_Path1 1 : BPath1AcModeActivated BPath1AcUfpError BPath1AcOfpError NPath1AcFunctionMode BPath1FlgCapaError BPath1ErrVAuxCell IPath1Unbalance BPath1RcpWarning BPath1OcpError BPath1OtpError BPath1SideBUvpError BPath1SideAUvpError BPath1SideBOvpError BPath1SideAOvpError BPath1Requested NPath1CurrentSideSelected NPath1VoltageSideSelected NPath1State;
+SIG_GROUP_ 2147490111 AcknowledgeErrors 1 :;
+SIG_GROUP_ 2147490111 DCHVI_AcknowledgeErrors 1 : BAckErrorsPath1Request BAckErrorsModuleRequest;
+SIG_GROUP_ 2147490047 Setpoints2Write 1 :;
+SIG_GROUP_ 2147490047 DCHVI_Setpoints2Write 1 : BL5_PPath1LimitHi BL5_PPath1LimitLo;
+SIG_GROUP_ 2147489983 DcSetpoints1Write 1 :;
+SIG_GROUP_ 2147489983 DCHVI_DcSetpoints1Write 1 : BL5_VPath1Setpoint BL5_IPath1LimitHi BL5_IPath1LimitLo BL5_NPath1VoltageSideSelect BL5_NPath1CurrentSideSelect;
+
+SG_MUL_VAL_ 2147487999 BL1_PPath2LimitLo BL1_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487999 BL2_PPath2LimitLo BL2_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487999 BL3_PPath2LimitLo BL3_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487999 BL4_PPath2LimitLo BL4_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487999 BL1_PPath2LimitHi BL1_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487999 BL2_PPath2LimitHi BL2_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487999 BL3_PPath2LimitHi BL3_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487999 BL4_PPath2LimitHi BL4_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487999 BL1_NMultiplexer NModuleSelect 1-1;
+SG_MUL_VAL_ 2147487999 BL2_NMultiplexer NModuleSelect 2-2;
+SG_MUL_VAL_ 2147487999 BL3_NMultiplexer NModuleSelect 3-3;
+SG_MUL_VAL_ 2147487999 BL4_NMultiplexer NModuleSelect 4-4;
+SG_MUL_VAL_ 2147488191 BL1_NPath1AcFrequencySetpoint BL1_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488191 BL2_NPath1AcFrequencySetpoint BL2_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488191 BL3_NPath1AcFrequencySetpoint BL3_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488191 BL4_NPath1AcFrequencySetpoint BL4_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488191 BL1_VqPath1AcSetpoint BL1_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488191 BL2_VqPath1AcSetpoint BL2_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488191 BL3_VqPath1AcSetpoint BL3_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488191 BL4_VqPath1AcSetpoint BL4_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488191 BL1_VdPath1AcSetpoint BL1_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488191 BL2_VdPath1AcSetpoint BL2_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488191 BL3_VdPath1AcSetpoint BL3_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488191 BL4_VdPath1AcSetpoint BL4_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488191 BL1_VDcPath1AcSetpoint BL1_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488191 BL2_VDcPath1AcSetpoint BL2_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488191 BL3_VDcPath1AcSetpoint BL3_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488191 BL4_VDcPath1AcSetpoint BL4_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488191 BL1_NMultiplexer NModuleSelect 1-1;
+SG_MUL_VAL_ 2147488191 BL2_NMultiplexer NModuleSelect 2-2;
+SG_MUL_VAL_ 2147488191 BL3_NMultiplexer NModuleSelect 3-3;
+SG_MUL_VAL_ 2147488191 BL4_NMultiplexer NModuleSelect 4-4;
+SG_MUL_VAL_ 2147488255 BL1_IqPath1AcLimitLo BL1_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL2_IqPath1AcLimitLo BL2_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL3_IqPath1AcLimitLo BL3_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL4_IqPath1AcLimitLo BL4_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL1_IqPath1AcLimitHi BL1_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL2_IqPath1AcLimitHi BL2_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL3_IqPath1AcLimitHi BL3_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL4_IqPath1AcLimitHi BL4_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL1_IqPath1AcSetpoint BL1_NMultiplexer 5-5;
+SG_MUL_VAL_ 2147488255 BL1_IdPath1AcLimitLo BL1_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL2_IdPath1AcLimitLo BL2_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL2_IqPath1AcSetpoint BL2_NMultiplexer 5-5;
+SG_MUL_VAL_ 2147488255 BL3_IqPath1AcSetpoint BL3_NMultiplexer 5-5;
+SG_MUL_VAL_ 2147488255 BL3_IdPath1AcLimitLo BL3_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL4_IqPath1AcSetpoint BL4_NMultiplexer 5-5;
+SG_MUL_VAL_ 2147488255 BL4_IdPath1AcLimitLo BL4_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL1_IdPath1AcSetpoint BL1_NMultiplexer 5-5;
+SG_MUL_VAL_ 2147488255 BL1_IdPath1AcLimitHi BL1_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL2_IdPath1AcLimitHi BL2_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL2_IdPath1AcSetpoint BL2_NMultiplexer 5-5;
+SG_MUL_VAL_ 2147488255 BL3_IdPath1AcSetpoint BL3_NMultiplexer 5-5;
+SG_MUL_VAL_ 2147488255 BL3_IdPath1AcLimitHi BL3_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL4_IdPath1AcSetpoint BL4_NMultiplexer 5-5;
+SG_MUL_VAL_ 2147488255 BL4_IdPath1AcLimitHi BL4_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL1_NPath1AcFunctionMode BL1_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL2_NPath1AcFunctionMode BL2_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL3_NPath1AcFunctionMode BL3_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL4_NPath1AcFunctionMode BL4_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147488255 BL1_NMultiplexer NModuleSelect 1-1;
+SG_MUL_VAL_ 2147488255 BL2_NMultiplexer NModuleSelect 2-2;
+SG_MUL_VAL_ 2147488255 BL3_NMultiplexer NModuleSelect 3-3;
+SG_MUL_VAL_ 2147488255 BL4_NMultiplexer NModuleSelect 4-4;
+SG_MUL_VAL_ 2147487935 BL1_NPath2CurrentSideSelect BL1_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL2_NPath2CurrentSideSelect BL2_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL3_NPath2CurrentSideSelect BL3_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL4_NPath2CurrentSideSelect BL4_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL1_NPath2VoltageSideSelect BL1_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL2_NPath2VoltageSideSelect BL2_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL3_NPath2VoltageSideSelect BL3_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL4_NPath2VoltageSideSelect BL4_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL1_IPath2LimitLo BL1_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL2_IPath2LimitLo BL2_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL3_IPath2LimitLo BL3_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL4_IPath2LimitLo BL4_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL1_IPath2LimitHi BL1_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL2_IPath2LimitHi BL2_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL3_IPath2LimitHi BL3_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL4_IPath2LimitHi BL4_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL1_VPath2Setpoint BL1_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL2_VPath2Setpoint BL2_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL3_VPath2Setpoint BL3_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL4_VPath2Setpoint BL4_NMultiplexer 2-2;
+SG_MUL_VAL_ 2147487935 BL1_NMultiplexer NModuleSelect 1-1;
+SG_MUL_VAL_ 2147487935 BL2_NMultiplexer NModuleSelect 2-2;
+SG_MUL_VAL_ 2147487935 BL3_NMultiplexer NModuleSelect 3-3;
+SG_MUL_VAL_ 2147487935 BL4_NMultiplexer NModuleSelect 4-4;
+SG_MUL_VAL_ 2147490047 BL5_PPath1LimitLo BL5_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147490047 BL6_PPath1LimitLo BL6_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147490047 BL7_PPath1LimitLo BL7_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147490047 BL5_PPath1LimitHi BL5_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147490047 BL6_PPath1LimitHi BL6_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147490047 BL7_PPath1LimitHi BL7_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147490047 BL5_NMultiplexer NModuleSelect 1-1;
+SG_MUL_VAL_ 2147490047 BL6_NMultiplexer NModuleSelect 2-2;
+SG_MUL_VAL_ 2147490047 BL7_NMultiplexer NModuleSelect 3-3;
+SG_MUL_VAL_ 2147489983 BL5_NPath1CurrentSideSelect BL5_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147489983 BL6_NPath1CurrentSideSelect BL6_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147489983 BL7_NPath1CurrentSideSelect BL7_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147489983 BL5_NPath1VoltageSideSelect BL5_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147489983 BL6_NPath1VoltageSideSelect BL6_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147489983 BL7_NPath1VoltageSideSelect BL7_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147489983 BL5_IPath1LimitLo BL5_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147489983 BL6_IPath1LimitLo BL6_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147489983 BL7_IPath1LimitLo BL7_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147489983 BL5_IPath1LimitHi BL5_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147489983 BL6_IPath1LimitHi BL6_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147489983 BL7_IPath1LimitHi BL7_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147489983 BL5_VPath1Setpoint BL5_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147489983 BL6_VPath1Setpoint BL6_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147489983 BL7_VPath1Setpoint BL7_NMultiplexer 1-1;
+SG_MUL_VAL_ 2147489983 BL5_NMultiplexer NModuleSelect 1-1;
+SG_MUL_VAL_ 2147489983 BL6_NMultiplexer NModuleSelect 2-2;
+SG_MUL_VAL_ 2147489983 BL7_NMultiplexer NModuleSelect 3-3;

--- a/decoder/D65/send_d65_data.py
+++ b/decoder/D65/send_d65_data.py
@@ -3,7 +3,11 @@ import sys
 import time
 import logging
 import argparse
+import io
+import tempfile
 import re
+import ctypes
+import subprocess
 from copy import deepcopy
 from pathlib import Path
 
@@ -15,7 +19,7 @@ from itertools import chain
 from concurrent.futures import ThreadPoolExecutor
 from threading import Lock
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Literal, Iterable, cast
+from typing import Literal, Iterable, Any
 from canmatrix import CanMatrix
 from canmatrix import formats as canmatrix_formats
 
@@ -28,7 +32,7 @@ from decoder.utils import (
     convert_to_eng,
     is_victoriametrics_online,
 )
-from decoder.sending import send_decoded
+from decoder.sending import send_decoded, normalize_dbc_entries
 from decoder.config import (
     LOG_FORMAT,
     server_vm_d65,
@@ -419,21 +423,6 @@ def send_files_to_victoriametrics(
     Uses ThreadPoolExecutor to send batches in parallel.
     """
 
-    def _normalize_dbc_entries(
-        entries: Iterable[DbcFileType | DBCSource],
-    ) -> list[DbcFileType]:
-        normalized: list[DbcFileType] = []
-        for entry in entries:
-            if (
-                isinstance(entry, tuple)
-                and len(entry) == 2
-                and isinstance(entry[1], int)
-            ):
-                normalized.append(cast(DbcFileType, entry))
-            else:
-                normalized.append((cast(DBCSource, entry), 0))
-        return normalized
-
     dbc_files = get_d65_dbc_files()
     if dbc_files_override := kwargs.get("dbc_files_override", None):
         if "Upper" in dbc_files_override:
@@ -441,10 +430,10 @@ def send_files_to_victoriametrics(
         if "Lower" in dbc_files_override:
             dbc_files["Lower"] = dbc_files_override["Lower"]
 
-    upper_dbc_files: list[DbcFileType] = _normalize_dbc_entries(
+    upper_dbc_files: list[DbcFileType] = normalize_dbc_entries(
         dbc_files["Upper"]
     )
-    lower_dbc_files: list[DbcFileType] = _normalize_dbc_entries(
+    lower_dbc_files: list[DbcFileType] = normalize_dbc_entries(
         dbc_files["Lower"]
     )
 
@@ -749,6 +738,346 @@ def get_d65_file_list_from_s3(
                     )
 
     return files
+
+
+def _get_available_ram_bytes() -> int | None:
+    if os.name == "nt":
+        # https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-memorystatusex
+        class MEMORYSTATUSEX(ctypes.Structure):
+            _fields_ = [
+                ("dwLength", ctypes.c_ulong),
+                ("dwMemoryLoad", ctypes.c_ulong),
+                ("ullTotalPhys", ctypes.c_ulonglong),
+                ("ullAvailPhys", ctypes.c_ulonglong),
+                ("ullTotalPageFile", ctypes.c_ulonglong),
+                ("ullAvailPageFile", ctypes.c_ulonglong),
+                ("ullTotalVirtual", ctypes.c_ulonglong),
+                ("ullAvailVirtual", ctypes.c_ulonglong),
+                ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+            ]
+
+        stat = MEMORYSTATUSEX()
+        stat.dwLength = ctypes.sizeof(MEMORYSTATUSEX)
+        if ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(stat)):
+            return int(stat.ullAvailPhys)
+        return None
+
+    if sys.platform == "darwin":
+        try:
+            out = subprocess.check_output(
+                ["vm_stat"], text=True, stderr=subprocess.DEVNULL
+            )
+            page_size = 4096
+            m = re.search(r"page size of (\d+) bytes", out)
+            if m:
+                page_size = int(m.group(1))
+
+            # free + inactive + speculative approximates quickly available RAM.
+            keys = ("Pages free", "Pages inactive", "Pages speculative")
+            pages = 0
+            for key in keys:
+                mm = re.search(rf"{key}:\s+(\d+)\.", out)
+                if mm:
+                    pages += int(mm.group(1))
+            if pages > 0:
+                return int(pages * page_size)
+        except Exception:
+            return None
+
+    try:
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        avail_pages = os.sysconf("SC_AVPHYS_PAGES")
+        return int(page_size * avail_pages)
+    except Exception:
+        return None
+
+
+def _select_s3_streaming_strategy(
+    s3_info_list: list[dict],
+    requested_strategy: Literal["auto", "memory", "tempfile"],
+    memory_fraction: float,
+    decode_overhead_factor: float,
+    max_active_files: int,
+) -> tuple[Literal["memory", "tempfile"], dict[str, int | float | None]]:
+    sizes = [
+        int(item["Size"])
+        for item in s3_info_list
+        if isinstance(item, dict) and "Size" in item
+    ]
+    sizes.sort(reverse=True)
+
+    max_active = max(1, max_active_files)
+    worst_parallel_bytes = sum(sizes[:max_active]) if sizes else 0
+    projected_peak_bytes = int(worst_parallel_bytes * decode_overhead_factor)
+    available_ram_bytes = _get_available_ram_bytes()
+    ram_budget_bytes = (
+        int(available_ram_bytes * memory_fraction)
+        if available_ram_bytes is not None
+        else None
+    )
+
+    if requested_strategy == "memory":
+        selected: Literal["memory", "tempfile"] = "memory"
+    elif requested_strategy == "tempfile":
+        selected = "tempfile"
+    else:
+        if (
+            ram_budget_bytes is not None
+            and projected_peak_bytes <= ram_budget_bytes
+        ):
+            selected = "memory"
+        else:
+            selected = "tempfile"
+
+    profile: dict[str, int | float | None] = {
+        "file_count": len(sizes),
+        "largest_file_bytes": sizes[0] if sizes else 0,
+        "worst_parallel_bytes": worst_parallel_bytes,
+        "projected_peak_bytes": projected_peak_bytes,
+        "available_ram_bytes": available_ram_bytes,
+        "ram_budget_bytes": ram_budget_bytes,
+        "max_active_files": max_active,
+        "decode_overhead_factor": decode_overhead_factor,
+    }
+    return selected, profile
+
+
+def _key_segment_from_s3_key(key: str) -> Literal["Upper", "Lower"] | None:
+    if key.startswith(MAC_UPPER):
+        return "Upper"
+    if key.startswith(MAC_LOWER):
+        return "Lower"
+    return None
+
+
+def _decode_and_send_d65_mdf(
+    mdf: MDF,
+    job: Literal["Upper", "Lower"],
+    server: str,
+    upper_dbc_files: list[DbcFileType],
+    lower_dbc_files: list[DbcFileType],
+    skip_signal_range_check: bool,
+    max_batch_size: int,
+) -> dict[str, int]:
+    dbc_files = upper_dbc_files if job == "Upper" else lower_dbc_files
+    decoded = mdf.extract_bus_logging(
+        database_files={"CAN": dbc_files},
+        ignore_value2text_conversion=True,
+    )
+    if not list(decoded.iter_channels()):
+        return {}
+    return send_decoded(
+        decoded=decoded,
+        server=server,
+        job=job,
+        skip_signal_fn=skip_signal,
+        skip_signal_range_check=skip_signal_range_check,
+        batch_size=max_batch_size,
+    )
+
+
+def main_post_s3_streaming_to_victoriametrics(
+    server: str,
+    start_date: datetime,
+    end_date: datetime,
+    s3_info_list: list[dict] | None = None,
+    ignore_upper: bool = False,
+    ignore_lower: bool = False,
+    streaming_strategy: Literal["auto", "memory", "tempfile"] = "auto",
+    memory_fraction: float = 0.35,
+    decode_overhead_factor: float = 2.5,
+    max_active_files: int = 1,
+    max_batch_size: int = 10_000,
+    skip_signal_range_check: bool = False,
+    **kwargs,
+) -> tuple[dict[str, int], dict[str, int]]:
+    if s3_info_list is None:
+        s3_info_list = get_d65_file_list_from_s3(
+            start=start_date,
+            end=end_date,
+            ignore_upper=ignore_upper,
+            ignore_lower=ignore_lower,
+        )
+
+    if not s3_info_list:
+        logging.warning("⚠️ No S3 files found to stream.")
+        return {}, {}
+
+    s3_info_list = [
+        item
+        for item in s3_info_list
+        if isinstance(item, dict)
+        and isinstance(item.get("Key", None), str)
+        and _key_segment_from_s3_key(item["Key"]) is not None
+    ]
+
+    if ignore_upper:
+        s3_info_list = [
+            item
+            for item in s3_info_list
+            if _key_segment_from_s3_key(item["Key"]) == "Lower"
+        ]
+    if ignore_lower:
+        s3_info_list = [
+            item
+            for item in s3_info_list
+            if _key_segment_from_s3_key(item["Key"]) == "Upper"
+        ]
+
+    send_newest_first = kwargs.get("send_newest_first", True)
+    s3_info_list.sort(
+        key=lambda x: x.get("Timestamp", datetime.min.replace(tzinfo=timezone.utc)),
+        reverse=send_newest_first,
+    )
+
+    if not s3_info_list:
+        logging.warning("⚠️ No S3 files left after filtering.")
+        return {}, {}
+
+    dbc_files = get_d65_dbc_files()
+    dbc_files_override: Any = kwargs.get("dbc_files_override", None)
+    if dbc_files_override:
+        if "Upper" in dbc_files_override:
+            dbc_files["Upper"] = dbc_files_override["Upper"]
+        if "Lower" in dbc_files_override:
+            dbc_files["Lower"] = dbc_files_override["Lower"]
+
+    upper_dbc_files = normalize_dbc_entries(dbc_files["Upper"])
+    lower_dbc_files = normalize_dbc_entries(dbc_files["Lower"])
+
+    selected_strategy, profile = _select_s3_streaming_strategy(
+        s3_info_list=s3_info_list,
+        requested_strategy=streaming_strategy,
+        memory_fraction=memory_fraction,
+        decode_overhead_factor=decode_overhead_factor,
+        max_active_files=max_active_files,
+    )
+    logging.info(
+        "🧠 S3 streaming preflight | files=%s largest=%sB "
+        "worst_parallel=%sB projected_peak=%sB available_ram=%sB "
+        "ram_budget=%sB strategy=%s",
+        profile["file_count"],
+        profile["largest_file_bytes"],
+        profile["worst_parallel_bytes"],
+        profile["projected_peak_bytes"],
+        profile["available_ram_bytes"],
+        profile["ram_budget_bytes"],
+        selected_strategy,
+    )
+
+    max_retries = 10
+    retry_interval_seconds = 60
+    for attempt in range(1, max_retries + 1):
+        if is_victoriametrics_online(server):
+            break
+        if attempt < max_retries:
+            logging.warning(
+                f" -> ⚠️ {server} not available (attempt {attempt}/{max_retries}). Retrying in 1 minute..."
+            )
+            time.sleep(retry_interval_seconds)
+        else:
+            logging.error(
+                f" -> ❌ {server} not available after {max_retries} attempts. Exiting..."
+            )
+            exit(1)
+
+    s3c = create_s3_client(max_pool_connections=max(1, max_active_files))
+    total_upper_counts: dict[str, int] = {}
+    total_lower_counts: dict[str, int] = {}
+    total = len(s3_info_list)
+    all_start_ts = time.time()
+
+    for idx, item in enumerate(s3_info_list, start=1):
+        key = item["Key"]
+        job = _key_segment_from_s3_key(key)
+        if job is None:
+            continue
+
+        count_str = f"[{idx} of {total}]"
+        start_ts = time.time()
+        result: dict[str, int] = {}
+        if selected_strategy == "memory":
+            blob = download_file_bytes_from_s3(
+                bucket_name=EESBuckets.S3_BUCKET_D65,
+                key=key,
+                s3_client=s3c,
+            )
+            if blob is None:
+                continue
+            try:
+                with MDF(io.BytesIO(blob)) as mdf:
+                    result = _decode_and_send_d65_mdf(
+                        mdf=mdf,
+                        job=job,
+                        server=server,
+                        upper_dbc_files=upper_dbc_files,
+                        lower_dbc_files=lower_dbc_files,
+                        skip_signal_range_check=skip_signal_range_check,
+                        max_batch_size=max_batch_size,
+                    )
+            except Exception as e:
+                logging.error(f"❌ {count_str} Error processing in memory {key}: {e}")
+            del blob
+        else:
+            tmp_path: Path | None = None
+            try:
+                with tempfile.NamedTemporaryFile(
+                    suffix=".mf4", delete=False
+                ) as tmp_file:
+                    tmp_path = Path(tmp_file.name)
+                ok = download_file_to_path_from_s3(
+                    bucket_name=EESBuckets.S3_BUCKET_D65,
+                    key=key,
+                    local_path=tmp_path,
+                    s3_client=s3c,
+                )
+                if not ok:
+                    continue
+                with MDF(tmp_path) as mdf:
+                    result = _decode_and_send_d65_mdf(
+                        mdf=mdf,
+                        job=job,
+                        server=server,
+                        upper_dbc_files=upper_dbc_files,
+                        lower_dbc_files=lower_dbc_files,
+                        skip_signal_range_check=skip_signal_range_check,
+                        max_batch_size=max_batch_size,
+                    )
+            except Exception as e:
+                logging.error(f"❌ {count_str} Error processing temp file {key}: {e}")
+            finally:
+                if tmp_path and tmp_path.exists():
+                    tmp_path.unlink()
+
+        sent = sum(result.values())
+        logging.info(
+            f"✅ {count_str} {job} streamed {shortpath(Path(key))} in {get_time_str(start_ts)} ({convert_to_eng(sent)} samples)"
+        )
+        for signal_name, count in result.items():
+            if job == "Upper":
+                total_upper_counts[signal_name] = (
+                    total_upper_counts.get(signal_name, 0) + count
+                )
+            else:
+                total_lower_counts[signal_name] = (
+                    total_lower_counts.get(signal_name, 0) + count
+                )
+
+    end_ts = time.time()
+    total_signals_sent = len(total_upper_counts) + len(total_lower_counts)
+    total_samples_sent = sum(total_upper_counts.values()) + sum(
+        total_lower_counts.values()
+    )
+    logging.info(
+        "🏁 Streamed %s S3 files in %s (%s signals | %s samples | %s samples/s).",
+        total,
+        get_time_str(all_start_ts, end_ts),
+        total_signals_sent,
+        convert_to_eng(total_samples_sent),
+        convert_to_eng(total_samples_sent / max(end_ts - all_start_ts, 1e-9)),
+    )
+
+    return total_lower_counts, total_upper_counts
 
 
 def download_d65_files_from_s3(
@@ -1078,13 +1407,16 @@ def main_post_to_victoriametrics(
         ([u for u in files if u[1] == "Upper"], "Upper"),
         ([l for l in files if l[1] == "Lower"], "Lower"),
     ]:
+        if len(_files) == 0:
+            logging.info(f" ✔️  [{_name}] Found 0 files.")
+            continue
         if len(_files) == 1:
             logging.info(
-                f" ✔️  [{_name}] Found 1 file starting at {files[0][2].astimezone().isoformat()}."
+                f" ✔️  [{_name}] Found 1 file starting at {_files[0][2].astimezone().isoformat()}."
             )
         else:
             logging.info(
-                f" ✔️  [{_name}] Found {len(files)} files from {files[0][2].astimezone().isoformat()} to {files[-1][2].astimezone().isoformat()}."
+                f" ✔️  [{_name}] Found {len(_files)} files from {_files[0][2].astimezone().isoformat()} to {_files[-1][2].astimezone().isoformat()}."
             )
 
     logging.info(
@@ -1292,7 +1624,59 @@ if __name__ == "__main__":
             "'--messages MsgA MsgB'."
         ),
     )
+    parser.add_argument(
+        "--s3-streaming",
+        action="store_true",
+        help=(
+            "Stream D65 S3 objects directly into decode/send pipeline "
+            "without pre-downloading all files to local storage."
+        ),
+    )
+    parser.add_argument(
+        "--s3-streaming-strategy",
+        type=str,
+        choices=["auto", "memory", "tempfile"],
+        default="auto",
+        help=(
+            "Streaming strategy for S3 object processing. "
+            "'auto' profiles projected memory and chooses memory/tempfile."
+        ),
+    )
+    parser.add_argument(
+        "--s3-streaming-memory-fraction",
+        type=float,
+        default=0.35,
+        help=(
+            "Fraction of available RAM allowed for projected streaming peak "
+            "when strategy=auto."
+        ),
+    )
+    parser.add_argument(
+        "--s3-streaming-decode-overhead",
+        type=float,
+        default=2.5,
+        help=(
+            "Multiplier used in projected RAM peak estimate "
+            "(raw object bytes -> decode peak)."
+        ),
+    )
+    parser.add_argument(
+        "--s3-streaming-max-active-files",
+        type=int,
+        default=1,
+        help=(
+            "Max concurrently active files assumed by preflight RAM estimate. "
+            "Current streaming execution processes files sequentially."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.s3_streaming_memory_fraction <= 0 or args.s3_streaming_memory_fraction > 1:
+        parser.error("--s3-streaming-memory-fraction must be in (0, 1].")
+    if args.s3_streaming_decode_overhead <= 0:
+        parser.error("--s3-streaming-decode-overhead must be > 0.")
+    if args.s3_streaming_max_active_files < 1:
+        parser.error("--s3-streaming-max-active-files must be >= 1.")
 
     server = server_vm_d65
 
@@ -1387,7 +1771,20 @@ if __name__ == "__main__":
 
     s3_info_list_for_post: list[dict] | None = None
 
-    if not args.skip_download:
+    if args.s3_streaming:
+        if args.skip_download:
+            logging.info(
+                "ℹ️ --s3-streaming enabled; ignoring --skip_download and using "
+                "S3 key list without bulk download."
+            )
+        s3_info_list_for_post = get_d65_file_list_from_s3(
+            start=start_date,
+            end=end_date,
+            posted_after=posted_after,
+            ignore_upper=effective_ignore_upper,
+            ignore_lower=effective_ignore_lower,
+        )
+    elif not args.skip_download:
         logging.info("⬇️ Starting D65 file download from S3 ...")
         s3_info_list_for_post = main_download_files(
             start_date=start_date,
@@ -1400,17 +1797,35 @@ if __name__ == "__main__":
     # main_delete_all_series(server)
     if not args.skip_post:
         logging.info("🌐 Starting D65 data post to VictoriaMetrics ...")
-        main_post_to_victoriametrics(
-            server=server,
-            start_date=start_date,
-            end_date=end_date,
-            ignore_upper=effective_ignore_upper,
-            ignore_lower=effective_ignore_lower,
-            s3_info_list=s3_info_list_for_post,
-            send_newest_first=True,
-            dbc_files_override=dbc_files_override,
-            # dbc_files_override={
-            #     "Upper": [],
-            #     "Lower": [f for f in get_d65_dbc_files()["Lower"] if "Main" in f.name],
-            # },
-        )
+        if args.s3_streaming:
+            main_post_s3_streaming_to_victoriametrics(
+                server=server,
+                start_date=start_date,
+                end_date=end_date,
+                ignore_upper=effective_ignore_upper,
+                ignore_lower=effective_ignore_lower,
+                s3_info_list=s3_info_list_for_post,
+                streaming_strategy=args.s3_streaming_strategy,
+                memory_fraction=args.s3_streaming_memory_fraction,
+                decode_overhead_factor=args.s3_streaming_decode_overhead,
+                max_active_files=args.s3_streaming_max_active_files,
+                max_batch_size=10_000,
+                skip_signal_range_check=False,
+                send_newest_first=True,
+                dbc_files_override=dbc_files_override,
+            )
+        else:
+            main_post_to_victoriametrics(
+                server=server,
+                start_date=start_date,
+                end_date=end_date,
+                ignore_upper=effective_ignore_upper,
+                ignore_lower=effective_ignore_lower,
+                s3_info_list=s3_info_list_for_post,
+                send_newest_first=True,
+                dbc_files_override=dbc_files_override,
+                # dbc_files_override={
+                #     "Upper": [],
+                #     "Lower": [f for f in get_d65_dbc_files()["Lower"] if "Main" in f.name],
+                # },
+            )

--- a/decoder/D65/send_d65_data.py
+++ b/decoder/D65/send_d65_data.py
@@ -46,6 +46,7 @@ logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 
 CSVContent = tuple[Path, Literal["Upper", "Lower"], datetime]
 DBCSource = str | os.PathLike[str] | CanMatrix
+DBC_FOLDER_OVERRIDE: str | None = None
 
 MAC_UPPER = "6C1D6B77"
 MAC_LOWER = "5A72CE4C"
@@ -101,17 +102,31 @@ def skip_signal(name: str) -> bool:
     return False
 
 
-def get_d65_dbc_base_path() -> Path:
-    # ‼️‼️‼️ Point these to where the D65 DBC files are located ‼️‼️‼️
-    _d65_loc = Path.joinpath(
+def resolve_dbc_folder(dbc_folder: str | None = None) -> Path:
+    value = DBC_FOLDER_OVERRIDE if dbc_folder is None else dbc_folder
+    default_folder = Path(__file__).resolve().parent / "dbc"
+    legacy_folder = Path.joinpath(
         Path.home(), "ttc500_shell/apps/ttc_590_d65_ctrl_app/dbc"
     )
-    if os.name == "nt":  # Override if on windows
-        _d65_loc = Path(
+    if os.name == "nt":
+        legacy_folder = Path(
             r"\\wsl$\Ubuntu-22.04-fvt-v5\home\default\ttc500_shell\apps\ttc_590_d65_ctrl_app\dbc"
         )
 
-    return _d65_loc
+    if value is None or not str(value).strip():
+        return default_folder
+
+    if str(value).strip().lower() in {"old", "compatibility"}:
+        return legacy_folder
+
+    resolved = Path(os.path.expanduser(os.path.expandvars(str(value).strip())))
+    if not resolved.is_absolute():
+        resolved = Path.cwd() / resolved
+    return resolved
+
+
+def get_d65_dbc_base_path(dbc_folder: str | None = None) -> Path:
+    return resolve_dbc_folder(dbc_folder)
 
 
 def get_d65_dbc_file(
@@ -130,7 +145,7 @@ def get_d65_dbc_file(
     _d65_loc = get_d65_dbc_base_path()
 
     if job == "Upper" or job == "Lower":
-        get_d65_dbc_files()[job]
+        return get_d65_dbc_files()[job]
     elif job == "Brightloop":
         return [Path.joinpath(_d65_loc, "brightloop", "d65_brightloops.dbc")]
     elif job == "NV":
@@ -149,9 +164,10 @@ def get_d65_dbc_file(
     return []
 
 
-def get_d65_dbc_files() -> dict[Literal["Upper", "Lower"], list[Path]]:
-    # ‼️‼️‼️ Point these to where the D65 DBC files are located ‼️‼️‼️
-    _d65_loc = get_d65_dbc_base_path()
+def get_d65_dbc_files(
+    dbc_folder: str | None = None,
+) -> dict[Literal["Upper", "Lower"], list[Path]]:
+    _d65_loc = get_d65_dbc_base_path(dbc_folder)
 
     d65_dbc_files = {
         "Lower": [
@@ -1675,7 +1691,15 @@ if __name__ == "__main__":
         action="store_true",
         help="Send to test node (server_vm_test_dump) instead of main D65 node.",
     )
+    parser.add_argument(
+        "--dbc-folder",
+        type=str,
+        default="",
+        help="DBC folder path, or 'old'/'compatibility' for workstation lookup. Defaults to decoder/D65/dbc.",
+    )
+
     args = parser.parse_args()
+    DBC_FOLDER_OVERRIDE = args.dbc_folder
 
     if args.s3_streaming_memory_fraction <= 0 or args.s3_streaming_memory_fraction > 1:
         parser.error("--s3-streaming-memory-fraction must be in (0, 1].")

--- a/decoder/D65/send_d65_data.py
+++ b/decoder/D65/send_d65_data.py
@@ -36,6 +36,7 @@ from decoder.sending import send_decoded, normalize_dbc_entries
 from decoder.config import (
     LOG_FORMAT,
     server_vm_d65,
+    server_vm_test_dump,
     server_vm_localhost,
     vmapi_import_prometheus,
 )
@@ -1669,6 +1670,11 @@ if __name__ == "__main__":
             "Current streaming execution processes files sequentially."
         ),
     )
+    parser.add_argument(
+        "--test",
+        action="store_true",
+        help="Send to test node (server_vm_test_dump) instead of main D65 node.",
+    )
     args = parser.parse_args()
 
     if args.s3_streaming_memory_fraction <= 0 or args.s3_streaming_memory_fraction > 1:
@@ -1678,7 +1684,7 @@ if __name__ == "__main__":
     if args.s3_streaming_max_active_files < 1:
         parser.error("--s3-streaming-max-active-files must be >= 1.")
 
-    server = server_vm_d65
+    server = server_vm_test_dump if args.test else server_vm_d65
 
     # Parse start time
     now = datetime.now().astimezone(ZoneInfo("America/Vancouver"))

--- a/decoder/s3_helper.py
+++ b/decoder/s3_helper.py
@@ -180,6 +180,83 @@ def download_files_from_s3(
     return count
 
 
+def download_file_to_path_from_s3(
+    bucket_name: EESBuckets | str,
+    key: str,
+    local_path: Path,
+    max_retries: int = 2,
+    s3_client=None,
+) -> bool:
+    """
+    Download one S3 object key to a local path with retries.
+    """
+    if isinstance(bucket_name, EESBuckets):
+        bucket_name = bucket_name.value[0]
+    elif not (
+        isinstance(bucket_name, str)
+        and bucket_name in [b.value[0] for b in EESBuckets]
+    ):
+        logging.error(f"❌ Invalid bucket name: {bucket_name}")
+        return False
+
+    s3c = s3_client if s3_client is not None else create_s3_client()
+    for attempt in range(1, max_retries + 2):
+        try:
+            s3c.download_file(bucket_name, key, str(local_path))
+            return True
+        except ClientError as e:
+            logging.error(
+                f"❌ Error downloading {key} from bucket '{bucket_name}' (attempt {attempt}): {e}"
+            )
+        except Exception as e:
+            logging.error(
+                f"❌ Unexpected error downloading {key} (attempt {attempt}): {e}"
+            )
+        if attempt <= max_retries:
+            time.sleep(1)
+    return False
+
+
+def download_file_bytes_from_s3(
+    bucket_name: EESBuckets | str,
+    key: str,
+    max_retries: int = 2,
+    s3_client=None,
+) -> bytes | None:
+    """
+    Download one S3 object and return its bytes in memory.
+    """
+    if isinstance(bucket_name, EESBuckets):
+        bucket_name = bucket_name.value[0]
+    elif not (
+        isinstance(bucket_name, str)
+        and bucket_name in [b.value[0] for b in EESBuckets]
+    ):
+        logging.error(f"❌ Invalid bucket name: {bucket_name}")
+        return None
+
+    s3c = s3_client if s3_client is not None else create_s3_client()
+    for attempt in range(1, max_retries + 2):
+        try:
+            resp = s3c.get_object(Bucket=bucket_name, Key=key)
+            body = resp.get("Body", None)
+            if body is None:
+                logging.error(f"❌ Empty body for key {key}")
+                return None
+            return body.read()
+        except ClientError as e:
+            logging.error(
+                f"❌ Error reading {key} from bucket '{bucket_name}' (attempt {attempt}): {e}"
+            )
+        except Exception as e:
+            logging.error(
+                f"❌ Unexpected error reading {key} (attempt {attempt}): {e}"
+            )
+        if attempt <= max_retries:
+            time.sleep(1)
+    return None
+
+
 def get_mf4_files_list_from_s3(
     bucket_name: EESBuckets | str,
     start_time: datetime | str = "",

--- a/decoder/s3_helper.py
+++ b/decoder/s3_helper.py
@@ -102,13 +102,10 @@ def download_files_from_s3(
 
     if isinstance(bucket_name, EESBuckets):
         bucket_name = bucket_name.value[0]
-    elif isinstance(bucket_name, str) and bucket_name in [
-        b.value[0] for b in EESBuckets
-    ]:
-        bucket_name = bucket_name
     else:
-        logging.error(f"❌ Invalid bucket name: {bucket_name}")
-        return count
+        if not isinstance(bucket_name, str) or not bucket_name.strip():
+            logging.error(f"❌ Invalid bucket name: {bucket_name}")
+            return count
 
     s3c = create_s3_client(max_pool_connections=max_workers)
     total_keys = len(keys)
@@ -192,10 +189,7 @@ def download_file_to_path_from_s3(
     """
     if isinstance(bucket_name, EESBuckets):
         bucket_name = bucket_name.value[0]
-    elif not (
-        isinstance(bucket_name, str)
-        and bucket_name in [b.value[0] for b in EESBuckets]
-    ):
+    elif not isinstance(bucket_name, str) or not bucket_name.strip():
         logging.error(f"❌ Invalid bucket name: {bucket_name}")
         return False
 
@@ -228,10 +222,7 @@ def download_file_bytes_from_s3(
     """
     if isinstance(bucket_name, EESBuckets):
         bucket_name = bucket_name.value[0]
-    elif not (
-        isinstance(bucket_name, str)
-        and bucket_name in [b.value[0] for b in EESBuckets]
-    ):
+    elif not isinstance(bucket_name, str) or not bucket_name.strip():
         logging.error(f"❌ Invalid bucket name: {bucket_name}")
         return None
 
@@ -279,11 +270,7 @@ def get_mf4_files_list_from_s3(
 
     if isinstance(bucket_name, EESBuckets):
         bucket_name = bucket_name.value[0]
-    elif isinstance(bucket_name, str) and bucket_name in [
-        b.value[0] for b in EESBuckets
-    ]:
-        bucket_name = bucket_name
-    else:
+    elif not isinstance(bucket_name, str) or not bucket_name.strip():
         logging.error(f"❌ Invalid bucket name: {bucket_name}")
         return []
 

--- a/decoder/sending.py
+++ b/decoder/sending.py
@@ -10,7 +10,7 @@ from asammdf import MDF, Signal
 from asammdf.blocks.types import DbcFileType, BusType
 from datetime import datetime, timedelta
 from collections.abc import Iterable
-from typing import Sequence, Callable, Optional
+from typing import Sequence, Callable, Optional, Any, cast
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 if __name__ == "__main__":
@@ -20,6 +20,20 @@ from decoder.config import *
 from decoder.utils import *
 from decoder.livelogger.CANReader import CANReader
 from decoder.livelogger.DBCDecoder import DBCDecoder
+
+
+def normalize_dbc_entries(entries: Iterable[DbcFileType | Any]) -> list[DbcFileType]:
+    normalized: list[DbcFileType] = []
+    for entry in entries:
+        if (
+            isinstance(entry, tuple)
+            and len(entry) == 2
+            and isinstance(entry[1], int)
+        ):
+            normalized.append(cast(DbcFileType, entry))
+        else:
+            normalized.append((cast(Any, entry), 0))
+    return normalized
 
 
 def _extend_no_proxy(entries: list[str]) -> None:
@@ -511,7 +525,9 @@ def decode_and_send(
         logger.warning("⚠️ No directory or files specified.")
         return signals_sample_count
 
-    database_files: dict[BusType, Iterable[DbcFileType]] = {"CAN": dbc_files}
+    database_files: dict[BusType, Iterable[DbcFileType]] = {
+        "CAN": normalize_dbc_entries(dbc_files)
+    }
 
     if not dbc_files:
         logger.error("⚠️ No DBC files specified.")


### PR DESCRIPTION
## Summary
Stream MF4 decode/send from S3 object keys to VictoriaMetrics with RAM preflight and memory/tempfile fallback.

## Linked issue
Closes #2

## Scope
- D65 S3 streaming path
- B3SR S3 streaming path
- Shared S3 bucket helper cleanup
- Test-node routing via `--test`

## Notes
Uses an auto memory/tempfile strategy based on projected RAM use.
